### PR TITLE
fix: PSTI,032 NMEA message bugfixes

### DIFF
--- a/src/signalk/signalk_output.h
+++ b/src/signalk/signalk_output.h
@@ -23,7 +23,7 @@ class SKOutput : public SKEmitter,
     : SKEmitter(sk_path), SymmetricTransform<T>(config_path) {
     Enable::setPriority(-5);
   }
- 
+
 
   virtual void set_input(T newValue, uint8_t inputChannel = 0) override {
     ValueProducer<T>::output = newValue;
@@ -36,7 +36,7 @@ class SKOutput : public SKEmitter,
     String json;
     JsonObject& root = jsonBuffer.createObject();
     root.set("path", this->get_sk_path());
-    root.set("value", ValueProducer<T>::output);    
+    root.set("value", ValueProducer<T>::output);
     root.printTo(json);
     return json;
   }

--- a/src/system/nmea_parser.cpp
+++ b/src/system/nmea_parser.cpp
@@ -123,6 +123,7 @@ bool parse_AV(bool* is_valid, char* s) {
   switch (*s) {
     case 'A':
       *is_valid = true;
+      break;
     case 'V':
       *is_valid = false;
       break;
@@ -171,7 +172,9 @@ bool parse_time(int* hour, int* minute, float* second, char* s) {
 
 bool parse_date(int* year, int* month, int* day, char* s) {
   int retval = sscanf(s, "%2d%2d%2d", day, month, year);
-  year += 2000;
+  // date expressed as C struct tm
+  *year += 100;
+  *month -= 1;
   return retval==3;
 }
 


### PR DESCRIPTION
Due to a missing `break`, `PSTI,032` (RTK baseline data) values were never properly emitted. Also the reported date was 100 years off.