### PR TITLE
Add all Adafruit library dependencies to library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -92,6 +92,21 @@
       "name": "Adafruit AHRS"
     },
     {
+      "name": "Adafruit Unified Sensor"
+    },
+    {
+      "name": "Adafruit BusIO"
+    },
+    {
+      "name": "Adafruit Sensor Calibration"
+    },
+    {
+      "name": "Adafruit FXAS21002C"
+    },
+    {
+      "name": "Adafruit FXOS8700"
+    },
+    {
       "name": "EspSoftwareSerial"
     },
     {


### PR DESCRIPTION
For some reason that no one is sure of, a recent update to PlatformIO has required that all of these libraries be explicitly included in `library.json`.