### PR TITLE
feature: add Enable::getClassName, use it in EnableAll()

### DIFF
--- a/src/sensors/analog_input.cpp
+++ b/src/sensors/analog_input.cpp
@@ -5,7 +5,7 @@
 #include "sensesp.h"
 
 AnalogInput::AnalogInput() : NumericSensor() {
-  this->className = "AnalogInput";
+  className = "AnalogInput";
 }
 
 void AnalogInput::update() {

--- a/src/sensors/analog_input.cpp
+++ b/src/sensors/analog_input.cpp
@@ -4,6 +4,10 @@
 
 #include "sensesp.h"
 
+AnalogInput::AnalogInput() : NumericSensor() {
+  this->className = "AnalogInput";
+}
+
 void AnalogInput::update() {
   output = analogRead(A0);
   this->notify();

--- a/src/sensors/analog_input.h
+++ b/src/sensors/analog_input.h
@@ -6,6 +6,7 @@
 class AnalogInput : public NumericSensor {
 
 public:
+  AnalogInput();
   void enable() override final;
 
 private:

--- a/src/sensors/digital_input.cpp
+++ b/src/sensors/digital_input.cpp
@@ -8,7 +8,7 @@ DigitalInput::DigitalInput(
     uint8_t pin, int pin_mode, int interrupt_type,
     String config_path)
     : Sensor(config_path), pin{pin}, interrupt_type{interrupt_type} {
-  this->className = "DigitalInput";
+  className = "DigitalInput";
   pinMode(pin, pin_mode);
 }
 
@@ -17,7 +17,7 @@ DigitalInputValue::DigitalInputValue(
     String config_path) :
       DigitalInput{pin, pin_mode, interrupt_type, config_path},
       BooleanProducer() {
-        this->className = "DigitalInputValue";
+        className = "DigitalInputValue";
       }
 
 void DigitalInputValue::enable() {
@@ -45,7 +45,7 @@ DigitalInputCounter::DigitalInputCounter(
       DigitalInput{pin, pin_mode, interrupt_type, config_path},
       IntegerProducer(),
       read_delay{read_delay} {
-        this->className = "DigitalInputCounter";
+        className = "DigitalInputCounter";
       }
 
 void DigitalInputCounter::enable() {

--- a/src/sensors/digital_input.cpp
+++ b/src/sensors/digital_input.cpp
@@ -8,6 +8,7 @@ DigitalInput::DigitalInput(
     uint8_t pin, int pin_mode, int interrupt_type,
     String config_path)
     : Sensor(config_path), pin{pin}, interrupt_type{interrupt_type} {
+  this->className = "DigitalInput";
   pinMode(pin, pin_mode);
 }
 
@@ -15,7 +16,9 @@ DigitalInputValue::DigitalInputValue(
     uint8_t pin, int pin_mode, int interrupt_type,
     String config_path) :
       DigitalInput{pin, pin_mode, interrupt_type, config_path},
-      BooleanProducer() {}
+      BooleanProducer() {
+        this->className = "DigitalInputValue";
+      }
 
 void DigitalInputValue::enable() {
   app.onInterrupt(
@@ -41,7 +44,9 @@ DigitalInputCounter::DigitalInputCounter(
     String config_path) :
       DigitalInput{pin, pin_mode, interrupt_type, config_path},
       IntegerProducer(),
-      read_delay{read_delay} {}
+      read_delay{read_delay} {
+        this->className = "DigitalInputCounter";
+      }
 
 void DigitalInputCounter::enable() {
   app.onInterrupt(pin, interrupt_type,

--- a/src/sensors/gps.cpp
+++ b/src/sensors/gps.cpp
@@ -7,6 +7,7 @@
 GPSInput::GPSInput(int reset_pin, String config_path)
     : Sensor(config_path) {
 
+  this->className = "GPSInput";
   this->reset_pin = reset_pin;
 
   nmea_parser.add_sentence_parser(new GPGGASentenceParser(&nmea_data));

--- a/src/sensors/gps.cpp
+++ b/src/sensors/gps.cpp
@@ -7,7 +7,7 @@
 GPSInput::GPSInput(int reset_pin, String config_path)
     : Sensor(config_path) {
 
-  this->className = "GPSInput";
+  className = "GPSInput";
   this->reset_pin = reset_pin;
 
   nmea_parser.add_sentence_parser(new GPGGASentenceParser(&nmea_data));

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -34,6 +34,7 @@ bool string_to_owda(OWDevAddr* addr, const char* str) {
 DallasTemperatureSensors::DallasTemperatureSensors(
     int pin, String config_path)
     : Sensor(config_path) {
+  this->className = "DallasTemperatureSensor";
   onewire = new OneWire(pin);
   sensors = new DallasTemperature(onewire);
   sensors->begin();
@@ -95,12 +96,16 @@ bool DallasTemperatureSensors::get_next_address(OWDevAddr* addr) {
 OneWireTemperature::OneWireTemperature(
     DallasTemperatureSensors* dts, String config_path)
     : NumericSensor(config_path), dts{dts} {
+  this->className = "OneWireTemperature";
   load_configuration();
   if (address==null_ow_addr) {
     // previously unconfigured sensor
     bool success = dts->get_next_address(&address);
     if (!success) {
-      debugE("FATAL: No more new OneWire sensors left");
+      debugE("FATAL: Unable to allocate a OneWire sensor for %s. "
+             "All sensors have already been configured. "
+             "Check the physical wiring of your sensors.",
+             config_path.c_str());
       found = false;
     } else {
       debugD("Registered a new OneWire sensor");
@@ -112,7 +117,8 @@ OneWireTemperature::OneWireTemperature(
       char addrstr[24];
       owda_to_string(addrstr, address);
       debugE("FATAL: OneWire sensor %s at %s is missing. "
-             "Check the physical wiring of the devices.", config_path.c_str(), addrstr);
+             "Check the physical wiring of your sensors.",
+             config_path.c_str(), addrstr);
       found = false;
     }
   }

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -34,7 +34,7 @@ bool string_to_owda(OWDevAddr* addr, const char* str) {
 DallasTemperatureSensors::DallasTemperatureSensors(
     int pin, String config_path)
     : Sensor(config_path) {
-  this->className = "DallasTemperatureSensor";
+  className = "DallasTemperatureSensor";
   onewire = new OneWire(pin);
   sensors = new DallasTemperature(onewire);
   sensors->begin();
@@ -96,7 +96,7 @@ bool DallasTemperatureSensors::get_next_address(OWDevAddr* addr) {
 OneWireTemperature::OneWireTemperature(
     DallasTemperatureSensors* dts, String config_path)
     : NumericSensor(config_path), dts{dts} {
-  this->className = "OneWireTemperature";
+  className = "OneWireTemperature";
   load_configuration();
   if (address==null_ow_addr) {
     // previously unconfigured sensor

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -3,7 +3,7 @@
 std::set<Sensor*> Sensor::sensors;
 
 Sensor::Sensor(String config_path) : Configurable{config_path}, Enable(10) {
-  this->className = "Sensor";
+  className = "Sensor";
   sensors.insert(this);
 }
 
@@ -11,20 +11,20 @@ Sensor::Sensor(String config_path) : Configurable{config_path}, Enable(10) {
 
 NumericSensor::NumericSensor(String config_path) :
    Sensor(config_path), NumericProducer() {
-      this->className = "NumericSensor";
+      className = "NumericSensor";
 
 };
 
 
 IntegerSensor::IntegerSensor(String config_path) :
    Sensor(config_path), IntegerProducer() {
-      this->className = "IntegerSensor";
+      className = "IntegerSensor";
 
 };
 
 
 StringSensor::StringSensor(String config_path) :
    Sensor(config_path), StringProducer() {
-      this->className = "StringSensor";
+      className = "StringSensor";
 
 };

--- a/src/sensors/sensor.cpp
+++ b/src/sensors/sensor.cpp
@@ -3,6 +3,7 @@
 std::set<Sensor*> Sensor::sensors;
 
 Sensor::Sensor(String config_path) : Configurable{config_path}, Enable(10) {
+  this->className = "Sensor";
   sensors.insert(this);
 }
 
@@ -10,17 +11,20 @@ Sensor::Sensor(String config_path) : Configurable{config_path}, Enable(10) {
 
 NumericSensor::NumericSensor(String config_path) :
    Sensor(config_path), NumericProducer() {
+      this->className = "NumericSensor";
 
 };
 
 
 IntegerSensor::IntegerSensor(String config_path) :
    Sensor(config_path), IntegerProducer() {
+      this->className = "IntegerSensor";
 
 };
 
 
 StringSensor::StringSensor(String config_path) :
    Sensor(config_path), StringProducer() {
+      this->className = "StringSensor";
 
 };

--- a/src/sensors/system_info.h
+++ b/src/sensors/system_info.h
@@ -5,7 +5,7 @@
 
 class SystemHz : public NumericSensor {
  public:
-  SystemHz() { this->className = "SystemHz"; }
+  SystemHz() { className = "SystemHz"; }
   void enable() override final;
   String get_value_name() { return "systemhz"; }
  private:
@@ -18,7 +18,7 @@ class SystemHz : public NumericSensor {
 
 class FreeMem : public Sensor, public ValueProducer<uint32_t> {
  public:
-  FreeMem() { this->className = "FreeMem"; }
+  FreeMem() { className = "FreeMem"; }
   void enable() override final;
   String get_value_name() { return "freemem"; }
  private:
@@ -27,7 +27,7 @@ class FreeMem : public Sensor, public ValueProducer<uint32_t> {
 
 class Uptime : public NumericSensor {
  public:
-  Uptime() { this->className = "Uptime"; }
+  Uptime() { className = "Uptime"; }
   void enable() override final;
   String get_value_name() { return "uptime"; }
  private:
@@ -36,7 +36,7 @@ class Uptime : public NumericSensor {
 
 class IPAddrDev : public StringSensor {
  public:
-  IPAddrDev() { this->className = "IPAddrDev"; }
+  IPAddrDev() { className = "IPAddrDev"; }
   void enable() override final;
   String get_value_name() { return "ipaddr"; }
  private:

--- a/src/sensors/system_info.h
+++ b/src/sensors/system_info.h
@@ -5,6 +5,7 @@
 
 class SystemHz : public NumericSensor {
  public:
+  SystemHz() { this->className = "SystemHz"; }
   void enable() override final;
   String get_value_name() { return "systemhz"; }
  private:
@@ -17,6 +18,7 @@ class SystemHz : public NumericSensor {
 
 class FreeMem : public Sensor, public ValueProducer<uint32_t> {
  public:
+  FreeMem() { this->className = "FreeMem"; }
   void enable() override final;
   String get_value_name() { return "freemem"; }
  private:
@@ -25,6 +27,7 @@ class FreeMem : public Sensor, public ValueProducer<uint32_t> {
 
 class Uptime : public NumericSensor {
  public:
+  Uptime() { this->className = "Uptime"; }
   void enable() override final;
   String get_value_name() { return "uptime"; }
  private:
@@ -33,6 +36,7 @@ class Uptime : public NumericSensor {
 
 class IPAddrDev : public StringSensor {
  public:
+  IPAddrDev() { this->className = "IPAddrDev"; }
   void enable() override final;
   String get_value_name() { return "ipaddr"; }
  private:

--- a/src/signalk/signalk_output.h
+++ b/src/signalk/signalk_output.h
@@ -21,6 +21,7 @@ class SKOutput : public SKEmitter,
 
   SKOutput(String sk_path, String config_path="")
     : SKEmitter(sk_path), SymmetricTransform<T>(config_path) {
+    Enable::className = "SKOutput";
     Enable::setPriority(-5);
   }
 

--- a/src/system/enable.cpp
+++ b/src/system/enable.cpp
@@ -1,4 +1,6 @@
 #include "enable.h"
+#include "sensesp_app.h"
+
 
 std::priority_queue<Enable*> Enable::enableList;
 
@@ -11,6 +13,7 @@ Enable::Enable(uint8_t priority) : priority{priority} {
 void Enable::enableAll() {
     while (!enableList.empty()) {
         auto& obj = *enableList.top();
+        debugD("Enabling sensor or transform: %s", obj.getClassName());
         obj.enable();
         enableList.pop();
     } // while

--- a/src/system/enable.cpp
+++ b/src/system/enable.cpp
@@ -10,10 +10,16 @@ Enable::Enable(uint8_t priority) : priority{priority} {
 
 
 void Enable::enableAll() {
+    debugD("Enabling all required sensors and transforms");
     while (!enableList.empty()) {
         auto& obj = *enableList.top();
+        #if __GXX_RTTI
         debugD("Enabling sensor or transform: %s", obj.getClassName());
+        #endif
         obj.enable();
         enableList.pop();
     } // while
+    #if ! __GXX_RTTI
+    debugD("To see each sensor and transform listed here, add 'build_unflags = -fno-rtti' to platformio.ini");
+    #endif
 }

--- a/src/system/enable.cpp
+++ b/src/system/enable.cpp
@@ -1,7 +1,6 @@
 #include "enable.h"
 #include "sensesp_app.h"
 
-
 std::priority_queue<Enable*> Enable::enableList;
 
 

--- a/src/system/enable.cpp
+++ b/src/system/enable.cpp
@@ -10,14 +10,7 @@ Enable::Enable(uint8_t priority) : priority{priority} {
 
 
 const char* Enable::getClassName() { 
-    static int counter = 1;
-    #if __GXX_RTTI
-    return typeid(*this).name();
-    #else
-    char s[4];
-    sprintf(s, "%d", counter++);
-    return s;
-    #endif
+   return this->className;
 }
 
 
@@ -29,7 +22,4 @@ void Enable::enableAll() {
         obj.enable();
         enableList.pop();
     } // while
-    #if ! __GXX_RTTI
-    debugD("To see the name of each sensor and transform, add 'build_unflags = -fno-rtti' to platformio.ini");
-    #endif
 }

--- a/src/system/enable.cpp
+++ b/src/system/enable.cpp
@@ -9,11 +9,6 @@ Enable::Enable(uint8_t priority) : priority{priority} {
 }
 
 
-const char* Enable::getClassName() { 
-   return this->className;
-}
-
-
 void Enable::enableAll() {
     debugD("Enabling all required sensors and transforms");
     while (!enableList.empty()) {

--- a/src/system/enable.cpp
+++ b/src/system/enable.cpp
@@ -9,17 +9,27 @@ Enable::Enable(uint8_t priority) : priority{priority} {
 }
 
 
+const char* Enable::getClassName() { 
+    static int counter = 1;
+    #if __GXX_RTTI
+    return typeid(*this).name();
+    #else
+    char s[4];
+    sprintf(s, "%d", counter++);
+    return s;
+    #endif
+}
+
+
 void Enable::enableAll() {
     debugD("Enabling all required sensors and transforms");
     while (!enableList.empty()) {
         auto& obj = *enableList.top();
-        #if __GXX_RTTI
         debugD("Enabling sensor or transform: %s", obj.getClassName());
-        #endif
         obj.enable();
         enableList.pop();
     } // while
     #if ! __GXX_RTTI
-    debugD("To see each sensor and transform listed here, add 'build_unflags = -fno-rtti' to platformio.ini");
+    debugD("To see the name of each sensor and transform, add 'build_unflags = -fno-rtti' to platformio.ini");
     #endif
 }

--- a/src/system/enable.h
+++ b/src/system/enable.h
@@ -25,7 +25,9 @@ class Enable {
         virtual void enable() {}
      
 
-        virtual const char* getClassName() { return typeid(*this).name(); }   
+        #if __GXX_RTTI
+        virtual const char* getClassName() { return typeid(*this).name(); }
+        #endif
 
 
         const int8_t getEnablePriority() { return priority; }

--- a/src/system/enable.h
+++ b/src/system/enable.h
@@ -27,7 +27,7 @@ class Enable {
         void setClassName(const char* newClassName) { className = newClassName; }
         
         
-        virtual const char* getClassName();
+        virtual const char* getClassName() { return className; };
 
 
         const int8_t getEnablePriority() { return priority; }

--- a/src/system/enable.h
+++ b/src/system/enable.h
@@ -4,7 +4,6 @@
 #include <queue>
 #include <stdint.h>
 #include <typeinfo>
-// BAS #include "sensesp_app.h"
 
 /**
  * Classes that implement "Enable" will have their enable() method

--- a/src/system/enable.h
+++ b/src/system/enable.h
@@ -3,7 +3,10 @@
 
 #include <queue>
 #include <stdint.h>
+
+#if __GXX_RTTI
 #include <typeinfo>
+#endif
 
 /**
  * Classes that implement "Enable" will have their enable() method
@@ -25,6 +28,9 @@ class Enable {
         virtual void enable() {}
 
 
+        void setClassName(const char* newClassName) { this->className = newClassName; }
+        
+        
         virtual const char* getClassName();
 
 
@@ -37,13 +43,22 @@ class Enable {
         /**
          * Called by the SensESP framework to initialize all of the objects
          * marked with this class. They will be initialized in priorty
-         * order.
+         * order. If you want to see see the name of each sensor and transport
+         * in the serial monitor as each one is enabled, add the following
+         * to your project's platformio.ini file:
+         * 
+         * build_unflags = -fno-rtti
          */
         static void enableAll();
     
 
         friend bool operator<(const Enable& lhs, const Enable& rhs) { return lhs.priority < rhs.priority; }
 
+    
+    protected:
+        const char* className = "Enable";
+    
+    
     private:
         int8_t priority;
 

--- a/src/system/enable.h
+++ b/src/system/enable.h
@@ -4,10 +4,6 @@
 #include <queue>
 #include <stdint.h>
 
-#if __GXX_RTTI
-#include <typeinfo>
-#endif
-
 /**
  * Classes that implement "Enable" will have their enable() method
  * called automatically at startup when the SensESP app itself

--- a/src/system/enable.h
+++ b/src/system/enable.h
@@ -23,11 +23,9 @@ class Enable {
          * to add runtime initialization code to your class
          */
         virtual void enable() {}
-     
 
-        #if __GXX_RTTI
-        virtual const char* getClassName() { return typeid(*this).name(); }
-        #endif
+
+        virtual const char* getClassName();
 
 
         const int8_t getEnablePriority() { return priority; }

--- a/src/system/enable.h
+++ b/src/system/enable.h
@@ -3,6 +3,8 @@
 
 #include <queue>
 #include <stdint.h>
+#include <typeinfo>
+// BAS #include "sensesp_app.h"
 
 /**
  * Classes that implement "Enable" will have their enable() method
@@ -22,6 +24,9 @@ class Enable {
          * to add runtime initialization code to your class
          */
         virtual void enable() {}
+     
+
+        virtual const char* getClassName() { return typeid(*this).name(); }   
 
 
         const int8_t getEnablePriority() { return priority; }

--- a/src/system/enable.h
+++ b/src/system/enable.h
@@ -24,7 +24,7 @@ class Enable {
         virtual void enable() {}
 
 
-        void setClassName(const char* newClassName) { this->className = newClassName; }
+        void setClassName(const char* newClassName) { className = newClassName; }
         
         
         virtual const char* getClassName();

--- a/src/transforms/analogvoltage.h
+++ b/src/transforms/analogvoltage.h
@@ -11,7 +11,7 @@ class AnalogVoltage : public Linear {
     public:
        AnalogVoltage(String config_path = "") : 
           Linear(1.0 / 1024.0 * 3.3, 0, config_path) {
-             this->className = "AnalogVoltage";
+             className = "AnalogVoltage";
           }
 };
 

--- a/src/transforms/analogvoltage.h
+++ b/src/transforms/analogvoltage.h
@@ -10,7 +10,9 @@ class AnalogVoltage : public Linear {
 
     public:
        AnalogVoltage(String config_path = "") : 
-          Linear(1.0 / 1024.0 * 3.3, 0, config_path) {}
+          Linear(1.0 / 1024.0 * 3.3, 0, config_path) {
+             this->className = "AnalogVoltage";
+          }
 };
 
 #endif

--- a/src/transforms/angle_correction.cpp
+++ b/src/transforms/angle_correction.cpp
@@ -3,6 +3,7 @@
 AngleCorrection::AngleCorrection(float offset, float min_angle, String config_path) :
     NumericTransform(config_path),
       offset{ offset }, min_angle{ min_angle } {
+  this->className = "AngleCorrection";
   load_configuration();
 }
 

--- a/src/transforms/angle_correction.cpp
+++ b/src/transforms/angle_correction.cpp
@@ -3,7 +3,7 @@
 AngleCorrection::AngleCorrection(float offset, float min_angle, String config_path) :
     NumericTransform(config_path),
       offset{ offset }, min_angle{ min_angle } {
-  this->className = "AngleCorrection";
+  className = "AngleCorrection";
   load_configuration();
 }
 

--- a/src/transforms/curveinterpolator.cpp
+++ b/src/transforms/curveinterpolator.cpp
@@ -16,7 +16,7 @@ CurveInterpolator::Sample::Sample(JsonObject& obj) : input{obj["input"]}, output
 CurveInterpolator::CurveInterpolator(std::set<Sample>* defaults, String config_path)
     : NumericTransform(config_path) {
 
-  this->className = "CurveInterpolator";    
+  className = "CurveInterpolator";    
 
   // Load default values if no configuration present...
   if (defaults != NULL) {

--- a/src/transforms/curveinterpolator.cpp
+++ b/src/transforms/curveinterpolator.cpp
@@ -16,6 +16,8 @@ CurveInterpolator::Sample::Sample(JsonObject& obj) : input{obj["input"]}, output
 CurveInterpolator::CurveInterpolator(std::set<Sample>* defaults, String config_path)
     : NumericTransform(config_path) {
 
+  this->className = "CurveInterpolator";    
+
   // Load default values if no configuration present...
   if (defaults != NULL) {
     samples.clear();

--- a/src/transforms/debounce.cpp
+++ b/src/transforms/debounce.cpp
@@ -2,7 +2,7 @@
 
 Debounce::Debounce(int msMinDelay, String config_path) :
     BooleanTransform(config_path), msMinDelay{msMinDelay} {
-
+    this->className = "Debounce";
     lastTime = millis();
 }
 

--- a/src/transforms/debounce.cpp
+++ b/src/transforms/debounce.cpp
@@ -2,7 +2,7 @@
 
 Debounce::Debounce(int msMinDelay, String config_path) :
     BooleanTransform(config_path), msMinDelay{msMinDelay} {
-    this->className = "Debounce";
+    className = "Debounce";
     lastTime = millis();
 }
 

--- a/src/transforms/difference.cpp
+++ b/src/transforms/difference.cpp
@@ -6,7 +6,7 @@ Difference::Difference(float k1, float k2, String config_path)
     : NumericTransform(config_path),
       k1{ k1 },
       k2{ k2 } {
-  this->className = "Difference";
+  className = "Difference";
   load_configuration();
 }
 

--- a/src/transforms/difference.cpp
+++ b/src/transforms/difference.cpp
@@ -6,6 +6,7 @@ Difference::Difference(float k1, float k2, String config_path)
     : NumericTransform(config_path),
       k1{ k1 },
       k2{ k2 } {
+  this->className = "Difference";
   load_configuration();
 }
 

--- a/src/transforms/frequency.cpp
+++ b/src/transforms/frequency.cpp
@@ -4,7 +4,7 @@
 
 Frequency::Frequency(float k, String config_path) :
     Transform<int, float>(config_path), k{k} {
-    this->className = "Frequency";
+    className = "Frequency";
     load_configuration();
 }
 

--- a/src/transforms/frequency.cpp
+++ b/src/transforms/frequency.cpp
@@ -4,6 +4,7 @@
 
 Frequency::Frequency(float k, String config_path) :
     Transform<int, float>(config_path), k{k} {
+    this->className = "Frequency";
     load_configuration();
 }
 

--- a/src/transforms/integrator.cpp
+++ b/src/transforms/integrator.cpp
@@ -7,7 +7,7 @@
 Integrator::Integrator(float k, float value, String config_path) :
     NumericTransform(config_path),
       k{ k } {
-  this->className = "Integrator";
+  className = "Integrator";
   output = value;
   load_configuration();
 }

--- a/src/transforms/integrator.cpp
+++ b/src/transforms/integrator.cpp
@@ -7,6 +7,7 @@
 Integrator::Integrator(float k, float value, String config_path) :
     NumericTransform(config_path),
       k{ k } {
+  this->className = "Integrator";
   output = value;
   load_configuration();
 }

--- a/src/transforms/linear.cpp
+++ b/src/transforms/linear.cpp
@@ -6,6 +6,7 @@ Linear::Linear(float k, float c, String config_path) :
     NumericTransform(config_path),
       k{ k },
       c{ c } {
+  this->className = "Linear";
   load_configuration();
 }
 

--- a/src/transforms/linear.cpp
+++ b/src/transforms/linear.cpp
@@ -6,7 +6,7 @@ Linear::Linear(float k, float c, String config_path) :
     NumericTransform(config_path),
       k{ k },
       c{ c } {
-  this->className = "Linear";
+  className = "Linear";
   load_configuration();
 }
 

--- a/src/transforms/moving_average.cpp
+++ b/src/transforms/moving_average.cpp
@@ -6,7 +6,7 @@ MovingAverage::MovingAverage(int n, float k, String config_path) :
     NumericTransform(config_path),
       n{ n },
       k{ k } {
-  this->className = "MovingAverage";
+  className = "MovingAverage";
   buf.resize(n, 0);
   load_configuration();
 }

--- a/src/transforms/moving_average.cpp
+++ b/src/transforms/moving_average.cpp
@@ -6,6 +6,7 @@ MovingAverage::MovingAverage(int n, float k, String config_path) :
     NumericTransform(config_path),
       n{ n },
       k{ k } {
+  this->className = "MovingAverage";
   buf.resize(n, 0);
   load_configuration();
 }

--- a/src/transforms/timestring.cpp
+++ b/src/transforms/timestring.cpp
@@ -4,7 +4,7 @@
 
 TimeString::TimeString(String config_path) :
     Transform<time_t, String>(config_path) {
-      this->className = "TimeString";
+      className = "TimeString";
 }
 
 void TimeString::set_input(time_t input, uint8_t inputChannel) {

--- a/src/transforms/timestring.cpp
+++ b/src/transforms/timestring.cpp
@@ -4,6 +4,7 @@
 
 TimeString::TimeString(String config_path) :
     Transform<time_t, String>(config_path) {
+      this->className = "TimeString";
 }
 
 void TimeString::set_input(time_t input, uint8_t inputChannel) {

--- a/src/transforms/transform.cpp
+++ b/src/transforms/transform.cpp
@@ -10,6 +10,7 @@ std::set<TransformBase*> TransformBase::transforms;
 
 TransformBase::TransformBase(String config_path) :
     Configurable{config_path}, Enable(5) {
+  this->className = "TransformBase";    
   transforms.insert(this);
 }
 

--- a/src/transforms/transform.cpp
+++ b/src/transforms/transform.cpp
@@ -10,7 +10,7 @@ std::set<TransformBase*> TransformBase::transforms;
 
 TransformBase::TransformBase(String config_path) :
     Configurable{config_path}, Enable(5) {
-  this->className = "TransformBase";    
+  className = "TransformBase";    
   transforms.insert(this);
 }
 

--- a/src/transforms/transform.h
+++ b/src/transforms/transform.h
@@ -57,6 +57,7 @@ class Transform : public TransformBase,
          TransformBase(config_path), 
          ValueConsumer<C>(), 
          ValueProducer<P>() {
+           this->className = "Transform";
       }
 
 
@@ -105,6 +106,7 @@ class SymmetricTransform : public Transform<T, T> {
   public:
      SymmetricTransform(String config_path="") :
       Transform<T, T>(config_path) {
+        Enable::className = "SymmetricTransform";
   }
 
 };

--- a/src/transforms/transform.h
+++ b/src/transforms/transform.h
@@ -57,7 +57,7 @@ class Transform : public TransformBase,
          TransformBase(config_path), 
          ValueConsumer<C>(), 
          ValueProducer<P>() {
-           this->className = "Transform";
+           className = "Transform";
       }
 
 

--- a/src/transforms/voltagedividerR2.cpp
+++ b/src/transforms/voltagedividerR2.cpp
@@ -2,7 +2,7 @@
 
 VoltageDividerR2::VoltageDividerR2(float R1, float Vin, String config_path) :
    SymmetricTransform<float>(config_path ), R1{R1}, Vin{Vin} {
-     this->className = "VoltageDivider2";
+     className = "VoltageDivider2";
 }
 
 void VoltageDividerR2::set_input(float Vout, uint8_t ignored) {

--- a/src/transforms/voltagedividerR2.cpp
+++ b/src/transforms/voltagedividerR2.cpp
@@ -2,6 +2,7 @@
 
 VoltageDividerR2::VoltageDividerR2(float R1, float Vin, String config_path) :
    SymmetricTransform<float>(config_path ), R1{R1}, Vin{Vin} {
+     this->className = "VoltageDivider2";
 }
 
 void VoltageDividerR2::set_input(float Vout, uint8_t ignored) {


### PR DESCRIPTION
Add more detailed info to the startup messages in the Serial Monitor, showing each sensor and transport that's being enabled. Output looks like this. I don't know what the leading integer is, nor the trailing "fE" and "E" in some cases. That's what comes back from `return typeid(*this).name();`
```␛[0m(I) (enable) WS client enabled
␛[0m(D) (enableAll) Enabling sensor or transform: 6Linear
␛[0m(D) (enableAll) Enabling sensor or transform: 22TemperatureInterpreter
␛[0m(D) (enableAll) Enabling sensor or transform: 16VoltageDividerR2
␛[0m(D) (enableAll) Enabling sensor or transform: 8SKOutputIfE
␛[0m(D) (enableAll) Enabling sensor or transform: 13AnalogVoltage
␛[0m(D) (enableAll) Enabling sensor or transform: 11AnalogInput
␛[0m(D) (enableAll) Enabling sensor or transform: 8SKOutputI6StringE
␛[0m(D) (enableAll) Enabling sensor or transform: 9IPAddrDev
␛[0m(D) (enableAll) Enabling sensor or transform: 8SKOutputIfE
␛[0m(D) (enableAll) Enabling sensor or transform: 6Uptime
␛[0m(D) (enableAll) Enabling sensor or transform: 8SKOutputIfE
␛[0m(D) (enableAll) Enabling sensor or transform: 7FreeMem
␛[0m(D) (enableAll) Enabling sensor or transform: 8SKOutputIfE
␛[0m(D) (enableAll) Enabling sensor or transform: 8SystemHz
␛[0m(I) (enable) All sensors and transforms enabled```