### PR TITLE
Add 'last value' to moving_avg config data

### DIFF
--- a/src/transforms/moving_average.cpp
+++ b/src/transforms/moving_average.cpp
@@ -46,7 +46,8 @@ static const char SCHEMA[] PROGMEM = R"({
     "type": "object",
     "properties": {
         "n": { "title": "Number of samples in average", "type": "integer" },
-        "k": { "title": "Multiplier", "type": "number" }
+        "k": { "title": "Multiplier", "type": "number" },
+        "value": { "title": "Last value", "type" : "number", "readOnly": true }
     }
   })";
 


### PR DESCRIPTION
The moving_average transport didn't show its last value when looking at its configuration data. I've found it helpful to have that when troubleshooting output, so I added it.