### PR TITLE
fix: change to WIFI_STA mode when connected to known WiFi

### DIFF
--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -45,6 +45,7 @@ void Networking::setup(std::function<void(bool)> connection_cb) {
 }
 
 void Networking::setup_saved_ssid(std::function<void(bool)> connection_cb) {
+  WiFi.mode(WIFI_STA);
   WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
 
   uint32_t timer_start = millis();
@@ -61,7 +62,6 @@ void Networking::setup_saved_ssid(std::function<void(bool)> connection_cb) {
     debugI("Connected to wifi, SSID: %s", WiFi.SSID().c_str());
     connection_cb(true);
   }
-  WiFi.mode(WIFI_STA);
 }
 
 void Networking::setup_wifi_manager(std::function<void(bool)> connection_cb) {

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -61,6 +61,7 @@ void Networking::setup_saved_ssid(std::function<void(bool)> connection_cb) {
     debugI("Connected to wifi, SSID: %s", WiFi.SSID().c_str());
     connection_cb(true);
   }
+  WiFi.mode(WIFI_STA);
 }
 
 void Networking::setup_wifi_manager(std::function<void(bool)> connection_cb) {

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -45,7 +45,6 @@ void Networking::setup(std::function<void(bool)> connection_cb) {
 }
 
 void Networking::setup_saved_ssid(std::function<void(bool)> connection_cb) {
-  WiFi.mode(WIFI_STA);
   WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
 
   uint32_t timer_start = millis();
@@ -61,6 +60,7 @@ void Networking::setup_saved_ssid(std::function<void(bool)> connection_cb) {
   if (WiFi.status() == WL_CONNECTED) {
     debugI("Connected to wifi, SSID: %s", WiFi.SSID().c_str());
     connection_cb(true);
+    WiFi.mode(WIFI_STA);
   }
 }
 


### PR DESCRIPTION
This should fix issue #87. When ESP is connecting to known WiFi SSID, then mode is changed to WIFI_STA instead of leaving it on WIFI_AP_STA.