### PR TITLE
Reset GPS after boot

### DIFF
--- a/src/sensors/gps.cpp
+++ b/src/sensors/gps.cpp
@@ -27,11 +27,15 @@ void GPSInput::enable() {
 
   // reset the GPS modules
   if (this->reset_pin) {
-    pinMode(this->reset_pin, OUTPUT);
-    digitalWrite(this->reset_pin, LOW);
-    app.onDelay(100, [this](){
-      digitalWrite(this->reset_pin, HIGH);
-      pinMode(this->reset_pin, INPUT);
+    // first wait for 5 s
+    app.onDelay(5000, [this](){
+      pinMode(this->reset_pin, OUTPUT);
+      digitalWrite(this->reset_pin, LOW);
+      // keep the reset pin pulled low for 1 s
+      app.onDelay(1000, [this](){
+        digitalWrite(this->reset_pin, HIGH);
+        pinMode(this->reset_pin, INPUT);
+      });
     });
   }
 

--- a/src/system/nmea_parser.cpp
+++ b/src/system/nmea_parser.cpp
@@ -519,6 +519,9 @@ void PSTI032SentenceParser::parse(char* buffer, int term_offsets[], int num_term
     return;
   }
 
+  time.tm_sec = (int)second;
+  time.tm_isdst = 0;
+
   if (is_valid) {
     nmea_data->datetime.set(mktime(&time));
     nmea_data->baseline_projection.set(projection);

--- a/src/wiring_helpers.cpp
+++ b/src/wiring_helpers.cpp
@@ -76,7 +76,7 @@ void setup_fuel_flow_meter(
 }
 
 
-void setup_gps(int reset_pin) {
+GPSInput* setup_gps(int reset_pin) {
   GPSInput* gps = new GPSInput(reset_pin);
   gps->nmea_data.position
     .connectTo(new SKOutputPosition("navigation.position", ""));
@@ -110,6 +110,8 @@ void setup_gps(int reset_pin) {
     .connectTo(new SKOutputNumber("navigation.rtkBaselineCourse"))
     ->connectTo(new AngleCorrection(0, 0, "/sensors/heading/correction"))
     ->connectTo(new SKOutputNumber("navigation.headingTrue", ""));
+
+  return gps;
 }
 
 void setup_onewire_temperature(

--- a/src/wiring_helpers.h
+++ b/src/wiring_helpers.h
@@ -2,6 +2,7 @@
 #define _wiring_helpers_H_
 
 #include "sensesp_app.h"
+#include "sensors/gps.h"
 #include "sensors/onewire_temperature.h"
 
 void setup_analog_input(
@@ -13,7 +14,7 @@ void setup_fuel_flow_meter(
   int return_flow_pin
 );
 
-void setup_gps(int reset_pin=0);
+GPSInput* setup_gps(int reset_pin=0);
 
 void setup_onewire_temperature(
   DallasTemperatureSensors* dts,


### PR DESCRIPTION
The NS-HP-GN GPS modules didn't seem to boot reliably after power-up, so I added some code to reset them after the startup.

Also: properly set all time struct fields when decoding GPS messages.

Also also: return the GPSInput object so that the wiring can be amended afterwards.
