### PR TITLE
ESP32 support and easy import as library

### DIFF
--- a/library.json
+++ b/library.json
@@ -36,7 +36,8 @@
       "name": "ESPAsyncTCP"
     },
     {
-      "name": "ESP Async WebServer"
+      "name": "ESP Async WebServer",
+      "version": "https://github.com/me-no-dev/ESPAsyncWebServer"
     },
     {
       "name": "ESP8266WiFi",

--- a/library.json
+++ b/library.json
@@ -26,7 +26,8 @@
       "version": "^0.2.2"
     },
     {
-      "name": "ESP8266WebServer"
+      "name": "ESP8266WebServer",
+      "platforms": "espressif8266"
     },
     {
       "name": "DNSServer"
@@ -38,10 +39,12 @@
       "name": "ESP Async WebServer"
     },
     {
-      "name": "ESP8266WiFi"
+      "name": "ESP8266WiFi",
+      "platforms": "espressif8266"
     },
     {
-      "name": "ESP8266mDNS"
+      "name": "ESP8266mDNS",
+      "platforms": "espressif8266"
     },
     {
       "name": "ESPAsyncWiFiManager"
@@ -60,7 +63,7 @@
       "name": "DallasTemperature"
     },
     {
-      "name": "ESP8266TrueRandom"
+      "name": "ESPTrueRandom"
     },
     {
       "name": "Adafruit ADS1X15"

--- a/library.json
+++ b/library.json
@@ -67,25 +67,6 @@
       "version": "https://github.com/sivar2311/ESPTrueRandom"
     },
     {
-      "name": "Adafruit ADS1X15"
-    },
-    {
-      "name": "Adafruit BME280 Library"
-    },
-    { 
-      "name": "Adafruit BMP280 Library"
-    },
-    {
-      "name": "Adafruit SHT31 Library"
-    },
-    {
-      "name": "Adafruit INA219"
-    },
-    {
-      "name": "Wire",
-      "platforms": "espressif8266"
-    },
-    {
       "name": "Wire"
     },
     {

--- a/library.json
+++ b/library.json
@@ -81,7 +81,7 @@
       "name": "RemoteDebug",
       "version": "https://github.com/JoaoLopesF/RemoteDebug.git#0b5a9c1a49fd2ade0e3cadc3a3707781e819359a" }
   ],
-  "version": "0.4.x",
+  "version": "0.4.3",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -63,10 +63,25 @@
       "name": "ESP8266TrueRandom"
     },
     {
+      "name": "Adafruit ADS1X15"
+    },
+    {
+      "name": "Adafruit BME280 Library"
+    },
+    { 
+      "name": "Adafruit BMP280 Library"
+    },
+    {
+      "name": "Adafruit SHT31 Library"
+    },
+    {
+      "name": "Adafruit INA219"
+    },
+    {
       "name": "RemoteDebug",
       "version": "https://github.com/JoaoLopesF/RemoteDebug.git#0b5a9c1a49fd2ade0e3cadc3a3707781e819359a" }
   ],
-  "version": "0.4.3",
+  "version": "0.4.x",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -62,8 +62,12 @@
     {
       "name": "DallasTemperature"
     },
+    { "name": "ESP8266TrueRandom",
+      "platforms": "espressif8266"
+    },
     {
-      "name": "ESPTrueRandom"
+      "name": "ESPRandom",
+      "platforms": "espressif32"
     },
     {
       "name": "Adafruit ADS1X15"
@@ -79,6 +83,10 @@
     },
     {
       "name": "Adafruit INA219"
+    },
+    {
+      "name": "Wire",
+      "platforms": "espressif8266"
     },
     {
       "name": "RemoteDebug",

--- a/library.json
+++ b/library.json
@@ -62,12 +62,9 @@
     {
       "name": "DallasTemperature"
     },
-    { "name": "ESP8266TrueRandom",
-      "platforms": "espressif8266"
-    },
     {
-      "name": "ESPRandom",
-      "platforms": "espressif32"
+      "name": "ESPTrueRandom",
+      "version": "https://github.com/sivar2311/ESPTrueRandom"
     },
     {
       "name": "Adafruit ADS1X15"

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -45,11 +45,7 @@ void Networking::setup(std::function<void(bool)> connection_cb) {
 }
 
 void Networking::setup_saved_ssid(std::function<void(bool)> connection_cb) {
-#ifdef ESP8266
-  WiFi.begin(ap_ssid, ap_password);
-#elif defined(ESP32)
   WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
-#endif
 
   uint32_t timer_start = millis();
 

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -45,7 +45,11 @@ void Networking::setup(std::function<void(bool)> connection_cb) {
 }
 
 void Networking::setup_saved_ssid(std::function<void(bool)> connection_cb) {
+#ifdef ESP8266
   WiFi.begin(ap_ssid, ap_password);
+#elif defined(ESP32)
+  WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
+#endif
 
   uint32_t timer_start = millis();
 

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -3,14 +3,15 @@
 #include "Arduino.h"
 
 #include <ArduinoJson.h>
-#include <ESP8266HTTPClient.h>
 #ifdef ESP8266
+  #include <ESP8266HTTPClient.h>
   #include <ESP8266mDNS.h>        // Include the mDNS library
 #elif defined(ESP32)
+  #include <HTTPClient.h>
   #include <ESPmDNS.h>
 #endif
 
-#include <ESP8266TrueRandom.h>
+#include <ESPTrueRandom.h>
 
 #include <WiFiClient.h>
 
@@ -194,8 +195,8 @@ void WSClient::send_access_request(const String server_address, const uint16_t s
   if (client_id == "") {
     // generate a client ID
     byte uuidNumber[16];
-    ESP8266TrueRandom.uuid(uuidNumber);
-    client_id = ESP8266TrueRandom.uuidToString(uuidNumber);
+    ESPTrueRandom.uuid(uuidNumber);
+    client_id = ESPTrueRandom.uuidToString(uuidNumber);
     save_configuration();
   }
 

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -6,12 +6,12 @@
 #ifdef ESP8266
   #include <ESP8266HTTPClient.h>
   #include <ESP8266mDNS.h>        // Include the mDNS library
+  #include <ESP8266TrueRandom.h>
 #elif defined(ESP32)
   #include <HTTPClient.h>
   #include <ESPmDNS.h>
+  #include <ESPRandom.h>
 #endif
-
-#include <ESPTrueRandom.h>
 
 #include <WiFiClient.h>
 
@@ -197,8 +197,13 @@ void WSClient::send_access_request(const String server_address, const uint16_t s
   if (client_id == "") {
     // generate a client ID
     byte uuidNumber[16];
-    ESPTrueRandom.uuid(uuidNumber);
-    client_id = ESPTrueRandom.uuidToString(uuidNumber);
+  #ifdef ESP8266
+    ESP8266TrueRandom.uuid(uuidNumber);
+    client_id = ESP8266TrueRandom.uuidToString(uuidNumber);
+  #elif defined(ESP32)
+    ESPRandom::uuid(uuidNumber);
+    client_id = ESPRandom::uuidToString(uuidNumber);
+  #endif
     save_configuration();
   }
 

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -54,7 +54,9 @@ WSClient::WSClient(String config_path, SKDelta* sk_delta,
 
 void WSClient::enable() {
   app.onDelay(0, [this](){ this->connect(); });
+#ifdef ESP8266
   app.onRepeat(20, [this](){ this->loop(); });
+#endif
   app.onRepeat(100, [this](){ this->send_delta(); });
   app.onRepeat(10000, [this](){ this->connect_loop(); });
 }

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -53,9 +53,7 @@ WSClient::WSClient(String config_path, SKDelta* sk_delta,
 
 void WSClient::enable() {
   app.onDelay(0, [this](){ this->connect(); });
-#ifdef ESP8266
   app.onRepeat(20, [this](){ this->loop(); });
-#endif
   app.onRepeat(100, [this](){ this->send_delta(); });
   app.onRepeat(10000, [this](){ this->connect_loop(); });
 }

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -6,13 +6,12 @@
 #ifdef ESP8266
   #include <ESP8266HTTPClient.h>
   #include <ESP8266mDNS.h>        // Include the mDNS library
-  #include <ESP8266TrueRandom.h>
 #elif defined(ESP32)
   #include <HTTPClient.h>
   #include <ESPmDNS.h>
-  #include <ESPRandom.h>
 #endif
 
+#include <ESPTrueRandom.h>
 #include <WiFiClient.h>
 
 #include "sensesp_app.h"
@@ -197,14 +196,8 @@ void WSClient::send_access_request(const String server_address, const uint16_t s
   if (client_id == "") {
     // generate a client ID
     byte uuidNumber[16];
-  #ifdef ESP8266
-    ESP8266TrueRandom.uuid(uuidNumber);
-    client_id = ESP8266TrueRandom.uuidToString(uuidNumber);
-  #elif defined(ESP32)
-    ESPRandom::uuid(uuidNumber);
-    client_id = ESPRandom::uuidToString(uuidNumber);
-  #endif
-    save_configuration();
+    ESPTrueRandom.uuid(uuidNumber);
+    client_id = ESPTrueRandom.uuidToString(uuidNumber);    save_configuration();
   }
 
   // create a new access request

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -195,7 +195,8 @@ void WSClient::send_access_request(const String server_address, const uint16_t s
     // generate a client ID
     byte uuidNumber[16];
     ESPTrueRandom.uuid(uuidNumber);
-    client_id = ESPTrueRandom.uuidToString(uuidNumber);    save_configuration();
+    client_id = ESPTrueRandom.uuidToString(uuidNumber);
+    save_configuration();
   }
 
   // create a new access request

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -28,7 +28,11 @@ RemoteDebug Debug;
 SensESPApp::SensESPApp(StdSensors_t stdSensors) : stdSensors{stdSensors} {
   // initialize filesystem
 
+#ifdef ESP8266
   if (!SPIFFS.begin()) {
+#elif defined(ESP32)
+  if (!SPIFFS.begin(true)) {
+#endif
     debugE("FATAL: Filesystem initialization failed.");
     ESP.restart();
   }

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -1,6 +1,10 @@
 #include "sensesp_app.h"
 
+#ifdef ESP8266
 #include "FS.h"
+#elif defined(ESP32)
+#include "SPIFFS.h"
+#endif
 
 #include "sensors/analog_input.h"
 #include "sensors/digital_input.h"
@@ -168,7 +172,7 @@ void SensESPApp::reset() {
   debugW("Resetting the device configuration.");
   networking->reset_settings();
   SPIFFS.format();
-  app.onDelay(1000, [](){ ESP.reset(); });
+  app.onDelay(1000, [](){ ESP.restart(); });
 }
 
 String SensESPApp::get_hostname() {

--- a/src/sensors/system_info.cpp
+++ b/src/sensors/system_info.cpp
@@ -1,7 +1,6 @@
 #include "system_info.h"
 
 #include "Arduino.h"
-#include <ESP8266WiFi.h>
 
 #include "sensesp.h"
 

--- a/src/system/configurable.cpp
+++ b/src/system/configurable.cpp
@@ -2,7 +2,11 @@
 
 #include "configurable.h"
 
+#ifdef ESP8266
 #include "FS.h"
+#elif defined(ESP32)
+#include "SPIFFS.h"
+#endif
 
 // Define a global configurable map. Rationale for a global variable:
 // Every Configurable with an id gets registered, and carrying an object

--- a/src/system/spiffs_storage.cpp
+++ b/src/system/spiffs_storage.cpp
@@ -2,7 +2,12 @@
 
 #include "spiffs_storage.h"
 
+#ifdef ESP8266
 #include "FS.h"
+#elif defined(ESP32)
+#include "SPIFFS.h"
+#endif
+
 
 void setup_spiffs_storage() {
   bool result = SPIFFS.begin();

--- a/src/transforms/change_filter.cpp
+++ b/src/transforms/change_filter.cpp
@@ -12,10 +12,10 @@ static float absf(float val) {
 
 
 ChangeFilter::ChangeFilter(float minDelta, float maxDelta, int maxSkips, String config_path) : 
+          NumericTransform(config_path),
           minDelta{minDelta},
           maxDelta{maxDelta},
-          maxSkips{maxSkips},
-          NumericTransform(config_path) {
+          maxSkips{maxSkips} {
 
   className = "ChangeFilter";
   load_configuration();

--- a/src/transforms/median.cpp
+++ b/src/transforms/median.cpp
@@ -2,8 +2,8 @@
 
 
 Median::Median(unsigned int sampleSize, String config_path) :
-    sampleSize{sampleSize},
-    NumericTransform(config_path) {
+    NumericTransform(config_path),
+    sampleSize{sampleSize} {
   className = "Median";
   load_configuration();
   buf.reserve(sampleSize);


### PR DESCRIPTION
I was working in parallel to @loopsmark on ESP32 support. The code changes are very similar, but i still post my work, since it differs in two import points:
* I use ESPTrueRandom for ESP8266 and ESP32, which simplifies the library dependencies.
* It is possible to import SensESP as a library in a project without any other dependencies.

As an example you can look at https://github.com/gzahl/SensGPS, which compiles for ESP8226 and ESP32 from the same sources. Both only depend explicitly on https://github.com/gzahl/SensESP#esp32

Please feel free to pull either my work or @loopsmark work. But it would be really nice to be able to simply import the upstream version of SensESP into new projects.

On a sidenode: 
* The dependency system of platformio is a mess (or i still don't understand it). It seems like all large libraries don't explicitly state their dependencies, but let just scan for them.
* Does anyone know, why the firmware (from the same code) is a lot larger for ESP32? It does not fit into the default partition layout of my 4M chip. The ESP8226 firmware is smaller. Maybe this can be optimized?
