### PR TITLE
ENH: Log emitted SignalK deltas to debug stream

### DIFF
--- a/src/signalk/signalk_delta.cpp
+++ b/src/signalk/signalk_delta.cpp
@@ -2,6 +2,7 @@
 
 #include "Arduino.h"
 #include "ArduinoJson.h"
+#include "sensesp.h"
 
 SKDelta::SKDelta(const String& hostname, unsigned int max_buffer_size)
 : hostname{hostname},
@@ -35,5 +36,7 @@ void SKDelta::get_delta(String& output) {
   }
 
   delta.printTo(output);
+
+  debugD("SKDelta::get_delta: %s", output.c_str());
 }
 


### PR DESCRIPTION
This PR logs the SK deltas emitted by the sensor to the debug output. Seeing how often we are sending deltas can be quite enlightening as its easy to overwhelm the server with unchanged values.