### PR TITLE
Add indirect dependencies as a workaround to a PlatformIO 5.0.1 bug

### DIFF
--- a/library.json
+++ b/library.json
@@ -89,6 +89,12 @@
       "name": "Adafruit MAX31856 library"
     },
     {
+      "name": "Adafruit Unified Sensor"
+    },
+    {
+      "name": "Adafruit BusIO"
+    },
+    {
       "name": "EspSoftwareSerial"
     },
     {


### PR DESCRIPTION
Projects using SensESP won't build properly because PIO 5.0.1 fails
to detect some dependencies of some Adafruit sensor libraries. As
a workaround, declaring these two dependencies in library.json seems
to fix.

This commit should be reverted once the underlying issue has been fixed.