### PR TITLE
Add SKValueListener and DigitalOutput

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,7 @@ Configuration can be updated with HTTP PUT requests:
 - [x] Authentication token support
 - [x] Make the project a library
 - [x] Web configuration UI
-- [ ] Control device support. For now, all devices are read-only, and controls such as leds, relays, or
-PWM output are not supported.
+- [x] Control device support. Support for SKValueListener is working with WS subscription. Relay sample is working, LEDs should work.
 
 SensESP Class Diagram
 ----------------------------

--- a/examples/relay_control.cpp
+++ b/examples/relay_control.cpp
@@ -1,8 +1,6 @@
 #include <Arduino.h>
 
 #include "sensesp_app.h"
-#include "sensors/analog_input.h"
-#include "transforms/linear.h"
 #include "signalk/signalk_output.h"
 #include "signalk/signalk_listener.h"
 #include "signalk/signalk_value_listener.h"

--- a/examples/relay_control.cpp
+++ b/examples/relay_control.cpp
@@ -1,0 +1,52 @@
+#include <Arduino.h>
+
+#include "sensesp_app.h"
+#include "sensors/analog_input.h"
+#include "transforms/linear.h"
+#include "signalk/signalk_output.h"
+#include "signalk/signalk_listener.h"
+#include "signalk/signalk_value_listener.h"
+#include "sensors/digital_output.h"
+#include "transforms/threshold.h"
+
+
+// Following sample shows how to listen for value on Signal K server.
+// This sample demonstrates how to make automatic navigation light switching device depending on light conditions.
+
+// SensESP builds upon the ReactESP framework. Every ReactESP application
+// defines an "app" object vs defining a "main()" method.
+ReactESP app([] () {
+
+  // Some initialization boilerplate when in debug mode...
+  #ifndef SERIAL_DEBUG_DISABLED
+  Serial.begin(115200);
+
+  // A small arbitrary delay is required to let the
+  // serial port catch up
+  delay(100);
+  Debug.setSerialEnabled(true);
+  #endif
+
+
+  // Create the global SensESPApp() object.
+  sensesp_app = new SensESPApp();
+  // The "SignalK path" identifies subscription of data from the SignalK network.
+  const char* sk_path = "environment.outside.illuminance";
+  // The "Configuration path" is combined with "/config" to formulate a URL
+  // used by the RESTful API for retrieving or setting configuration data.
+  // It is ALSO used to specify a path to the SPIFFS file system
+  // where configuration data is saved on the MCU board.  It should
+  // ALWAYS start with a forward slash if specified.  If left blank,
+  // that indicates this sensor or transform does not have any
+  // configuration to save.
+  // Note that if you want to be able to change the sk_path at runtime,
+  // you will need to specify a config_path.
+  const char* config_path = "/threshold/lights";
+  // Wire up the output of the float value on server "environment.outside.illuminance" to the NumericThreshold,
+  // and then output the transformed float to boolean to DigitalOutput
+  auto * listener = new SKOutputNumber(sk_path);
+  listener->connectTo(new NumericThreshold(0.0f, 100.0f, true, config_path), 0)
+          ->connectTo(new DigitalOutput(5));
+  // Start the SensESP application running
+  sensesp_app->enable();
+});

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -107,15 +107,15 @@ void WSClient::subscribe_listeners() {
     for (size_t i = 0; i < listeners.size(); i++) {
       auto* listener = listeners.at(i);
       String sk_path = listener->get_sk_path();
-      int period = listener->getPeriod();
+      int listenDelay = listener->getListenDelay();
 
       JsonObject& subscribePath = subscribe.createNestedObject();
 
       subscribePath["path"] = sk_path;
-      subscribePath["period"] = period;
+      subscribePath["period"] = listenDelay;
 
-      debugI("Adding %s subscription with period %d\n", sk_path.c_str(),
-             period);
+      debugI("Adding %s subscription with listen delay %d\n", sk_path.c_str(),
+             listenDelay);
     }
 
     String messageJson;

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -5,9 +5,9 @@
 #include <ArduinoJson.h>
 #include <ESP8266HTTPClient.h>
 #ifdef ESP8266
-  #include <ESP8266mDNS.h>        // Include the mDNS library
+#include <ESP8266mDNS.h>  // Include the mDNS library
 #elif defined(ESP32)
-  #include <ESPmDNS.h>
+#include <ESPmDNS.h>
 #endif
 
 #include <ESP8266TrueRandom.h>
@@ -16,10 +16,12 @@
 
 #include "sensesp_app.h"
 
+#include "signalk/signalk_listener.h"
+
 WSClient* ws_client;
 
-void webSocketClientEvent(WStype_t type, uint8_t * payload, size_t length) {
-  switch(type) {
+void webSocketClientEvent(WStype_t type, uint8_t* payload, size_t length) {
+  switch (type) {
     case WStype_DISCONNECTED:
       ws_client->on_disconnected();
       break;
@@ -35,12 +37,13 @@ void webSocketClientEvent(WStype_t type, uint8_t * payload, size_t length) {
     default:
       // Do nothing for other types
       break;
-   }
+  }
 }
 
 WSClient::WSClient(String config_path, SKDelta* sk_delta,
                    std::function<void(bool)> connected_cb,
-                   void_cb_func delta_cb) : Configurable{config_path} {
+                   void_cb_func delta_cb)
+    : Configurable{config_path} {
   this->sk_delta = sk_delta;
   this->connected_cb = connected_cb;
   this->delta_cb = delta_cb;
@@ -52,26 +55,26 @@ WSClient::WSClient(String config_path, SKDelta* sk_delta,
 }
 
 void WSClient::enable() {
-  app.onDelay(0, [this](){ this->connect(); });
-  app.onRepeat(20, [this](){ this->loop(); });
-  app.onRepeat(100, [this](){ this->send_delta(); });
-  app.onRepeat(10000, [this](){ this->connect_loop(); });
+  app.onDelay(0, [this]() { this->connect(); });
+  app.onRepeat(20, [this]() { this->loop(); });
+  app.onRepeat(100, [this]() { this->send_delta(); });
+  app.onRepeat(10000, [this]() { this->connect_loop(); });
 }
 
 void WSClient::connect_loop() {
-  if (this->connection_state==disconnected) {
+  if (this->connection_state == disconnected) {
     this->connect();
   }
 }
 
 void WSClient::on_disconnected() {
   if (this->connection_state == connecting && server_detected) {
-     // Going from connecting directly to disconnect when we
-     // know we have found and talked to the server usually means
-     // the authentication token is bad.
-     debugW("Bad access token detected. Setting token to null.");
-     auth_token = NULL_AUTH_TOKEN;
-     save_configuration();
+    // Going from connecting directly to disconnect when we
+    // know we have found and talked to the server usually means
+    // the authentication token is bad.
+    debugW("Bad access token detected. Setting token to null.");
+    auth_token = NULL_AUTH_TOKEN;
+    save_configuration();
   }
   this->connection_state = disconnected;
   server_detected = false;
@@ -84,20 +87,86 @@ void WSClient::on_error() {
   this->connected_cb(false);
 }
 
-void WSClient::on_connected(uint8_t * payload) {
+void WSClient::on_connected(uint8_t* payload) {
   this->connection_state = connected;
   debugI("Websocket client connected to URL: %s\n", payload);
   this->connected_cb(true);
+  debugI("Subscribing to SignalK listeners...");
+  this->subscribe_listeners();
 }
 
-void WSClient::on_receive_delta(uint8_t * payload) {
+void WSClient::subscribe_listeners() {
+  const std::vector<SKListener*>& listeners = SKListener::get_listeners();
+
+  if (listeners.size() > 0) {
+    DynamicJsonBuffer jsonBuffer;
+    JsonObject& subscription = jsonBuffer.createObject();
+    subscription["context"] = "vessels.self";
+    JsonArray& subscribe = subscription.createNestedArray("subscribe");
+
+    for (size_t i = 0; i < listeners.size(); i++) {
+      auto* listener = listeners.at(i);
+      String sk_path = listener->get_sk_path();
+      int period = listener->getPeriod();
+
+      JsonObject& subscribePath = subscribe.createNestedObject();
+
+      subscribePath["path"] = sk_path;
+      subscribePath["period"] = period;
+
+      debugI("Adding %s subscription with period %d\n", sk_path.c_str(),
+             period);
+    }
+
+    String messageJson;
+
+    subscription.printTo(messageJson);
+    debugI("Subscription JSON message:\n %s", messageJson.c_str());
+    this->client.sendTXT(messageJson);
+  }
+}
+
+void WSClient::on_receive_delta(uint8_t* payload) {
+  #ifdef SIGNALK_PRINT_RCV_DELTA
   debugD("Websocket payload received: %s", (char*)payload);
+  #endif
+  
+  DynamicJsonBuffer jsonBuffer;
+  JsonObject& message = jsonBuffer.parseObject(String((char*)payload));
+
+  if (message.success()) {
+    JsonArray& updates = message["updates"];
+
+    for (size_t i = 0; i < updates.size(); i++) {
+      JsonObject& update = updates[i];
+
+      JsonArray& values = update["values"];
+
+      for (size_t vi = 0; vi < values.size(); vi++) {
+        JsonObject& value = values[vi];
+        
+        const char* path = value["path"];
+        //debugD("Got update of value %s\n", path);
+
+        const std::vector<SKListener*>& listeners = SKListener::get_listeners();
+
+        for (size_t i = 0; i < listeners.size(); i++)
+        {
+          SKListener* listener = listeners[i];
+          if(listener->get_sk_path().equals(path))
+          {
+            listener->parseValue(value);
+          }
+        }        
+      }
+    }
+  }
 }
 
 bool WSClient::get_mdns_service(String& server_address, uint16_t& server_port) {
   // get IP address using an mDNS query
   int n = MDNS.queryService("signalk-ws", "tcp");
-  if (n==0) {
+  if (n == 0) {
     // no service found
     return false;
   } else {
@@ -109,7 +178,7 @@ bool WSClient::get_mdns_service(String& server_address, uint16_t& server_port) {
 }
 
 void WSClient::connect() {
-  if (connection_state!=disconnected) {
+  if (connection_state != disconnected) {
     return;
   }
   debugD("Initiating connection");
@@ -149,13 +218,14 @@ void WSClient::connect() {
   this->test_token(server_address, server_port);
 }
 
-void WSClient::test_token(const String server_address, const uint16_t server_port) {
-
+void WSClient::test_token(const String server_address,
+                          const uint16_t server_port) {
   // FIXME: implement async HTTP client!
   WiFiClient client;
   HTTPClient http;
 
-  String url = String("http://") + server_address + ":" + server_port + "/signalk/v1/api/";
+  String url = String("http://") + server_address + ":" + server_port +
+               "/signalk/v1/api/";
   debugD("Testing token with url %s", url.c_str());
   http.begin(client, url);
   String full_token = String("JWT ") + auth_token;
@@ -169,8 +239,7 @@ void WSClient::test_token(const String server_address, const uint16_t server_por
       debugD("Returned payload (length %d) is: ", payload.length());
       debugD("%s", payload.c_str());
       debugD("End of payload output");
-    }
-    else {
+    } else {
       debugD("Returned payload is empty");
     }
     if (httpCode == 200) {
@@ -189,7 +258,8 @@ void WSClient::test_token(const String server_address, const uint16_t server_por
   }
 }
 
-void WSClient::send_access_request(const String server_address, const uint16_t server_port) {
+void WSClient::send_access_request(const String server_address,
+                                   const uint16_t server_port) {
   debugD("Preparing a new access request");
   if (client_id == "") {
     // generate a client ID
@@ -203,16 +273,15 @@ void WSClient::send_access_request(const String server_address, const uint16_t s
   DynamicJsonBuffer buf;
   JsonObject& req = buf.createObject();
   req["clientId"] = client_id;
-  req["description"] =
-    String("SensESP device: ") + sensesp_app->get_hostname();
+  req["description"] = String("SensESP device: ") + sensesp_app->get_hostname();
   String json_req = "";
   req.printTo(json_req);
 
   WiFiClient client;
   HTTPClient http;
 
-  String url = String("http://") + server_address + ":" + server_port
-      + "/signalk/v1/access/requests";
+  String url = String("http://") + server_address + ":" + server_port +
+               "/signalk/v1/access/requests";
   http.begin(client, url);
   http.addHeader("Content-Type", "application/json");
   int httpCode = http.POST(json_req);
@@ -243,12 +312,14 @@ void WSClient::send_access_request(const String server_address, const uint16_t s
   save_configuration();
 
   debugD("Polling %s in 5 seconds", polling_href.c_str());
-  app.onDelay(5000, [this, server_address, server_port](){
+  app.onDelay(5000, [this, server_address, server_port]() {
     this->poll_access_request(server_address, server_port, this->polling_href);
   });
 }
 
-void WSClient::poll_access_request(const String server_address, const uint16_t server_port, const String href) {
+void WSClient::poll_access_request(const String server_address,
+                                   const uint16_t server_port,
+                                   const String href) {
   debugD("Polling SK Server for authentication token");
 
   WiFiClient client;
@@ -265,7 +336,9 @@ void WSClient::poll_access_request(const String server_address, const uint16_t s
     String state = resp["state"];
     debugD("%s", state.c_str());
     if (state == "PENDING") {
-      app.onDelay(5000, [this, server_address, server_port, href](){ this->poll_access_request(server_address, server_port, href); });
+      app.onDelay(5000, [this, server_address, server_port, href]() {
+        this->poll_access_request(server_address, server_port, href);
+      });
       return;
     } else if (state == "COMPLETED") {
       JsonObject& access_req = resp["accessRequest"];
@@ -282,13 +355,15 @@ void WSClient::poll_access_request(const String server_address, const uint16_t s
         String token = access_req["token"];
         auth_token = token;
         save_configuration();
-        app.onDelay(0, [this, server_address, server_port](){ this->connect_ws(server_address, server_port); });
+        app.onDelay(0, [this, server_address, server_port]() {
+          this->connect_ws(server_address, server_port);
+        });
         return;
       }
     }
   } else {
     http.end();
-    if (httpCode==500) {
+    if (httpCode == 500) {
       // this is probably the server barfing due to
       // us polling a non-existing request. Just
       // delete the polling href.
@@ -314,16 +389,12 @@ void WSClient::connect_ws(const String host, const uint16_t port) {
   this->client.setAuthorization(full_token.c_str());
 }
 
-void WSClient::loop() {
-  this->client.loop();
-}
+void WSClient::loop() { this->client.loop(); }
 
-bool WSClient::is_connected() {
-  return connection_state==connected;
-}
+bool WSClient::is_connected() { return connection_state == connected; }
 
 void WSClient::restart() {
-  if (connection_state==connected) {
+  if (connection_state == connected) {
     this->client.disconnect();
     connection_state = disconnected;
   }
@@ -333,7 +404,7 @@ void WSClient::send_delta() {
   String output;
   if (sk_delta->data_available()) {
     sk_delta->get_delta(output);
-    if (connection_state==connected) {
+    if (connection_state == connected) {
       this->client.sendTXT(output);
       this->delta_cb();
     }
@@ -361,10 +432,7 @@ static const char SCHEMA[] PROGMEM = R"({
     }
   })";
 
-String WSClient::get_config_schema() {
-  return FPSTR(SCHEMA);
-}
-
+String WSClient::get_config_schema() { return FPSTR(SCHEMA); }
 
 bool WSClient::set_configuration(const JsonObject& config) {
   String expected[] = {"sk_address", "sk_port", "token", "client_id"};

--- a/src/net/ws_client.h
+++ b/src/net/ws_client.h
@@ -1,6 +1,6 @@
 #ifndef _ws_client_H_
 #define _ws_client_H_
-
+#include <set>
 #include <functional>
 
 #include <WebSocketsClient.h>
@@ -50,6 +50,7 @@ class WSClient : public Configurable {
   void send_access_request(const String host, const uint16_t port);
   void poll_access_request(const String host, const uint16_t port, const String href);
   void connect_ws(const String host, const uint16_t port);
+  void subscribe_listeners();
   std::function<void(bool)> connected_cb;
   void_cb_func delta_cb;
   bool get_mdns_service(String &server_address, uint16_t& server_port);

--- a/src/sensors/digital_output.cpp
+++ b/src/sensors/digital_output.cpp
@@ -1,0 +1,13 @@
+#include "digital_output.h"
+#include "Arduino.h"
+
+DigitalOutput::DigitalOutput(int pin)
+{
+    this->pinNumber = pin;
+    pinMode(pin, OUTPUT);
+}
+
+void DigitalOutput::set_input(bool newValue, uint8_t inputChannel)
+{
+    digitalWrite(this->pinNumber, newValue);
+}

--- a/src/sensors/digital_output.cpp
+++ b/src/sensors/digital_output.cpp
@@ -3,11 +3,11 @@
 
 DigitalOutput::DigitalOutput(int pin)
 {
-    this->pinNumber = pin;
+    pinNumber = pin;
     pinMode(pin, OUTPUT);
 }
 
 void DigitalOutput::set_input(bool newValue, uint8_t inputChannel)
 {
-    digitalWrite(this->pinNumber, newValue);
+    digitalWrite(pinNumber, newValue);
 }

--- a/src/sensors/digital_output.h
+++ b/src/sensors/digital_output.h
@@ -1,0 +1,17 @@
+#ifndef _digital_output_H
+#define _digital_output_H
+
+#include "system/observable.h"
+#include "system/valueconsumer.h"
+#include <ArduinoJson.h>
+
+class DigitalOutput : public BooleanConsumer
+{
+    public: 
+        DigitalOutput(int pin);
+        void set_input(bool newValue, uint8_t inputChannel = 0) override;
+    private:
+        int pinNumber;
+};
+
+#endif

--- a/src/signalk/signalk_listener.cpp
+++ b/src/signalk/signalk_listener.cpp
@@ -2,7 +2,7 @@
 
 std::vector<SKListener*> SKListener::listeners;
 
-SKListener::SKListener(String sk_path, int period) : sk_path{sk_path} {
+SKListener::SKListener(String sk_path, int listen_Delay) : sk_path{sk_path} {
   listeners.push_back(this);
-  this->period = period;
+  this->listen_delay = listen_Delay;
 }

--- a/src/signalk/signalk_listener.cpp
+++ b/src/signalk/signalk_listener.cpp
@@ -1,0 +1,8 @@
+#include "signalk_listener.h"
+
+std::vector<SKListener*> SKListener::listeners;
+
+SKListener::SKListener(String sk_path, int period) : sk_path{sk_path} {
+  listeners.push_back(this);
+  this->period = period;
+}

--- a/src/signalk/signalk_listener.cpp
+++ b/src/signalk/signalk_listener.cpp
@@ -2,7 +2,6 @@
 
 std::vector<SKListener*> SKListener::listeners;
 
-SKListener::SKListener(String sk_path, int listen_Delay) : sk_path{sk_path} {
+SKListener::SKListener(String sk_path, int listen_Delay) : sk_path{sk_path}, listen_delay{listen_Delay} {
   listeners.push_back(this);
-  this->listen_delay = listen_Delay;
 }

--- a/src/signalk/signalk_listener.h
+++ b/src/signalk/signalk_listener.h
@@ -12,7 +12,7 @@
 #include "sensesp.h"
 
 /**
- * A SignalK listener is one that listens subscribes for SignalK stream deltas
+ * A SignalK listener is one that listens for SignalK stream deltas
  * and notifies of value changes
  */
 class SKListener : virtual public Observable {
@@ -23,7 +23,7 @@ class SKListener : virtual public Observable {
          * @param sk_path The SignalK path that identifies
          * this particular subscription to value
          */
-        SKListener(String sk_path, int period);
+        SKListener(String sk_path, int listen_delay);
 
         /**
          * Returns the current SignalK path.  An empty string
@@ -34,9 +34,9 @@ class SKListener : virtual public Observable {
             return sk_path;
         }
 
-        int getPeriod()
+        int getListenDelay()
         {
-            return period;
+            return listen_delay;
         }
 
         virtual void parseValue(JsonObject& json)
@@ -53,7 +53,7 @@ class SKListener : virtual public Observable {
 
     private:
         static std::vector<SKListener*> listeners;
-        int period;
+        int listen_delay;
 };
 
 #endif

--- a/src/signalk/signalk_listener.h
+++ b/src/signalk/signalk_listener.h
@@ -22,6 +22,7 @@ class SKListener : virtual public Observable {
          * The constructor
          * @param sk_path The SignalK path that identifies
          * this particular subscription to value
+         * @param listen_delay The SignalK transmission rate, e.g. every period/1000 seconds.
          */
         SKListener(String sk_path, int listen_delay);
 

--- a/src/signalk/signalk_listener.h
+++ b/src/signalk/signalk_listener.h
@@ -1,0 +1,59 @@
+#ifndef _signalk_listener_H_
+#define _signalk_listener_H_
+
+#include <set>
+
+#include "Arduino.h"
+#include <ArduinoJson.h>
+
+#include "system/configurable.h"
+#include "system/observable.h"
+#include "system/valueproducer.h"
+#include "sensesp.h"
+
+/**
+ * A SignalK listener is one that listens subscribes for SignalK stream deltas
+ * and notifies of value changes
+ */
+class SKListener : virtual public Observable {
+
+    public:
+        /**
+         * The constructor
+         * @param sk_path The SignalK path that identifies
+         * this particular subscription to value
+         */
+        SKListener(String sk_path, int period);
+
+        /**
+         * Returns the current SignalK path.  An empty string
+         * is returned if this particular source is not configured
+         * or intended to return actual data.
+         */
+        String& get_sk_path() {
+            return sk_path;
+        }
+
+        int getPeriod()
+        {
+            return period;
+        }
+
+        virtual void parseValue(JsonObject& json)
+        {
+
+        }
+
+        static const std::vector<SKListener*>& get_listeners() {
+            return listeners;
+        }
+
+    protected:
+        String sk_path;
+
+    private:
+        static std::vector<SKListener*> listeners;
+        int period;
+};
+
+#endif

--- a/src/signalk/signalk_value_listener.h
+++ b/src/signalk/signalk_value_listener.h
@@ -6,7 +6,7 @@
 #include "system/valueproducer.h"
 #include <ArduinoJson.h>
 ///////////////////
-// SKListener is object that listens for specific value in Signal K, period is interval between updates in ms
+// SKListener is object that listens for specific value in Signal K, listen_Delay is minimum interval between updates in ms
 ///////////////////
 template <class T>
 class SKValueListener : public SKListener, public ValueProducer<T> {
@@ -18,8 +18,8 @@ class SKValueListener : public SKListener, public ValueProducer<T> {
 
   void parseValue(JsonObject& json) override
   {
-       this->output = (T)json["value"];
-       this->notify();
+       output = (T)json["value"];
+       notify();
   }  
 
 

--- a/src/signalk/signalk_value_listener.h
+++ b/src/signalk/signalk_value_listener.h
@@ -13,12 +13,15 @@ class SKValueListener : public SKListener, public ValueProducer<T> {
  public:
   SKValueListener(String sk_path, int listen_Delay = 1000) : SKListener(sk_path, listen_Delay) 
   {
-       
+       if(sk_path.isEmpty())
+       {
+            DEBUG_E("SKValueListener: User has provided empty sk_path. The subscription will not work as expected!");
+       }
   }
 
   void parseValue(JsonObject& json) override
   {
-       output = (T)json["value"];
+       this->output = (T)json["value"];
        notify();
   }  
 

--- a/src/signalk/signalk_value_listener.h
+++ b/src/signalk/signalk_value_listener.h
@@ -1,0 +1,29 @@
+#ifndef _sk_value_listener_H
+#define _sk_value_listener_H
+
+#include "signalk_listener.h"
+#include "system/observable.h"
+#include "system/valueproducer.h"
+#include <ArduinoJson.h>
+///////////////////
+// SKListener is object that listens for specific value in Signal K, period is interval between updates in ms
+///////////////////
+template <class T>
+class SKValueListener : public SKListener, public ValueProducer<T> {
+ public:
+  SKValueListener(String sk_path, int period) : SKListener(sk_path, period) 
+  {
+
+  }
+
+  void parseValue(JsonObject& json) override
+  {
+       this->output = (T)json["value"];
+       this->notify();
+  }  
+
+
+};
+
+
+#endif

--- a/src/signalk/signalk_value_listener.h
+++ b/src/signalk/signalk_value_listener.h
@@ -11,9 +11,9 @@
 template <class T>
 class SKValueListener : public SKListener, public ValueProducer<T> {
  public:
-  SKValueListener(String sk_path, int period) : SKListener(sk_path, period) 
+  SKValueListener(String sk_path, int listen_Delay = 1000) : SKListener(sk_path, listen_Delay) 
   {
-
+       
   }
 
   void parseValue(JsonObject& json) override
@@ -25,5 +25,8 @@ class SKValueListener : public SKListener, public ValueProducer<T> {
 
 };
 
-
+typedef SKValueListener<float> SKFloatListener;
+typedef SKValueListener<int> SKIntListener;
+typedef SKValueListener<bool> SKBoolListener;
+typedef SKValueListener<String> SKStringListener;
 #endif

--- a/src/transforms/threshold.cpp
+++ b/src/transforms/threshold.cpp
@@ -5,14 +5,14 @@ void ThresholdTransform<C,P>::set_input(C input, uint8_t inputChannel) {
   
   if(input >= minValue && input <= maxValue)
   {
-      output = inRange;
+      this->output = inRange;
   }
   else
   {
-      output = outRange;
+      this->output = outRange;
   }
   
-  notify();
+  this->notify();
 }
 
 

--- a/src/transforms/threshold.cpp
+++ b/src/transforms/threshold.cpp
@@ -3,57 +3,51 @@
 template <class C, class P>
 void ThresholdTransform<C,P>::set_input(C input, uint8_t inputChannel) {
   
-  if(input >= this->minValue && input <= this->maxValue)
+  if(input >= minValue && input <= maxValue)
   {
-      this->output = this->inRange;
-
-      debugI("Threshold is in range.");
+      output = inRange;
   }
   else
   {
-      this->output = this->outRange;
-
-      debugI("Threshold is out of range.");
+      output = outRange;
   }
-
-  debugI("Threshold updated.");
   
-  this->notify();
+  notify();
 }
 
 
 JsonObject& NumericThreshold::get_configuration(JsonBuffer& buf)
 {
     JsonObject& root = buf.createObject();
-    root["min"] = this->minValue;
-    root["max"] = this->maxValue;
-    root["in-range"] = this->inRange;
-    root["value"] = this->output;
+    root["min"] = minValue;
+    root["max"] = maxValue;
+    root["in_range"] = inRange;
+    root["value"] = output;
     return root;
 }
 
 static const char NUMERIC_SCHEMA[] PROGMEM = R"({
     "type": "object",
     "properties": {
-        "min": { "title": "Minimal value", "type": "number" },
-        "max": { "title": "Maximal value", "type": "number" },
-        "in-range": { "title": "In range value", "type": "boolean" },
+        "min": { "title": "Minimal value", "type": "number", "description" : "Minimum value when output will be set to In range value." },
+        "max": { "title": "Maximal value", "type": "number", "description" : "Maximum value when output will be set to In range value." },
+        "in_range": { "title": "In range value", "type": "boolean", "description" : "Output value (1/0 eg. on/off) when input value is in range defined." },
         "value": { "title": "Last value", "type": "boolean" }
     }
   })";
 
   bool NumericThreshold::set_configuration(const JsonObject& config)
   {
-      String expected[] = {"min", "max", "in-range", "value"};
+      String expected[] = {"min", "max", "in_range", "value"};
       for (auto str : expected) {
         if (!config.containsKey(str)) {
           return false;
         }
       }
-      this->minValue = config["min"];
-      this->maxValue = config["max"];
-      this->inRange = config["in-range"];
-      this->output = config["value"];
+      minValue = config["min"];
+      maxValue = config["max"];
+      inRange = config["in_range"];
+      output = config["value"];
 
       return true;
   }
@@ -67,35 +61,35 @@ static const char NUMERIC_SCHEMA[] PROGMEM = R"({
   JsonObject& IntegerThreshold::get_configuration(JsonBuffer& buf)
   {
       JsonObject& root = buf.createObject();
-      root["min"] = this->minValue;
-      root["max"] = this->maxValue;
-      root["in-range"] = this->inRange;
-      root["value"] = this->output;
+      root["min"] = minValue;
+      root["max"] = maxValue;
+      root["in_range"] = inRange;
+      root["value"] = output;
       return root;
   }
 
   static const char INTEGER_SCHEMA[] PROGMEM = R"({
       "type": "object",
       "properties": {
-          "min": { "title": "Minimal value", "type": "number" },
-          "max": { "title": "Maximal value", "type": "number" },
-          "in-range": { "title": "In range value", "type": "boolean" },
+          "min": { "title": "Minimal value", "type": "number", "description" : "Minimum value when output will be set to In range value." },
+          "max": { "title": "Maximal value", "type": "number", "description" : "Maximum value when output will be set to In range value." },
+          "in_range": { "title": "In range value", "type": "boolean", "description" : "Output value (1/0 eg. on/off) when input value is in range defined." },
           "value": { "title": "Last value", "type": "boolean" }
       }
     })";
 
   bool IntegerThreshold::set_configuration(const JsonObject& config)
   {
-      String expected[] = {"min", "max", "in-range"};
+      String expected[] = {"min", "max", "in_range"};
       for (auto str : expected) {
         if (!config.containsKey(str)) {
           return false;
         }
       }
-      this->minValue = config["min"];
-      this->maxValue = config["max"];
-      this->inRange = config["in-range"];
-      this->output = config["value"];
+      minValue = config["min"];
+      maxValue = config["max"];
+      inRange = config["in_range"];
+      output = config["value"];
 
       return true;
   }

--- a/src/transforms/threshold.cpp
+++ b/src/transforms/threshold.cpp
@@ -1,0 +1,106 @@
+#include "threshold.h"
+
+template <class C, class P>
+void ThresholdTransform<C,P>::set_input(C input, uint8_t inputChannel) {
+  
+  if(input >= this->minValue && input <= this->maxValue)
+  {
+      this->output = this->inRange;
+
+      debugI("Threshold is in range.");
+  }
+  else
+  {
+      this->output = this->outRange;
+
+      debugI("Threshold is out of range.");
+  }
+
+  debugI("Threshold updated.");
+  
+  this->notify();
+}
+
+
+JsonObject& NumericThreshold::get_configuration(JsonBuffer& buf)
+{
+    JsonObject& root = buf.createObject();
+    root["min"] = this->minValue;
+    root["max"] = this->maxValue;
+    root["in-range"] = this->inRange;
+    root["value"] = this->output;
+    return root;
+}
+
+static const char NUMERIC_SCHEMA[] PROGMEM = R"({
+    "type": "object",
+    "properties": {
+        "min": { "title": "Minimal value", "type": "number" },
+        "max": { "title": "Maximal value", "type": "number" },
+        "in-range": { "title": "In range value", "type": "boolean" },
+        "value": { "title": "Last value", "type": "boolean" }
+    }
+  })";
+
+  bool NumericThreshold::set_configuration(const JsonObject& config)
+  {
+      String expected[] = {"min", "max", "in-range", "value"};
+      for (auto str : expected) {
+        if (!config.containsKey(str)) {
+          return false;
+        }
+      }
+      this->minValue = config["min"];
+      this->maxValue = config["max"];
+      this->inRange = config["in-range"];
+      this->output = config["value"];
+
+      return true;
+  }
+
+  String NumericThreshold::get_config_schema()
+  {
+    return FPSTR(NUMERIC_SCHEMA);
+  }
+
+
+  JsonObject& IntegerThreshold::get_configuration(JsonBuffer& buf)
+  {
+      JsonObject& root = buf.createObject();
+      root["min"] = this->minValue;
+      root["max"] = this->maxValue;
+      root["in-range"] = this->inRange;
+      root["value"] = this->output;
+      return root;
+  }
+
+  static const char INTEGER_SCHEMA[] PROGMEM = R"({
+      "type": "object",
+      "properties": {
+          "min": { "title": "Minimal value", "type": "number" },
+          "max": { "title": "Maximal value", "type": "number" },
+          "in-range": { "title": "In range value", "type": "boolean" },
+          "value": { "title": "Last value", "type": "boolean" }
+      }
+    })";
+
+  bool IntegerThreshold::set_configuration(const JsonObject& config)
+  {
+      String expected[] = {"min", "max", "in-range"};
+      for (auto str : expected) {
+        if (!config.containsKey(str)) {
+          return false;
+        }
+      }
+      this->minValue = config["min"];
+      this->maxValue = config["max"];
+      this->inRange = config["in-range"];
+      this->output = config["value"];
+
+      return true;
+  }
+
+  String IntegerThreshold::get_config_schema()
+  {
+    return FPSTR(INTEGER_SCHEMA);
+  }

--- a/src/transforms/threshold.h
+++ b/src/transforms/threshold.h
@@ -1,0 +1,50 @@
+#include "transform.h"
+#ifndef _threshold_h
+#define _threshold_h
+template <typename C, typename P>
+class ThresholdTransform : public Transform<C, P> {
+ public:
+  ThresholdTransform(C minValue, C maxValue, P inRange, P outRange,
+                     String config_path="") : Transform<C, P>(config_path) {
+    this->minValue = minValue;
+    this->maxValue = maxValue;
+    this->inRange = inRange;
+    this->outRange = outRange;
+    Enable::className = "ThresholdTransform";
+    this->load_configuration();
+  };
+  virtual void set_input(C newValue, uint8_t inputChannel = 0) override;
+ protected:
+  C minValue;
+  C maxValue;
+  P inRange;
+  P outRange;
+};
+
+
+class NumericThreshold : public ThresholdTransform<float, bool>
+{
+    public:
+      NumericThreshold(float minValue, float maxValue, bool inRange,
+                     String config_path="") :
+                      ThresholdTransform<float, bool>(minValue, maxValue, inRange, !inRange, config_path)
+                      {}
+
+    virtual JsonObject& get_configuration(JsonBuffer& buf) override;
+    virtual bool set_configuration(const JsonObject& config) override;
+    virtual String get_config_schema() override;
+};
+
+class IntegerThreshold : public ThresholdTransform<int, bool>
+{
+    public:
+      IntegerThreshold(int minValue, int maxValue, bool inRange,
+                     String config_path="") :
+                      ThresholdTransform<int, bool>(minValue, maxValue, inRange, !inRange, config_path)
+                      {}
+
+    virtual JsonObject& get_configuration(JsonBuffer& buf) override;
+    virtual bool set_configuration(const JsonObject& config) override;
+    virtual String get_config_schema() override;
+};
+#endif

--- a/src/transforms/threshold.h
+++ b/src/transforms/threshold.h
@@ -1,6 +1,15 @@
 #include "transform.h"
 #ifndef _threshold_h
 #define _threshold_h
+
+/**
+ * A Transform base class that translates the value of type C into value of type P using threshold.
+ * Base class for classes NumericThreshold and IntegerThreshold.
+ * Arguments are minValue - minimum value for output to be inRange value.
+ *               maxValue - maximum value for output to be InRange value.
+ *               inRange - value if input value is in range
+ *               outRange - value if input value is out of the range
+ */
 template <typename C, typename P>
 class ThresholdTransform : public Transform<C, P> {
  public:
@@ -21,11 +30,14 @@ class ThresholdTransform : public Transform<C, P> {
   P outRange;
 };
 
-
+/**
+ * A Transform that translates float value into boolean value. User can define minValue and MaxValue to set region.
+ * If value is in range transform will use inRange boolean value as output. In other cases it uses !inRange value.
+ */
 class NumericThreshold : public ThresholdTransform<float, bool>
 {
     public:
-      NumericThreshold(float minValue, float maxValue, bool inRange,
+      NumericThreshold(float minValue, float maxValue, bool inRange = true,
                      String config_path="") :
                       ThresholdTransform<float, bool>(minValue, maxValue, inRange, !inRange, config_path)
                       {}
@@ -35,10 +47,14 @@ class NumericThreshold : public ThresholdTransform<float, bool>
     virtual String get_config_schema() override;
 };
 
+/**
+ * A Transform that translates integer value into boolean value. User can define minValue and MaxValue to set region.
+ * If value is in range transform will use inRange boolean value as output. In other cases it uses !inRange value.
+ */
 class IntegerThreshold : public ThresholdTransform<int, bool>
 {
     public:
-      IntegerThreshold(int minValue, int maxValue, bool inRange,
+      IntegerThreshold(int minValue, int maxValue, bool inRange = true,
                      String config_path="") :
                       ThresholdTransform<int, bool>(minValue, maxValue, inRange, !inRange, config_path)
                       {}


### PR DESCRIPTION
Added support for listening SignalK paths using SignalK subscription over WS. 
Added few classes to support subscribing to data on server. 

I've created class that represents value listerner called **SKValueListerner<T>**, that is **ValueProducer<T>**, so using what is already there I can connect value in SignalK to for example **DigitalOutput** (new class added). 

This is sample code for connecting navigation.lights value to D1 digital output for switching relay:

```
  auto * listener = new SKValueListener<bool>("navigation.lights", 500);
  listener->attach([]()
  {
    debugI("Navigation lights status has been updated!");
  });
  listener->connectTo(new DigitalOutput(5));
```

I've tested this code using D1 mini with relay HAT and SignalK Node Server and it works just fine.