### PR TITLE
Add classname to change_filter()

### DIFF
--- a/src/transforms/change_filter.cpp
+++ b/src/transforms/change_filter.cpp
@@ -17,6 +17,7 @@ ChangeFilter::ChangeFilter(float minDelta, float maxDelta, int maxSkips, String 
           maxSkips{maxSkips},
           NumericTransform(config_path) {
 
+  className = "ChangeFilter";
   load_configuration();
   skips = maxSkips+1;
 }


### PR DESCRIPTION
Noticed this while looking at the contstructors of all configurable classes for `load_configuration()`.