### PR TITLE
Fix problem with hostname in Issue #144

### DIFF
--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -124,11 +124,6 @@ void Networking::setup_wifi_manager(std::function<void(bool)> connection_cb) {
 
 ObservableValue<String>* Networking::get_hostname() { return this->hostname; }
 
-// No longer used
-// void Networking::set_hostname(String hostname) {
-//  debugD("Setting hostname");
-//  this->hostname->set(hostname);
-//}
 
 static const char SCHEMA_PREFIX[] PROGMEM = R"({
 "type": "object",
@@ -150,7 +145,11 @@ String get_property_row(String key, String title, bool readonly) {
 
 String Networking::get_config_schema() {
   String schema;
-  bool hostname_preset = preset_hostname != "";
+  // If hostname is not set by SensESPAppBuilder::set_hostname() in main.cpp,
+  // then preset_hostname will be "SensESP", and should not be read-only in the
+  // Config UI. If preset_hostname is not "SensESP", then it was set in main.cpp, so
+  // it should be read-only.
+  bool hostname_preset = preset_hostname != "SensESP";
   bool wifi_preset = preset_ssid != "";
   return String(FPSTR(SCHEMA_PREFIX))
     + get_property_row("hostname", "ESP device hostname", hostname_preset) + ","
@@ -174,7 +173,7 @@ bool Networking::set_configuration(const JsonObject& config) {
     return false;
   }
 
-  if (preset_hostname == "") {
+  if (preset_hostname == "SensESP") {
     this->hostname->set(config["hostname"].as<String>());
   }
   

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -35,7 +35,7 @@ enum StandardSensors {
 
 class SensESPApp {
  public:
-  SensESPApp(String hostname = "", String ssid = "", String wifi_password = "",
+  SensESPApp(String hostname = "SensESP", String ssid = "", String wifi_password = "",
              String sk_server_address = "", uint16_t sk_server_port = 0,
              StandardSensors sensors = ALL, int led_pin = LED_PIN,
              bool enable_led = ENABLE_LED, int led_ws_connected = 200,


### PR DESCRIPTION
Hostname can now be set and edited independently of wifi credentials. That is, either or both can be set or not set with SensESPAppBuilder in main.cpp, and still behave properly in the Config UI.