### PR TITLE
Add comments for documentation

### DIFF
--- a/src/transforms/moving_average.cpp
+++ b/src/transforms/moving_average.cpp
@@ -14,16 +14,21 @@ MovingAverage::MovingAverage(int n, float k, String config_path) :
 
 void MovingAverage::set_input(float input, uint8_t inputChannel) {
 
+  // So the first value to be included in the average doesn't default to 0.0
   if (!initialized) {
     buf.assign(n, input);
     output = input;
     initialized = true;
   }
   else {
+    // Subtract 1/nth of the oldest value and add 1/nth of the newest value
     output += -k*buf[ptr]/n;
+    output += k * input/n;
+    
+    // Save the most recent input, then advance to the next storage location.
+    // When storage location n is reached, start over again at 0.
     buf[ptr] = input;
     ptr = (ptr+1) % n;
-    output += k * input/n;
   }
   notify();
 }

--- a/src/transforms/moving_average.h
+++ b/src/transforms/moving_average.h
@@ -12,28 +12,22 @@
  * MovingAverage outputs the average of the most recent n values. It also incorporates
  * a "scale" factor, in case you want to increase or decrease your final output by a
  * fixed percentage.
- * 
- * @param n is the number of samples to average
- * 
- * @param k is the "scale" - defaults to 1.0, so has no effect unless you use other than 1.0
- * 
  */
 
 // y = k * 1/n * \sum_k=1^n(x_k)
 class MovingAverage : public NumericTransform {
 
  public:
-  MovingAverage(int n, float k=1., String config_path="");
-
   /**
-   * set_input is used to input a new value to this transform. After the
-   * transformation, notify() is called to output the new value.
-   */
+   * @param n is the number of most recent values you want to average for your output
+   * 
+   * @param the moving average will be multiplied by k before it is output - make it 
+   * something other than 1. if you need to scale your output up or down by a fixed
+   * percentage
+   * 
+   * */
+  MovingAverage(int n, float k=1., String config_path="");
   virtual void set_input(float input, uint8_t inputChannel = 0) override;
-
-  /** 
-   * For reading and writing the configuration of this transform
-   */
   virtual JsonObject& get_configuration(JsonBuffer& buf) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/transforms/moving_average.h
+++ b/src/transforms/moving_average.h
@@ -5,12 +5,35 @@
 
 #include "transform.h"
 
+/**
+ * MovingAverage is used to smooth the output of a value (signal) that has frequent
+ * variations. For example, the output of a temperature sensor may vary from 180 to 185
+ * several times over a short period, but you just want to see the average of that.
+ * MovingAverage outputs the average of the most recent n values. It also incorporates
+ * a "scale" factor, in case you want to increase or decrease your final output by a
+ * fixed percentage.
+ * 
+ * @param n is the number of samples to average
+ * 
+ * @param k is the "scale" - defaults to 1.0, so has no effect unless you use other than 1.0
+ * 
+ */
+
 // y = k * 1/n * \sum_k=1^n(x_k)
 class MovingAverage : public NumericTransform {
 
  public:
   MovingAverage(int n, float k=1., String config_path="");
+
+  /**
+   * set_input is used to input a new value to this transform. After the
+   * transformation, notify() is called to output the new value.
+   */
   virtual void set_input(float input, uint8_t inputChannel = 0) override;
+
+  /** 
+   * For reading and writing the configuration of this transform
+   */
   virtual JsonObject& get_configuration(JsonBuffer& buf) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;


### PR DESCRIPTION
Reviewing @joelkoz's recent change to MovingAverage, I realized I didn't understand how it worked. The PR adds a description for the class documentation, and explains how the transform works.