### PR TITLE
fix: change config_path to config_path.c_str() in debug msg

### DIFF
--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -112,7 +112,7 @@ OneWireTemperature::OneWireTemperature(
       char addrstr[24];
       owda_to_string(addrstr, address);
       debugE("FATAL: OneWire sensor %s at %s is missing. "
-             "Check the physical wiring of the devices.", config_path, addrstr);
+             "Check the physical wiring of the devices.", config_path.c_str(), addrstr);
       found = false;
     }
   }


### PR DESCRIPTION
A recently modified debug() message broke the build.