### PR TITLE
Configurable NMEA input stream

### DIFF
--- a/examples/gps_compass.cpp
+++ b/examples/gps_compass.cpp
@@ -1,8 +1,6 @@
 #include <Arduino.h>
 
-// needed because the GPS module needs the only serial port
-// on ESP8266
-#define SERIAL_DEBUG_DISABLED
+#include "SoftwareSerial.h"
 
 #include "sensesp_app.h"
 #include "wiring_helpers.h"
@@ -10,7 +8,22 @@
 ReactESP app([] () {
   sensesp_app = new SensESPApp();
 
-  setup_gps(D7);
+  // Hardware serial port is reserved for serial terminal
+
+  Serial.begin(115200);
+  Serial.available();
+
+  // A small arbitrary delay is required to let the
+  // serial port catch up
+  delay(100);
+  Debug.setSerialEnabled(true);
+
+  // Software serial port is used for receiving NMEA data
+
+  SoftwareSerial* swSerial = new SoftwareSerial(D7, SW_SERIAL_UNUSED_PIN);
+  swSerial->begin(38400, SWSERIAL_8N1);
+  
+  setup_gps(swSerial);
 
   sensesp_app->enable();
 });

--- a/src/sensors/gps.cpp
+++ b/src/sensors/gps.cpp
@@ -4,11 +4,12 @@
 
 #include "sensesp.h"
 
-GPSInput::GPSInput(int reset_pin, String config_path)
+GPSInput::GPSInput(int reset_pin, int bitrate, String config_path)
     : Sensor(config_path) {
 
   className = "GPSInput";
   this->reset_pin = reset_pin;
+  this->bitrate = bitrate;
 
   nmea_parser.add_sentence_parser(new GPGGASentenceParser(&nmea_data));
   nmea_parser.add_sentence_parser(new GPGLLSentenceParser(&nmea_data));
@@ -21,7 +22,7 @@ GPSInput::GPSInput(int reset_pin, String config_path)
 }
 
 void GPSInput::enable() {
-  Serial.begin(GPS_SERIAL_BITRATE);
+  Serial.begin(bitrate);
   // This moves RX to pin 13 (D7)
   Serial.swap();
 

--- a/src/sensors/gps.cpp
+++ b/src/sensors/gps.cpp
@@ -4,12 +4,11 @@
 
 #include "sensesp.h"
 
-GPSInput::GPSInput(int reset_pin, int bitrate, String config_path)
+GPSInput::GPSInput(Stream* rx_stream, String config_path)
     : Sensor(config_path) {
 
   className = "GPSInput";
-  this->reset_pin = reset_pin;
-  this->bitrate = bitrate;
+  this->rx_stream = rx_stream;
 
   nmea_parser.add_sentence_parser(new GPGGASentenceParser(&nmea_data));
   nmea_parser.add_sentence_parser(new GPGLLSentenceParser(&nmea_data));
@@ -22,28 +21,10 @@ GPSInput::GPSInput(int reset_pin, int bitrate, String config_path)
 }
 
 void GPSInput::enable() {
-  Serial.begin(bitrate);
-  // This moves RX to pin 13 (D7)
-  Serial.swap();
-
-  // reset the GPS modules
-  if (this->reset_pin) {
-    // first wait for 5 s
-    app.onDelay(5000, [this](){
-      pinMode(this->reset_pin, OUTPUT);
-      digitalWrite(this->reset_pin, LOW);
-      // keep the reset pin pulled low for 1 s
-      app.onDelay(1000, [this](){
-        digitalWrite(this->reset_pin, HIGH);
-        pinMode(this->reset_pin, INPUT);
-      });
-    });
-  }
-
   // enable reading the serial port
-  app.onAvailable(Serial, [this](){
-    while (Serial.available()) {
-      nmea_parser.read(Serial.read());
+  app.onAvailable(*rx_stream, [this](){
+    while (this->rx_stream->available()) {
+      nmea_parser.handle(this->rx_stream->read());
     }
   });
 

--- a/src/sensors/gps.h
+++ b/src/sensors/gps.h
@@ -7,15 +7,14 @@
 // Support for a GPS module communicating with NMEA-0183
 // messages over a serial interface
 
-constexpr int GPS_SERIAL_BITRATE = 115200;
-
 class GPSInput : public Sensor {
  public:
-  GPSInput(int reset_pin, String config_path="");
+  GPSInput(int reset_pin, int bitrate=115200, String config_path="");
   virtual void enable() override final;
   NMEAData nmea_data;
  private:
   int reset_pin;
+  int bitrate;
   NMEAParser nmea_parser;
 };
 

--- a/src/sensors/gps.h
+++ b/src/sensors/gps.h
@@ -9,12 +9,11 @@
 
 class GPSInput : public Sensor {
  public:
-  GPSInput(int reset_pin, int bitrate=115200, String config_path="");
+  GPSInput(Stream* rx_stream, String config_path="");
   virtual void enable() override final;
   NMEAData nmea_data;
  private:
-  int reset_pin;
-  int bitrate;
+  Stream* rx_stream;
   NMEAParser nmea_parser;
 };
 

--- a/src/system/nmea_parser.cpp
+++ b/src/system/nmea_parser.cpp
@@ -543,7 +543,7 @@ void NMEAParser::add_sentence_parser(SentenceParser* parser) {
   sentence_parsers[sentence] = parser;
 }
 
-void NMEAParser::read(char c) {
+void NMEAParser::handle(char c) {
   (this->*(current_state))(c);
 }
 

--- a/src/system/nmea_parser.cpp
+++ b/src/system/nmea_parser.cpp
@@ -178,6 +178,15 @@ bool parse_date(int* year, int* month, int* day, char* s) {
   return retval==3;
 }
 
+void report_success(bool ok, const char* sentence) {
+  if (!ok) {
+    debugI("Failed to parse %s", sentence);
+    return;
+  } else {
+    debugD("Parsed sentence %s", sentence);
+  }
+}
+
 void GPGGASentenceParser::parse(char* buffer, int term_offsets[], int num_terms) {
   bool ok = true;
 
@@ -233,8 +242,8 @@ void GPGGASentenceParser::parse(char* buffer, int term_offsets[], int num_terms)
   // 15   = Checksum
   // (validated already earlier)
 
+  report_success(ok, sentence());
   if (!ok) {
-    debugI("Failed to parse %s", sentence());
     return;
   }
 
@@ -268,8 +277,8 @@ void GPGLLSentenceParser::parse(char* buffer, int term_offsets[], int num_terms)
   //       4    W         East/West
   ok &= parse_EW(&position.longitude, buffer+term_offsets[4]);
 
+  report_success(ok, sentence());
   if (!ok) {
-    debugI("Failed to parse %s", sentence());
     return;
   }
 
@@ -321,8 +330,8 @@ void GPRMCSentenceParser::parse(char* buffer, int term_offsets[], int num_terms)
     variation_defined = true;
   }
 
+  report_success(ok, sentence());
   if (!ok) {
-    debugI("Failed to parse %s", sentence());
     return;
   }
 
@@ -352,8 +361,8 @@ void PSTISentenceParser::parse(
 
   ok &= parse_int(&subsentence, buffer+term_offsets[1]);
 
+  report_success(ok, sentence());
   if (!ok) {
-    debugI("Failed to parse %s", sentence());
     return;
   }
 
@@ -433,8 +442,8 @@ void PSTI030SentenceParser::parse(char* buffer, int term_offsets[], int num_term
   // 14  RTK Ratio  4.2  AR ratio factor for validation
   ok &= parse_float(&rtk_ratio, buffer+term_offsets[15]);
 
+  report_success(ok, sentence());
   if (!ok) {
-    debugI("Failed to parse %s", sentence());
     return;
   }
 
@@ -514,8 +523,8 @@ void PSTI032SentenceParser::parse(char* buffer, int term_offsets[], int num_term
     // 14  Reserve    Reserve
   }
 
+  report_success(ok, sentence());
   if (!ok) {
-    debugI("Failed to parse %s", sentence());
     return;
   }
 

--- a/src/system/nmea_parser.h
+++ b/src/system/nmea_parser.h
@@ -121,7 +121,7 @@ class PSTI032SentenceParser : public SentenceParser {
 class NMEAParser {
 public:
   NMEAParser();
-  void read(char c);
+  void handle(char c);
   void add_sentence_parser(SentenceParser* parser);
 private:
   void (NMEAParser::* current_state) (char);

--- a/src/wiring_helpers.cpp
+++ b/src/wiring_helpers.cpp
@@ -76,8 +76,8 @@ void setup_fuel_flow_meter(
 }
 
 
-GPSInput* setup_gps(int reset_pin) {
-  GPSInput* gps = new GPSInput(reset_pin);
+GPSInput* setup_gps(int bitrate, int reset_pin) {
+  GPSInput* gps = new GPSInput(reset_pin, bitrate);
   gps->nmea_data.position
     .connectTo(new SKOutputPosition("navigation.position", ""));
   gps->nmea_data.gnss_quality

--- a/src/wiring_helpers.cpp
+++ b/src/wiring_helpers.cpp
@@ -76,8 +76,8 @@ void setup_fuel_flow_meter(
 }
 
 
-GPSInput* setup_gps(int bitrate, int reset_pin) {
-  GPSInput* gps = new GPSInput(reset_pin, bitrate);
+GPSInput* setup_gps(Stream* rx_stream) {
+  GPSInput* gps = new GPSInput(rx_stream);
   gps->nmea_data.position
     .connectTo(new SKOutputPosition("navigation.position", ""));
   gps->nmea_data.gnss_quality

--- a/src/wiring_helpers.h
+++ b/src/wiring_helpers.h
@@ -14,7 +14,7 @@ void setup_fuel_flow_meter(
   int return_flow_pin
 );
 
-GPSInput* setup_gps(int reset_pin=0);
+GPSInput* setup_gps(int bitrate, int reset_pin=0);
 
 void setup_onewire_temperature(
   DallasTemperatureSensors* dts,

--- a/src/wiring_helpers.h
+++ b/src/wiring_helpers.h
@@ -14,7 +14,7 @@ void setup_fuel_flow_meter(
   int return_flow_pin
 );
 
-GPSInput* setup_gps(int bitrate, int reset_pin=0);
+GPSInput* setup_gps(Stream* rx_stream);
 
 void setup_onewire_temperature(
   DallasTemperatureSensors* dts,


### PR DESCRIPTION
NMEA Input streams are now configurable and the software serial library can be used to handle the serial receive pin.

Also removed the resetting logic because it was very specific to my own setup and shouldn't have been added to SensESP in the first place.