### PR TITLE
fix: Hard-code network settings after one successful connection

### DIFF
--- a/src/net/networking.h
+++ b/src/net/networking.h
@@ -18,18 +18,24 @@ class Networking : public Configurable {
   virtual JsonObject& get_configuration(JsonBuffer& buf) override final;
   virtual bool set_configuration(const JsonObject& config) override final;
   virtual String get_config_schema() override;
-  
+
   void set_hostname(String hostname);
 
   void reset_settings();
 
  protected:
   void check_connection();
+  void setup_saved_ssid(std::function<void(bool)> connection_cb);
+  void setup_wifi_manager(std::function<void(bool)> connection_cb);
  private:
   AsyncWebServer* server;
+  // FIXME: DNSServer and AsyncWiFiManager could be instantiated in
+  // respective methods to save some runtime memory
   DNSServer* dns;
   AsyncWiFiManager* wifi_manager;
   ObservableValue<String>* hostname;
+  String ap_ssid = "";
+  String ap_password = "";
 };
 
 #endif

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -135,7 +135,7 @@ void OneWireTemperature::update() {
 }
 
 void OneWireTemperature::read_value() {
-  output = dts->sensors->getTempC(address.data());
+  output = dts->sensors->getTempC(address.data()) + 273.15;
   this->notify();
 }
 

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -135,6 +135,7 @@ void OneWireTemperature::update() {
 }
 
 void OneWireTemperature::read_value() {
+  // getTempC returns degrees Celsius but SignalK expects Kelvins
   output = dts->sensors->getTempC(address.data()) + 273.15;
   this->notify();
 }

--- a/src/wiring_helpers.cpp
+++ b/src/wiring_helpers.cpp
@@ -52,27 +52,27 @@ void setup_fuel_flow_meter(
                               "/sensors/fuel/rate/calibrate");
 
   diff->connectFrom(freq1, freq2)
-      -> connectTo(new SKOutputNumber("propulsion.0.fuel.rate", "/sensors/fuel/rate/sk"))
+      -> connectTo(new SKOutputNumber("propulsion.main.fuel.rate", "/sensors/fuel/rate/sk"))
       -> connectTo(new MovingAverage(10, 1., "/sensors/fuel/average/calibrate")) // this is the same as above, but averaged over 10 s
-      -> connectTo(new SKOutputNumber("propulsion.0.fuel.averageRate", "/sensors/fuel/average/sk"));
+      -> connectTo(new SKOutputNumber("propulsion.main.fuel.averageRate", "/sensors/fuel/average/sk"));
 
 
   // Integrate the net flow over time. The output is dependent
   // on the the input counter update rate!
   diff->connectTo(new Integrator(1., 0.))
-      -> connectTo(new SKOutputNumber("propulsion.left.fuel.used", "/sensors/fuel/used/sk"));
+      -> connectTo(new SKOutputNumber("propulsion.main.fuel.used", "/sensors/fuel/used/sk"));
 
 
   // Integrate the total outflow over time. The output is dependent
   // on the the input counter update rate!
   freq1-> connectTo(new Integrator(0.46/1e6, 0., "/sensors/fuel/in_used/calibrate"))
-       -> connectTo(new SKOutputNumber("propulsion.left.fuel.usedGross", "/sensors/fuel/in_used/sk"));
+       -> connectTo(new SKOutputNumber("propulsion.main.fuel.usedGross", "/sensors/fuel/in_used/sk"));
 
 
   // Integrate the net fuel flow over time. The output is dependent
   // on the the input counter update rate!
   freq2->connectTo(new Integrator(0.46/1e6, 0., "/sensors/fuel/out_used/calibrate"))
-       -> connectTo(new SKOutputNumber("propulsion.left.fuel.usedReturn", "/sensors/fuel/out_used/sk"));
+       -> connectTo(new SKOutputNumber("propulsion.main.fuel.usedReturn", "/sensors/fuel/out_used/sk"));
 }
 
 
@@ -134,6 +134,6 @@ void setup_rpm_meter(SensESPApp* seapp, int input_pin) {
 
   (new DigitalInputCounter(input_pin, INPUT_PULLUP, RISING, 500))
       -> connectTo<float>(new Frequency(1./97., "/sensors/engine_rpm/calibrate"))
-      -> connectTo(new SKOutputNumber("propulsion.left.revolutions", "/sensors/engine_rpm/sk"));
+      -> connectTo(new SKOutputNumber("propulsion.main.revolutions", "/sensors/engine_rpm/sk"));
 
 }


### PR DESCRIPTION
With this one, I'd like you to think hard whether you like my approach. Basically, I found that the bug @ba58smith reported was almost a show-stopper for me. I had some sensors behind the same power switch as the SK server itself. When I turned the power on, the Raspi couldn't get the network up fast enough and the ESPs would fall back to unconfigured mode. Every single time.

What I do is I save SSIDs and network passwords after a successful network login via Wifimanager. Then, if the values have been set, they're used unconditionally for reconnecting to the network. Basically, once Wifimanager is successfully used, the next time the device will wait forever until the same network becomes available again. The downside is there's no way to access Wifimanager again but by resetting the device. This worked for my use case but would break if, say, you wanted to use a different network for development.

Fixes #16 