### PR TITLE
fix: Onewire detection logic

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ build_flags =
    -Wall
    -Wno-reorder
 
-upload_speed = 230400
+upload_speed = 460800
 lib_deps =
     ReactESP
     ESP8266WebServer

--- a/src/devices/onewire_temperature.cpp
+++ b/src/devices/onewire_temperature.cpp
@@ -97,15 +97,16 @@ OneWireTemperature::OneWireTemperature(
     // previously unconfigured device
     bool success = dts->get_next_address(&address);
     if (!success) {
-      debugE("FATAL: Could not find available OneWire devices");
+      debugE("FATAL: No more unregistered OneWire devices left");
       found = false;
     } else {
+      debugD("Registered previously unconfigured OneWire device");
       dts->register_address(address);
     }
   } else {
     bool success = dts->register_address(address);
     if (!success) {
-      debugE("FATAL: OneWire device(s) found, but could not be registered");
+      debugE("FATAL: Previously saved OneWire device could no longer be found");
       found = false;
     }
   }

--- a/src/devices/onewire_temperature.h
+++ b/src/devices/onewire_temperature.h
@@ -36,7 +36,7 @@ class OneWireTemperature : public NumericDevice {
  private:
   OneWire* onewire;
   DallasTemperatureSensors* dts;
-  bool found=false;
+  bool found = true;
   OWDevAddr address = {};
   void update();
   void read_value();


### PR DESCRIPTION
I had broken Onewire device detection logic, and the debug messages were misleading as well.