### PR TITLE
Add read_delay to onewire_temp sensor

### DIFF
--- a/examples/OneWire_temperatures.cpp
+++ b/examples/OneWire_temperatures.cpp
@@ -32,22 +32,24 @@ ReactESP app([] () {
   */
   DallasTemperatureSensors* dts = new DallasTemperatureSensors(D7);
 
-  auto* pCoolantTemp = new OneWireTemperature(dts, "/coolantTemperature/oneWire");
+  uint read_delay = 500;
+
+  auto* pCoolantTemp = new OneWireTemperature(dts, read_delay, "/coolantTemperature/oneWire");
 
     pCoolantTemp->connectTo(new Linear(1.0, 0.0, "/coolantTemperature/linear"))
                 ->connectTo(new SKOutputNumber("propulsion.mainEngine.coolantTemperature", "/coolantTemperature/skPath"));
 
-  auto* pExhaustTemp = new OneWireTemperature(dts, "/exhaustTemperature/oneWire");
+  auto* pExhaustTemp = new OneWireTemperature(dts, read_delay, "/exhaustTemperature/oneWire");
     
     pExhaustTemp->connectTo(new Linear(1.0, 0.0, "/exhaustTemperature/linear"))
                 ->connectTo(new SKOutputNumber("propulsion.mainEngine.exhaustTemperature", "/exhaustTemperature/skPath"));
   
-  auto* p24VTemp = new OneWireTemperature(dts, "/24vAltTemperature/oneWire");
+  auto* p24VTemp = new OneWireTemperature(dts, read_delay, "/24vAltTemperature/oneWire");
       
       p24VTemp->connectTo(new Linear(1.0, 0.0, "/24vAltTemperature/linear"))
               ->connectTo(new SKOutputNumber("electrical.alternators.24V.temperature", "/24vAltTemperature/skPath"));
 
-  auto* p12VTemp = new OneWireTemperature(dts, "/12vAltTemperature/oneWire");
+  auto* p12VTemp = new OneWireTemperature(dts, read_delay, "/12vAltTemperature/oneWire");
       
       p12VTemp->connectTo(new Linear(1.0, 0.0, "/12vAltTemperature/linear"))
               ->connectTo(new SKOutputNumber("electrical.alternators.12V.temperature", "/12vAltTemperature/skPath"));      

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -94,8 +94,8 @@ bool DallasTemperatureSensors::get_next_address(OWDevAddr* addr) {
 }
 
 OneWireTemperature::OneWireTemperature(
-    DallasTemperatureSensors* dts, String config_path)
-    : NumericSensor(config_path), dts{dts} {
+    DallasTemperatureSensors* dts, uint read_delay, String config_path)
+    : NumericSensor(config_path), dts{dts}, read_delay{read_delay}{
   className = "OneWireTemperature";
   load_configuration();
   if (address==null_ow_addr) {
@@ -126,7 +126,7 @@ OneWireTemperature::OneWireTemperature(
 
 void OneWireTemperature::enable() {
   if (found) {
-    app.onRepeat(1000, [this](){ this->update(); });
+    app.onRepeat(read_delay, [this](){ this->update(); });
   }
 }
 

--- a/src/sensors/onewire_temperature.h
+++ b/src/sensors/onewire_temperature.h
@@ -26,7 +26,7 @@ class DallasTemperatureSensors : public Sensor {
 
 class OneWireTemperature : public NumericSensor {
  public:
-  OneWireTemperature(DallasTemperatureSensors* dts,
+  OneWireTemperature(DallasTemperatureSensors* dts, uint read_delay = 1000,
                      String config_path="");
   void enable() override final;
   virtual JsonObject& get_configuration(JsonBuffer& buf) override final;
@@ -36,6 +36,7 @@ class OneWireTemperature : public NumericSensor {
  private:
   OneWire* onewire;
   DallasTemperatureSensors* dts;
+  uint read_delay;
   bool found = true;
   OWDevAddr address = {};
   void update();


### PR DESCRIPTION
Add `uint read_delay` to the constructor of OneWireTemperature, with the default value of 1,000, which is what it was hard-coded to be before this.

Confirmed (on my own boat with OneWire sensors) that the read delay can be set separately for each sensor.

I wanted to add this to the configurable values, but I get a JSON error whenever I try to access the configuration through the web UI. Something about not being able to read the configuration. "Unexpected token t at position 405'. 

This will break any existing main.cpp that uses OneWire, IF a config path was specified for `OneWireTemperature`, like this:
`new OneWireTemperature(dts, "/coolantTemperature/oneWire");`.

Should not be a problem - just add the desired read_delay:
```
uint read_delay = 500;
new OneWireTemperature(dts, read_delay, "/coolantTemperature/oneWire");
```
