### PR TITLE
Configpath msgs

### DIFF
--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -21,7 +21,7 @@ RemoteDebug Debug;
 
 // FIXME: Setting up the system is too verbose and repetitive
 
-SensESPApp::SensESPApp() {
+SensESPApp::SensESPApp(bool disableStdSensors) : disableStdSensors{disableStdSensors} {
   // initialize filesystem
 
   if (!SPIFFS.begin()) {
@@ -35,7 +35,9 @@ SensESPApp::SensESPApp() {
 
   // setup standard sensors and their transforms
 
-  setup_standard_sensors(hostname);
+  if(!disableStdSensors) {
+    setup_standard_sensors(hostname);
+  }
 
   // create the SK delta object
 

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -17,7 +17,7 @@
 
 class SensESPApp {
  public:
-  SensESPApp();
+  SensESPApp(bool disableStdSensors = false);
   void enable();
   void reset();
   String get_hostname();
@@ -62,6 +62,7 @@ class SensESPApp {
 
 
  private:
+  bool disableStdSensors;
   void setup_standard_sensors(ObservableValue<String>* hostname);
 
   HTTPServer* http_server;

--- a/src/system/configurable.cpp
+++ b/src/system/configurable.cpp
@@ -37,10 +37,15 @@ String Configurable::get_config_schema() {
 }
 
 void Configurable::load_configuration() {
-  if (config_path=="" || !SPIFFS.exists(config_path)) {
-    // nothing to load from
+  if (config_path=="") {
     debugI(
-      "Not loading configuration, config_path empty or file does not exist: %s",
+      "Not loading configuration: no config_path specified: %s",
+      config_path.c_str());
+    return;
+  }
+  if (!SPIFFS.exists(config_path)) {
+    debugI(
+      "Not loading configuration: file does not exist: %s",
       config_path.c_str());
     return;
   }


### PR DESCRIPTION
Make the debug message for `Configurable::load_configuration()` specific to the cause of the message (no config path was specified, or no file was found in SPIFFS).
I did this because I often saw one or the other of these messages in the Serial Monitor that didn't make sense, so I wanted to make sure I understood the message. Now that I've done that, I've uncovered what I think is a bug: the error message that results from `if (!SPIFFS.exists(config_path))` happens for many sensors and transports when it doesn't appear to be correct. See Issue #88 .