### PR TITLE
Rename id to config_path, remove schema

### DIFF
--- a/src/devices/device.cpp
+++ b/src/devices/device.cpp
@@ -2,25 +2,25 @@
 
 std::set<Device*> Device::devices;
 
-Device::Device(String id, String schema) : Configurable{id, schema}, Enable(10) {
+Device::Device(String config_path) : Configurable{config_path}, Enable(10) {
   devices.insert(this);
 }
 
 
 
-NumericDevice::NumericDevice(String id, String schema) :
-   Device(id, schema), NumericProducer() {
+NumericDevice::NumericDevice(String config_path) :
+   Device(config_path), NumericProducer() {
 
 };
 
 
-IntegerDevice::IntegerDevice(String id, String schema) :
-   Device(id, schema), IntegerProducer() {
+IntegerDevice::IntegerDevice(String config_path) :
+   Device(config_path), IntegerProducer() {
 
 };
 
 
-StringDevice::StringDevice(String id, String schema) :
-   Device(id, schema), StringProducer() {
+StringDevice::StringDevice(String config_path) :
+   Device(config_path), StringProducer() {
 
 };

--- a/src/devices/device.h
+++ b/src/devices/device.h
@@ -14,7 +14,7 @@
 
 class Device : virtual public Observable, public Configurable, public Enable {
   public:
-    Device(String id="", String schema="");
+    Device(String config_path="");
 
   // Was used by sensesp_app::enable(). Now handled by Enable.  Deprecate?
   static const std::set<Device*>& get_devices() {
@@ -30,7 +30,7 @@ class Device : virtual public Observable, public Configurable, public Enable {
 class NumericDevice : public Device, public NumericProducer {
 
     public:
-        NumericDevice(String id="", String schema="");
+        NumericDevice(String config_path="");
 
 };
 
@@ -38,7 +38,7 @@ class NumericDevice : public Device, public NumericProducer {
 class IntegerDevice : public Device, public IntegerProducer {
 
     public:
-        IntegerDevice(String id="", String schema="");
+        IntegerDevice(String config_path="");
 
 };
 
@@ -46,7 +46,7 @@ class IntegerDevice : public Device, public IntegerProducer {
 class StringDevice : public Device, public StringProducer {
 
     public:
-        StringDevice(String id="", String schema="");
+        StringDevice(String config_path="");
 
 };
 

--- a/src/devices/digital_input.cpp
+++ b/src/devices/digital_input.cpp
@@ -6,15 +6,15 @@
 
 DigitalInput::DigitalInput(
     uint8_t pin, int pin_mode, int interrupt_type,
-    String id, String schema)
-    : Device{id, schema}, pin{pin}, interrupt_type{interrupt_type} {
+    String config_path)
+    : Device(config_path), pin{pin}, interrupt_type{interrupt_type} {
   pinMode(pin, pin_mode);
 }
 
 DigitalInputValue::DigitalInputValue(
     uint8_t pin, int pin_mode, int interrupt_type,
-    String id, String schema) :
-      DigitalInput{pin, pin_mode, interrupt_type, id, schema},
+    String config_path) :
+      DigitalInput{pin, pin_mode, interrupt_type, config_path},
       BooleanProducer() {}
 
 void DigitalInputValue::enable() {
@@ -38,8 +38,8 @@ void DigitalInputValue::enable() {
 DigitalInputCounter::DigitalInputCounter(
     uint8_t pin, int pin_mode, int interrupt_type,
     uint read_delay,
-    String id, String schema) :
-      DigitalInput{pin, pin_mode, interrupt_type, id, schema},
+    String config_path) :
+      DigitalInput{pin, pin_mode, interrupt_type, config_path},
       IntegerProducer(),
       read_delay{read_delay} {}
 

--- a/src/devices/digital_input.h
+++ b/src/devices/digital_input.h
@@ -6,7 +6,7 @@
 class DigitalInput : public Device {
  public:
   DigitalInput(uint8_t pin, int pin_mode, int interrupt_type,
-               String id="", String schema="");
+               String config_path="");
 
  protected:
   uint8_t pin;
@@ -19,7 +19,7 @@ class DigitalInput : public Device {
 class DigitalInputValue : public DigitalInput, public BooleanProducer {
  public:
   DigitalInputValue(uint8_t pin, int pin_mode, int interrupt_type,
-                    String id="", String schema="");
+                    String config_path="");
 
   virtual void enable() override final;
 
@@ -32,7 +32,7 @@ class DigitalInputCounter : public DigitalInput, public IntegerProducer {
  public:
   DigitalInputCounter(uint8_t pin, int pin_mode, int interrupt_type,
                       uint read_delay,
-                      String id="", String schema="");
+                      String config_path="");
 
   void enable() override final;
 

--- a/src/devices/gps.cpp
+++ b/src/devices/gps.cpp
@@ -4,8 +4,8 @@
 
 #include "sensesp.h"
 
-GPSInput::GPSInput(int rx_pin, String id, String schema)
-    : Device{id, schema} {
+GPSInput::GPSInput(int rx_pin, String config_path)
+    : Device(config_path) {
 
   nmea_parser.add_sentence_parser(new GPGGASentenceParser(&nmea_data));
   nmea_parser.add_sentence_parser(new GPGLLSentenceParser(&nmea_data));

--- a/src/devices/gps.h
+++ b/src/devices/gps.h
@@ -11,7 +11,7 @@ constexpr int GPS_SERIAL_BITRATE = 115200;
 
 class GPSInput : public Device {
  public:
-  GPSInput(int rx_pin, String id="", String schema="");
+  GPSInput(int rx_pin, String config_path="");
   virtual void enable() override final;
   NMEAData nmea_data;
  private:

--- a/src/devices/onewire_temperature.cpp
+++ b/src/devices/onewire_temperature.cpp
@@ -32,8 +32,8 @@ bool string_to_owda(OWDevAddr* addr, const char* str) {
 }
 
 DallasTemperatureSensors::DallasTemperatureSensors(
-    int pin, String id, String schema)
-    : Device{id, schema} {
+    int pin, String config_path)
+    : Device(config_path) {
   onewire = new OneWire(pin);
   sensors = new DallasTemperature(onewire);
   sensors->begin();
@@ -90,8 +90,8 @@ bool DallasTemperatureSensors::get_next_address(OWDevAddr* addr) {
 }
 
 OneWireTemperature::OneWireTemperature(
-    DallasTemperatureSensors* dts, String id, String schema)
-    : NumericDevice{id, schema}, dts{dts} {
+    DallasTemperatureSensors* dts, String config_path)
+    : NumericDevice(config_path), dts{dts} {
   load_configuration();
   if (address==null_ow_addr) {
     // previously unconfigured device

--- a/src/devices/onewire_temperature.h
+++ b/src/devices/onewire_temperature.h
@@ -12,7 +12,7 @@ typedef std::array<uint8_t, 8> OWDevAddr;
 
 class DallasTemperatureSensors : public Device {
  public:
-  DallasTemperatureSensors(int pin, String id="", String schema="");
+  DallasTemperatureSensors(int pin, String config_path="");
   void enable() override final {}
   bool register_address(const OWDevAddr& addr);
   bool get_next_address(OWDevAddr* addr);
@@ -27,7 +27,7 @@ class DallasTemperatureSensors : public Device {
 class OneWireTemperature : public NumericDevice {
  public:
   OneWireTemperature(DallasTemperatureSensors* dts,
-                     String id="", String schema="");
+                     String config_path="");
   void enable() override final;
   virtual JsonObject& get_configuration(JsonBuffer& buf) override final;
   virtual bool set_configuration(const JsonObject& config) override final;

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -17,8 +17,8 @@ void save_config_callback() {
   should_save_config = true;
 }
 
-Networking::Networking(String id, String schema)
-    : Configurable{id, schema} {
+Networking::Networking(String config_path)
+    : Configurable{config_path} {
   hostname = new ObservableValue<String>(String("unknown"));
   load_configuration();
   server = new AsyncWebServer(80);

--- a/src/net/networking.h
+++ b/src/net/networking.h
@@ -12,7 +12,7 @@
 
 class Networking : public Configurable {
  public:
-  Networking(String id, String schema="");
+  Networking(String config_path);
   void setup(std::function<void(bool)> connection_cb);
   ObservableValue<String>* get_hostname();
   virtual JsonObject& get_configuration(JsonBuffer& buf) override final;

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -35,9 +35,9 @@ void webSocketClientEvent(WStype_t type, uint8_t * payload, size_t length) {
    }
 }
 
-WSClient::WSClient(String id, String schema, SKDelta* sk_delta,
+WSClient::WSClient(String config_path, SKDelta* sk_delta,
                    std::function<void(bool)> connected_cb,
-                   void_cb_func delta_cb) : Configurable{id, schema} {
+                   void_cb_func delta_cb) : Configurable{config_path} {
   this->sk_delta = sk_delta;
   this->connected_cb = connected_cb;
   this->delta_cb = delta_cb;

--- a/src/net/ws_client.h
+++ b/src/net/ws_client.h
@@ -13,7 +13,7 @@ enum ConnectionState { disconnected, connecting, connected };
 
 class WSClient : public Configurable {
  public:
-  WSClient(String id, String schema, SKDelta* sk_delta,
+  WSClient(String config_path, SKDelta* sk_delta,
             std::function<void(bool)> connected_cb,
             void_cb_func delta_cb);
   void enable();

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -30,7 +30,7 @@ SensESPApp::SensESPApp() {
   }
 
   // create the networking object
-  networking = new Networking("/system/networking", "");
+  networking = new Networking("/system/networking");
   ObservableValue<String>* hostname = networking->get_hostname();
 
   // setup standard devices and their transforms
@@ -64,7 +64,7 @@ SensESPApp::SensESPApp() {
     this->led_blinker.flip();
   };
   this->ws_client = new WSClient(
-    "/system/sk", "",
+    "/system/sk", 
     sk_delta, ws_connected_cb, ws_delta_cb);
 }
 

--- a/src/system/configurable.cpp
+++ b/src/system/configurable.cpp
@@ -9,18 +9,17 @@
 // reference around would unnecessarily reduce readability of the code.
 std::map<String, Configurable*> configurables;
 
-Configurable::Configurable(String id="", String schema="")
-    : id{id}, schema{schema} {
-  if (id != "") {
-    auto it = configurables.find(id);
+Configurable::Configurable(String config_path="")
+    : config_path{config_path} {
+  if (config_path != "") {
+    auto it = configurables.find(config_path);
     if (it != configurables.end()) {
-      debugW("WARNING: Overriding id %s", id.c_str());
+      debugW("WARNING: Overriding id %s", config_path.c_str());
     }
-    configurables[id] = this;
+    configurables[config_path] = this;
   }
 }
 
-// Returns the current configuration
 JsonObject& Configurable::get_configuration(JsonBuffer& buf) {
   debugW("WARNING: get_configuration not defined");
   return buf.createObject();
@@ -32,48 +31,43 @@ bool Configurable::set_configuration(const JsonObject& config) {
   return false;
 }
 
-// Returns the configuration schema.
-// The schema is a Json object defining and describing the configuration
-// keys and possibly allowed value types. The schema can be used
-// in client code to render a configuration UI with helpful
-// descriptions.
-// Schema format TBD.
+
 String Configurable::get_config_schema() {
   return "{}";
 }
 
 void Configurable::load_configuration() {
-  if (id=="" || !SPIFFS.exists(id)) {
+  if (config_path=="" || !SPIFFS.exists(config_path)) {
     // nothing to load from
     debugI(
-      "Not loading configuration, id empty or file does not exist: %s",
-      id.c_str());
+      "Not loading configuration, config_path empty or file does not exist: %s",
+      config_path.c_str());
     return;
   }
 
-  File f = SPIFFS.open(id, "r");
+  File f = SPIFFS.open(config_path, "r");
   DynamicJsonBuffer jsonBuffer;
   JsonObject& obj = jsonBuffer.parse(f);
   if (!obj.success()) {
     debugW(
       "WARNING: Could not parse configuration for %s",
-      id.c_str());
+      config_path.c_str());
   }
   if (!set_configuration(obj)) {
     debugW(
       "WARNING: Could not set configuration for %s",
-      id.c_str());
+      config_path.c_str());
   }
   f.close();
 }
 
 void Configurable::save_configuration() {
-  if (id=="") {
-    debugI("WARNING: Could not save configuration (id not set)");
+  if (config_path=="") {
+    debugI("WARNING: Could not save configuration (config_path not set)");
   }
   DynamicJsonBuffer jsonBuffer;
   JsonObject& obj = get_configuration(jsonBuffer);
-  File f = SPIFFS.open(id, "w");
+  File f = SPIFFS.open(config_path, "w");
   obj.printTo(f);
   f.close();
 }

--- a/src/system/configurable.h
+++ b/src/system/configurable.h
@@ -7,19 +7,69 @@
 #include <ArduinoJson.h>
 
 
+/**
+ * A Configurable is any object that is capable of having configuration data that
+ * can be set remotely using a RESTful API, and can be persisted to the 
+ * local file system.
+ */
 class Configurable {
  public:
-  Configurable(String id, String schema);
-  const String id;
+  /**
+   * Create a configurable object who's configuration is saved using the
+   * specified config_path.
+   * @param config_path The partial path used for the URL when configuring this object
+   *    remotely with a browser. The config_path also represents the path to the local
+   *    file where the configuration data is persisted. Given this, be sure to
+   *    chose a path that is both valid for URLs as well as file names. A configuration
+   *    path should always start with a forward slash.  Leaving the config_path blank
+   *    indicates that this object does not need or want configuration data support.
+   */
+  Configurable(String config_path);
+  
+  const String config_path;
+
+
+  /**
+   * Returns the current configuration data as a JsonObject. In
+   * general, the current state of local member variables are 
+   * saved to a new object created with JsonBuffer::createObject() 
+   * and returned.
+   */  
   virtual JsonObject& get_configuration(JsonBuffer& buf);
+
+
+
+  /**
+   * Sets the current state of local member variables using
+   * the data stored in config.
+   */
   virtual bool set_configuration(const JsonObject& config);
+
+
+  /**
+   * Returns a configuration schema that specifies the key/value pairs
+   * that can be expected when calling get_configuration(), or are
+   * expected by set_configuration(). The schema will be in 
+   * JSON Schema format
+   * @see https://json-schema.org
+   */
   virtual String get_config_schema();
+
+
+  /**
+   * Persists the configuration returned by get_configuration()
+   * to the local file system.
+   */
   virtual void save_configuration();
+
  protected:
+  /**
+   * Loads a configuration previously saved with save_configuration() and
+   * passes the configuration to set_configuration().
+   */
   virtual void load_configuration();
- private:
-  String schema;
-};
+
+ };
 
 extern std::map<String, Configurable*> configurables;
 

--- a/src/transforms/difference.cpp
+++ b/src/transforms/difference.cpp
@@ -2,8 +2,8 @@
 
 // Difference
 
-Difference::Difference(String path, float k1, float k2, String id, String schema)
-    : OneToOneTransform<float>{ path, id, schema },
+Difference::Difference(String path, float k1, float k2, String config_path)
+    : OneToOneTransform<float>{ path, config_path },
       k1{ k1 },
       k2{ k2 } {
   load_configuration();

--- a/src/transforms/difference.h
+++ b/src/transforms/difference.h
@@ -7,7 +7,7 @@
 // y = k1 * x1 - k2 * x2
 class Difference : public OneToOneTransform<float> {
  public:
-  Difference(String sk_path, float k1, float k2, String id="", String schema="");
+  Difference(String sk_path, float k1, float k2, String config_path="");
   virtual void set_input(float input, uint8_t inputChannel) override final;
   virtual String as_json() override final;
   virtual JsonObject& get_configuration(JsonBuffer& buf) override final;

--- a/src/transforms/frequency.cpp
+++ b/src/transforms/frequency.cpp
@@ -2,9 +2,9 @@
 
 // Frequency
 
-Frequency::Frequency(String sk_path, float k, String id, String schema) :
+Frequency::Frequency(String sk_path, float k, String config_path) :
     IntegerConsumer(),
-    NumericTransform{sk_path, id, schema}, k{k} {
+    NumericTransform{sk_path, config_path}, k{k} {
   //load_configuration();
 }
 

--- a/src/transforms/frequency.h
+++ b/src/transforms/frequency.h
@@ -8,7 +8,7 @@
 // the last reading
 class Frequency : public IntegerConsumer, public NumericTransform {
  public:
-  Frequency(String sk_path, float k=1, String id="", String schema="");
+  Frequency(String sk_path, float k=1, String config_path="");
   virtual void set_input(int input, uint8_t inputChannel = 0) override final;
   virtual String as_json() override final;
   virtual void enable() override final;

--- a/src/transforms/gnss_position.h
+++ b/src/transforms/gnss_position.h
@@ -15,8 +15,8 @@
 
 class GNSSPosition : public OneToOneTransform<Position> {
  public:
-  GNSSPosition(String sk_path, String id="", String schema="") :
-    OneToOneTransform<Position>{sk_path, id, schema } {
+  GNSSPosition(String sk_path, String config_path="") :
+    OneToOneTransform<Position>{sk_path, config_path} {
   }
 
   virtual void set_input(Position newValue, uint8_t inputChannel = 0) {

--- a/src/transforms/integrator.cpp
+++ b/src/transforms/integrator.cpp
@@ -5,8 +5,8 @@
 
 // Integrator
 
-Integrator::Integrator(String path, float k, float value, String id, String schema) :
-    OneToOneTransform<float>{ path, id, schema },
+Integrator::Integrator(String path, float k, float value, String config_path) :
+    OneToOneTransform<float>{ path, config_path },
       k{ k } {
   output = value;
   load_configuration();

--- a/src/transforms/integrator.h
+++ b/src/transforms/integrator.h
@@ -7,7 +7,7 @@
 // y = k * sum(x_t)
 class Integrator : public OneToOneTransform<float> {
  public:
-  Integrator(String sk_path, float k=1, float value=0, String id="", String schema="");
+  Integrator(String sk_path, float k=1, float value=0, String config_path="");
   virtual void enable() override final;
   virtual void set_input(float input, uint8_t inputChannel = 0) override final;
   String as_json() override final;

--- a/src/transforms/linear.cpp
+++ b/src/transforms/linear.cpp
@@ -2,8 +2,8 @@
 
 // Linear
 
-Linear::Linear(String path, float k, float c, String id, String schema) :
-    OneToOneTransform<float>{ path, id, schema },
+Linear::Linear(String path, float k, float c, String config_path) :
+    OneToOneTransform<float>{ path, config_path },
       k{ k },
       c{ c } {
   load_configuration();

--- a/src/transforms/linear.h
+++ b/src/transforms/linear.h
@@ -7,7 +7,7 @@
 // y = k * x + c
 class Linear : public OneToOneTransform<float>  {
  public:
-  Linear(String sk_path, float k, float c, String id="", String schema="");
+  Linear(String sk_path, float k, float c, String config_path="");
   virtual void set_input(float input, uint8_t inputChannel = 0) override final;
   virtual String as_json() override final;
   virtual JsonObject& get_configuration(JsonBuffer& buf) override final;

--- a/src/transforms/moving_average.cpp
+++ b/src/transforms/moving_average.cpp
@@ -2,8 +2,8 @@
 
 // MovingAverage
 
-MovingAverage::MovingAverage(String path, int n, float k, String id, String schema) :
-    OneToOneTransform<float>{ path, id, schema },
+MovingAverage::MovingAverage(String path, int n, float k, String config_path) :
+    OneToOneTransform<float>{ path, config_path },
       n{ n },
       k{ k } {
   buf.resize(n, 0);

--- a/src/transforms/moving_average.h
+++ b/src/transforms/moving_average.h
@@ -9,7 +9,7 @@
 class MovingAverage : public OneToOneTransform<float> {
 
  public:
-  MovingAverage(String sk_path, int n, float k=1., String id="", String schema="");
+  MovingAverage(String sk_path, int n, float k=1., String config_path="");
   virtual void set_input(float input, uint8_t inputChannel = 0) override final;
   virtual String as_json() override final;
   virtual JsonObject& get_configuration(JsonBuffer& buf) override final;

--- a/src/transforms/passthrough.h
+++ b/src/transforms/passthrough.h
@@ -10,8 +10,8 @@ class Passthrough : public OneToOneTransform<T> {
  public:
   Passthrough() : Passthrough("") {}
 
-  Passthrough(String sk_path, String id="", String schema="")
-    : OneToOneTransform<T>{sk_path, id, schema} {
+  Passthrough(String sk_path, String config_path="")
+    : OneToOneTransform<T>{sk_path, config_path} {
 
   }
 

--- a/src/transforms/timestring.cpp
+++ b/src/transforms/timestring.cpp
@@ -1,9 +1,9 @@
 #include "timestring.h"
 
 
-TimeString::TimeString(String path, String id, String schema) :
+TimeString::TimeString(String path, String config_path) :
     ValueConsumer<time_t>(),
-    StringTransform{ path, id, schema } {
+    StringTransform{ path, config_path } {
   load_configuration();
 }
 

--- a/src/transforms/timestring.h
+++ b/src/transforms/timestring.h
@@ -8,7 +8,7 @@
 
 class TimeString : public ValueConsumer<time_t>, public StringTransform {
  public:
-  TimeString(String sk_path, String id="", String schema="");
+  TimeString(String sk_path, String config_path="");
   virtual void set_input(time_t input, uint8_t inputChannel = 0) override final;
   String as_json() override final;
   virtual JsonObject& get_configuration(JsonBuffer& buf) override final;

--- a/src/transforms/transform.cpp
+++ b/src/transforms/transform.cpp
@@ -8,7 +8,7 @@
 
 std::set<TransformBase*> TransformBase::transforms;
 
-TransformBase::TransformBase(String sk_path, String id, String schema) :
-    Configurable{id, schema}, SignalKSource(sk_path), Enable(5) {
+TransformBase::TransformBase(String sk_path, String config_path) :
+    Configurable{config_path}, SignalKSource(sk_path), Enable(5) {
   transforms.insert(this);
 }

--- a/src/transforms/transform.h
+++ b/src/transforms/transform.h
@@ -29,7 +29,7 @@ class TransformBase : public SignalKSource,
                       public Configurable, 
                       public Enable {
  public:
-    TransformBase(String sk_path, String id="", String schema="");
+    TransformBase(String sk_path, String config_path="");
 
   
   // Primary purpose of this was to supply SignalK sources
@@ -52,8 +52,8 @@ class TransformBase : public SignalKSource,
 template <typename T>
 class Transform : public TransformBase, public ValueProducer<T> {
     public:
-      Transform(String sk_path, String id="", String schema="") :
-         TransformBase(sk_path, id, schema), ValueProducer<T>() {
+      Transform(String sk_path, String config_path="") :
+         TransformBase(sk_path, config_path), ValueProducer<T>() {
       }
 };
 
@@ -72,9 +72,9 @@ template <typename T>
 class OneToOneTransform : public ValueConsumer<T>, public Transform<T> {
 
   public: 
-     OneToOneTransform(String sk_path, String id="", String schema="") :
+     OneToOneTransform(String sk_path, String config_path="") :
       ValueConsumer<T>(),
-      Transform<T>(sk_path, id, schema) {
+      Transform<T>(sk_path, config_path) {
   }
 };
 

--- a/src/wiring_helpers.cpp
+++ b/src/wiring_helpers.cpp
@@ -19,25 +19,25 @@
 void setup_analog_input(
     SensESPApp* seapp,
     String sk_path, float k, float c,
-    String id, String schema) {
+    String config_path) {
   seapp->connect_1to1<AnalogInput, Linear>(
     new AnalogInput(),
     new Linear(
       sk_path, k, c,
-      id, schema));
+      config_path));
 }
 
 void setup_digital_input(
     SensESPApp* seapp,
     int digital_pin,
     String sk_path, float k, float c,
-    String id, String schema) {
+    String config_path) {
   // expose a slowly changing (button-type) digital input
   seapp->connect_1to1<DigitalInputValue, Linear>(
     new DigitalInputValue(digital_pin, INPUT_PULLUP, RISING),
     new Linear(
       sk_path, k, c,
-      id, schema));
+      config_path));
 }
 
 void setup_fuel_flow_meter(
@@ -182,12 +182,12 @@ void setup_onewire_temperature(
     SensESPApp* seapp,
     DallasTemperatureSensors* dts,
     String sk_path,
-    String id,
+    String config_path,
     String schema
 ) {
   seapp->connect_1to1<OneWireTemperature, Passthrough<float>>(
     new OneWireTemperature(dts),
-    new Passthrough<float>(sk_path, id, schema));
+    new Passthrough<float>(sk_path, config_path));
 }
 
 void setup_rpm_meter(SensESPApp* seapp, int input_pin) {

--- a/src/wiring_helpers.h
+++ b/src/wiring_helpers.h
@@ -7,13 +7,13 @@
 void setup_analog_input(
     SensESPApp* seapp,
     String sk_path, float k=1, float c=0,
-    String id="", String schema="");
+    String config_path="");
 
 void setup_digital_input(
     SensESPApp* seapp,
     int digital_pin,
     String sk_path, float k=1, float c=0,
-    String id="", String schema="");
+    String config_path="");
 
 void setup_fuel_flow_meter(
   SensESPApp* seapp,
@@ -27,8 +27,7 @@ void setup_onewire_temperature(
   SensESPApp* seapp,
   DallasTemperatureSensors* dts,
   String sk_path,
-  String id,
-  String schema
+  String config_path
 );
 
 void setup_rpm_meter(SensESPApp* seapp, int input_pin);


### PR DESCRIPTION
Renamed the Configurable parameter from "id" to "config_path" to better document purpose.  Removed "schema" parameter entirely in anticipation of future UI PR.  Schema will be supplied by overriding method Configurable::get_config_schema().

For this PR, the actual "changes" are in Configurable.h.  Most other changes are simply to support the changes there.