### PR TITLE
Correct erroneous Debug message

### DIFF
--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -179,7 +179,7 @@ bool Networking::set_configuration(const JsonObject& config) {
   }
   
   if (preset_ssid == "") {
-    debugW("Ignoring saved SSID and password");
+    debugW("Using saved SSID and password");
     this->ap_ssid = config["ap_ssid"].as<String>();
     this->ap_password = config["ap_password"].as<String>();
   }


### PR DESCRIPTION
This message was the opposite of what it should have been. It really means "Using SSID and password that were saved by WifiManager or updated in the Config UI" - but that seems a bit much, so I just made it "Using saved SSID and password".