### PR TITLE
Add Adafruit INA219 Library

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -41,6 +41,7 @@ lib_deps =
     Adafruit BME280 Library
     Adafruit BMP280 Library
     Adafruit SHT31 Library
-
+    Adafruit INA219
+    
 extra_scripts = extra_script.py
 


### PR DESCRIPTION
The Adafruit INA219 Library was missing from the dependency list causing the examples to compile with an error. This fixed it for me. I just started learning about SensESP, so I'm not sure it's the only place to edit...