### PR TITLE
Sample platformio.ini

### DIFF
--- a/examples/OneWire_temperatures.cpp
+++ b/examples/OneWire_temperatures.cpp
@@ -7,18 +7,18 @@
 #include "sensesp_app.h"
 #include "sensors/onewire_temperature.h"
 #include "signalk/signalk_output.h"
-#include "wiring_helpers.h"
 #include "transforms/linear.h"
+#include "wiring_helpers.h"
 
-ReactESP app([] () {
-  #ifndef SERIAL_DEBUG_DISABLED
+ReactESP app([]() {
+#ifndef SERIAL_DEBUG_DISABLED
   Serial.begin(115200);
 
   // A small delay and one debugI() are required so that
   // the serial output displays everything
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
+#endif
   delay(100);
   debugI("Serial debug enabled");
 
@@ -38,25 +38,33 @@ ReactESP app([] () {
 
   uint read_delay = 500;
 
-  auto* pCoolantTemp = new OneWireTemperature(dts, read_delay, "/coolantTemperature/oneWire");
+  auto* coolant_temp =
+      new OneWireTemperature(dts, read_delay, "/coolantTemperature/oneWire");
 
-    pCoolantTemp->connectTo(new Linear(1.0, 0.0, "/coolantTemperature/linear"))
-                ->connectTo(new SKOutputNumber("propulsion.mainEngine.coolantTemperature", "/coolantTemperature/skPath"));
+  coolant_temp->connectTo(new Linear(1.0, 0.0, "/coolantTemperature/linear"))
+      ->connectTo(new SKOutputNumber("propulsion.mainEngine.coolantTemperature",
+                                     "/coolantTemperature/skPath"));
 
-  auto* pExhaustTemp = new OneWireTemperature(dts, read_delay, "/exhaustTemperature/oneWire");
-    
-    pExhaustTemp->connectTo(new Linear(1.0, 0.0, "/exhaustTemperature/linear"))
-                ->connectTo(new SKOutputNumber("propulsion.mainEngine.exhaustTemperature", "/exhaustTemperature/skPath"));
-  
-  auto* p24VTemp = new OneWireTemperature(dts, read_delay, "/24vAltTemperature/oneWire");
-      
-      p24VTemp->connectTo(new Linear(1.0, 0.0, "/24vAltTemperature/linear"))
-              ->connectTo(new SKOutputNumber("electrical.alternators.24V.temperature", "/24vAltTemperature/skPath"));
+  auto* exhaust_temp =
+      new OneWireTemperature(dts, read_delay, "/exhaustTemperature/oneWire");
 
-  auto* p12VTemp = new OneWireTemperature(dts, read_delay, "/12vAltTemperature/oneWire");
-      
-      p12VTemp->connectTo(new Linear(1.0, 0.0, "/12vAltTemperature/linear"))
-              ->connectTo(new SKOutputNumber("electrical.alternators.12V.temperature", "/12vAltTemperature/skPath"));      
+  exhaust_temp->connectTo(new Linear(1.0, 0.0, "/exhaustTemperature/linear"))
+      ->connectTo(new SKOutputNumber("propulsion.mainEngine.exhaustTemperature",
+                                     "/exhaustTemperature/skPath"));
+
+  auto* alt_24v_temp =
+      new OneWireTemperature(dts, read_delay, "/24vAltTemperature/oneWire");
+
+  alt_24v_temp->connectTo(new Linear(1.0, 0.0, "/24vAltTemperature/linear"))
+      ->connectTo(new SKOutputNumber("electrical.alternators.24V.temperature",
+                                     "/24vAltTemperature/skPath"));
+
+  auto* alt_12v_temp =
+      new OneWireTemperature(dts, read_delay, "/12vAltTemperature/oneWire");
+
+  alt_12v_temp->connectTo(new Linear(1.0, 0.0, "/12vAltTemperature/linear"))
+      ->connectTo(new SKOutputNumber("electrical.alternators.12V.temperature",
+                                     "/12vAltTemperature/skPath"));
 
   sensesp_app->enable();
 });

--- a/examples/ads1x15_volt_meter.cpp
+++ b/examples/ads1x15_volt_meter.cpp
@@ -9,25 +9,25 @@
 #include "sensesp_app.h"
 #include "sensors/ads1x15.h"
 #include "signalk/signalk_output.h"
-#include "transforms/linear.h"
 #include "transforms/ads1x15_voltage.h"
+#include "transforms/linear.h"
 #include "transforms/voltage_multiplier.h"
 
-ReactESP app([] () {
-  #ifndef SERIAL_DEBUG_DISABLED
+ReactESP app([]() {
+#ifndef SERIAL_DEBUG_DISABLED
   Serial.begin(115200);
 
   // A small delay and one debugI() are required so that
   // the serial output displays everything
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
+#endif
   delay(100);
   debugI("Serial debug enabled");
 
   sensesp_app = new SensESPApp();
-  
-  // Create an instance of a ADS1115 Analog-to-Digital Converter (ADC). 
+
+  // Create an instance of a ADS1115 Analog-to-Digital Converter (ADC).
   ADS1x15CHIP_t chip = ADS1115chip;
   adsGain_t gain = GAIN_TWOTHIRDS;
   ADS1115* ads1115 = new ADS1115(0x48, gain);
@@ -37,29 +37,40 @@ ReactESP app([] () {
   uint8_t channel_12V = 0;
   uint read_delay_12V = 500;
 
-  auto* p12V_AltVoltage = new ADS1115value(ads1115, channel_12V, read_delay_12V, "/12V_Alt/ADC read delay");
+  auto* alt_12v_voltage = new ADS1115value(ads1115, channel_12V, read_delay_12V,
+                                           "/12V_Alt/ADC read delay");
 
-  // The output from the ADS1115 needs to be sent through some transforms to get it ready to display in Signal K:
-  // - ADS1x15Voltage() takes the output from the ADS1115 and converts it back into the voltage that was read by the chip.
-  // - VoltageMultiplier() reverses the effect of the physical voltage divider that was used to step the source voltage
-  //   down to less than 5 volts, which is the maximum the ADC can read. The output is the original voltage.
-  // - SKOutputNumber() is a specialized transport to send a float value to the Signal K server.
+  // The output from the ADS1115 needs to be sent through some transforms to get
+  // it ready to display in Signal K:
+  // - ADS1x15Voltage() takes the output from the ADS1115 and converts it back
+  // into the voltage that was read by the chip.
+  // - VoltageMultiplier() reverses the effect of the physical voltage divider
+  // that was used to step the source voltage
+  //   down to less than 5 volts, which is the maximum the ADC can read. The
+  //   output is the original voltage.
+  // - SKOutputNumber() is a specialized transport to send a float value to the
+  // Signal K server.
 
-    p12V_AltVoltage->connectTo(new ADS1x15Voltage(chip, gain)) 
-                  ->connectTo(new VoltageMultiplier(10000, 4730, "/12V_Alt/VoltMuliplier"))  // Measured ohm values of R1 and R2 in the physical voltage divider
-                  ->connectTo(new SKOutputNumber("electrical.alternators.12V.voltage", "/12V_Alt/skPath"));
+  alt_12v_voltage->connectTo(new ADS1x15Voltage(chip, gain))
+      ->connectTo(new VoltageMultiplier(
+          10000, 4730,
+          "/12V_Alt/VoltMuliplier"))  // Measured ohm values of R1 and R2 in the
+                                      // physical voltage divider
+      ->connectTo(new SKOutputNumber("electrical.alternators.12V.voltage",
+                                     "/12V_Alt/skPath"));
 
-
-  // Create a second instance of ADS1115value to read from the same physical ADS1115, but from channel 1 instead of 0.
+  // Create a second instance of ADS1115value to read from the same physical
+  // ADS1115, but from channel 1 instead of 0.
   uint8_t channel_24V = 1;
   uint read_delay_24V = 500;
 
-  auto* p24VAltVoltage = new ADS1115value(ads1115, channel_24V, read_delay_24V, "/24V_Alt/ADC read delay");
+  auto* alt_24v_voltage = new ADS1115value(ads1115, channel_24V, read_delay_24V,
+                                           "/24V_Alt/ADC read delay");
 
-    p24VAltVoltage->connectTo(new ADS1x15Voltage(chip, gain)) 
-                  ->connectTo(new VoltageMultiplier(21800, 4690, "/24V_Alt/VoltMuliplier"))
-                  ->connectTo(new SKOutputNumber("electrical.alternators.24V.voltage", "/24V_Alt/skPath"));                
+  alt_24v_voltage->connectTo(new ADS1x15Voltage(chip, gain))
+      ->connectTo(new VoltageMultiplier(21800, 4690, "/24V_Alt/VoltMuliplier"))
+      ->connectTo(new SKOutputNumber("electrical.alternators.24V.voltage",
+                                     "/24V_Alt/skPath"));
 
- 
   sensesp_app->enable();
 });

--- a/examples/analog_input.cpp
+++ b/examples/analog_input.cpp
@@ -1,35 +1,34 @@
+#include "sensors/analog_input.h"
+
 #include <Arduino.h>
 
 #include "sensesp_app.h"
-#include "sensors/analog_input.h"
-#include "transforms/linear.h"
 #include "signalk/signalk_output.h"
+#include "transforms/linear.h"
 
 // SensESP builds upon the ReactESP framework. Every ReactESP application
 // defines an "app" object vs defining a "main()" method.
-ReactESP app([] () {
+ReactESP app([]() {
 
-  // Some initialization boilerplate when in debug mode...
-  #ifndef SERIAL_DEBUG_DISABLED
+// Some initialization boilerplate when in debug mode...
+#ifndef SERIAL_DEBUG_DISABLED
   Serial.begin(115200);
 
   // A small delay and one debugI() are required so that
   // the serial output displays everything
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
+#endif
   delay(100);
   debugI("Serial debug enabled");
 
   // Create the global SensESPApp() object.
   sensesp_app = new SensESPApp();
 
-
   // The "SignalK path" identifies this sensor to the SignalK server. Leaving
   // this blank would indicate this particular sensor (or transform) does not
   // broadcast SignalK data.
   const char* sk_path = "indoor.illumination";
-
 
   // The "Configuration path" is combined with "/config" to formulate a URL
   // used by the RESTful API for retrieving or setting configuration data.
@@ -41,32 +40,32 @@ ReactESP app([] () {
   // run-time configuration.
   const char* analog_in_config_path = "/indoor_illumination/analog_in";
   const char* linear_config_path = "/indoor_illumination/linear";
-  
 
-  // Create a sensor that is the source of our data, that will be read every 500 ms. 
-  // It's a light sensor that's connected to the ESP's AnalogIn pin. 
-  // The AnalogIn pin on ESP8266 is always A0, but ESP32 has many pins that can be
+  // Create a sensor that is the source of our data, that will be read every 500
+  // ms. It's a light sensor that's connected to the ESP's AnalogIn pin. The
+  // AnalogIn pin on ESP8266 is always A0, but ESP32 has many pins that can be
   // used for AnalogIn, and they're expressed here as the XX in GPIOXX.
-  // When it's dark, the sensor's output (as read by analogRead()) is 120, and when
-  // it's bright, the output is 850, for a range of 730.
+  // When it's dark, the sensor's output (as read by analogRead()) is 120, and
+  // when it's bright, the output is 850, for a range of 730.
   uint8_t pin = A0;
   uint read_delay = 500;
-  
-  auto* pAnalogInput = new AnalogInput(pin, read_delay, analog_in_config_path);
 
-  // A Linear transform takes its input, multiplies it by the multiplier, then adds the offset,
-  // to calculate its output. In this example, we want to see the final output presented
-  // as a percentage, where dark = 0% and bright = 100%. To get a percentage, we use this formula:
-  // sensor output * (100 / 730) - 16.44 = output (a percentage from 0 to 100).
-  // Dark = 120 * (100 / 730) + (-16.44) = 0%
-  // Bright = 850 * (100 / 730) + (-16.44) = 100%
-  const float multiplier = 0.137; // 100% divided by 730 = 0.137 "percent per analogRead() unit"
+  auto* analog_input = new AnalogInput(pin, read_delay, analog_in_config_path);
+
+  // A Linear transform takes its input, multiplies it by the multiplier, then
+  // adds the offset, to calculate its output. In this example, we want to see
+  // the final output presented as a percentage, where dark = 0% and bright =
+  // 100%. To get a percentage, we use this formula: sensor output * (100 / 730)
+  // - 16.44 = output (a percentage from 0 to 100). Dark = 120 * (100 / 730) +
+  // (-16.44) = 0% Bright = 850 * (100 / 730) + (-16.44) = 100%
+  const float multiplier =
+      0.137;  // 100% divided by 730 = 0.137 "percent per analogRead() unit"
   const float offset = -16.44;
 
   // Wire up the output of the analog input to the Linear transform,
   // and then output the results to the SignalK server.
-  pAnalogInput -> connectTo(new Linear(multiplier, offset, linear_config_path))
-               -> connectTo(new SKOutputNumber(sk_path));
+  analog_input->connectTo(new Linear(multiplier, offset, linear_config_path))
+      ->connectTo(new SKOutputNumber(sk_path));
 
   // Start the SensESP application running
   sensesp_app->enable();

--- a/examples/bme280_example.cpp
+++ b/examples/bme280_example.cpp
@@ -22,17 +22,15 @@ ReactESP app([] () {
   delay(100);
   debugI("Serial debug enabled");
 
-  // Create the SensESPApp with whatever "standard sensors" you want: noStdSensors, allStdSensors, or uptimeOnly.
-  // The default is allStdSensors.
-  sensesp_app = new SensESPApp(uptimeOnly);
+  sensesp_app = new SensESPApp();
 
   // Create a BME280, which represents the physical sensor.
   // 0x77 is the default address. Some chips use 0x76, which is shown here.
-  auto* pBME280 = new BME280(0x76);
+  auto* bme280 = new BME280(0x76);
 
   // If you want to change any of the settings that are set by Adafruit_BME280::setSampling(), do
   // that here, like this:
-  // pBME280->pAdafruitBME280->setSampling(); // pass in the parameters you want
+  // bme280->pAdafruitBME280->setSampling(); // pass in the parameters you want
 
 
   // Define the read_delays you're going to use:
@@ -41,22 +39,22 @@ ReactESP app([] () {
 
   // Create a BME280value, which is used to read a specific value from the BME280, and send its output
   // to SignalK as a number (float). This one is for the temperature reading.
-  auto* pBMEtemperature = new BME280value(pBME280, temperature, read_delay, "/Outside/Temperature");
+  auto* bme_temperature = new BME280value(bme280, temperature, read_delay, "/Outside/Temperature");
       
-      pBMEtemperature->connectTo(new SKOutputNumber("environment.outside.temperature"));
+      bme_temperature->connectTo(new SKOutputNumber("environment.outside.temperature"));
 
 
   // Do the same for the barometric pressure value. Its read_delay is longer, since barometric pressure can't
   // change all that quickly. It could be much longer for that reason.
-  auto* pBMEpressure = new BME280value(pBME280, pressure,  pressure_read_delay, "/Outside/Pressure");
+  auto* bme_pressure = new BME280value(bme280, pressure,  pressure_read_delay, "/Outside/Pressure");
       
-      pBMEpressure->connectTo(new SKOutputNumber("environment.outside.pressure"));
+      bme_pressure->connectTo(new SKOutputNumber("environment.outside.pressure"));
 
 
   // Do the same for the humidity value.
-  auto* pBMEhumidity = new BME280value(pBME280, humidity,  read_delay, "Outside/Humidity");
+  auto* bme_humidity = new BME280value(bme280, humidity,  read_delay, "Outside/Humidity");
       
-      pBMEhumidity->connectTo(new SKOutputNumber("environment.outside.humidity"));      
+      bme_humidity->connectTo(new SKOutputNumber("environment.outside.humidity"));      
 
 
   sensesp_app->enable();

--- a/examples/bmp280_example.cpp
+++ b/examples/bmp280_example.cpp
@@ -7,50 +7,51 @@
 #define USE_LIB_WEBSOCKET true
 
 #include "sensesp_app.h"
-#include "signalk/signalk_output.h"
 #include "sensors/bmp280.h"
+#include "signalk/signalk_output.h"
 
-ReactESP app([] () {
-  #ifndef SERIAL_DEBUG_DISABLED
+ReactESP app([]() {
+#ifndef SERIAL_DEBUG_DISABLED
   Serial.begin(115200);
 
   // A small delay and one debugI() are required so that
   // the serial output displays everything
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
+#endif
   delay(100);
   debugI("Serial debug enabled");
 
-  // Create the SensESPApp with whatever "standard sensors" you want: noStdSensors, allStdSensors, or uptimeOnly.
-  // The default is allStdSensors.
-  sensesp_app = new SensESPApp(uptimeOnly);
+  sensesp_app = new SensESPApp();
 
   // Create a BMP280, which represents the physical sensor.
   // 0x77 is the default address. Some chips use 0x76, which is shown here.
-  auto* pBMP280 = new BMP280(0x76);
+  auto* bmp280 = new BMP280(0x76);
 
-  // If you want to change any of the settings that are set by Adafruit_BMP280::setSampling(), do
-  // that here, like this:
-  // pBMP280->pAdafruitBMP280->setSampling(); // pass in the parameters you want
+  // If you want to change any of the settings that are set by
+  // Adafruit_BMP280::setSampling(), do that here, like this:
+  // bmp280->pAdafruitBMP280->setSampling(); // pass in the parameters you want
 
   // Define the read_delays you're going to use:
-  const uint read_delay = 1000; // once per second
-  const uint pressure_read_delay = 60000; // once per minute
+  const uint read_delay = 1000;            // once per second
+  const uint pressure_read_delay = 60000;  // once per minute
 
-  // Create a BMP280value, which is used to read a specific value from the BMP280, and send its output
-  // to SignalK as a number (float). This one is for the temperature reading.
-  auto* pBMPtemperature = new BMP280value(pBMP280, temperature, read_delay, "/Outside/Temperature");
-      
-      pBMPtemperature->connectTo(new SKOutputNumber("environment.outside.temperature"));
+  // Create a BMP280value, which is used to read a specific value from the
+  // BMP280, and send its output to SignalK as a number (float). This one is for
+  // the temperature reading.
+  auto* bmp_temperature =
+      new BMP280value(bmp280, temperature, read_delay, "/Outside/Temperature");
 
+  bmp_temperature->connectTo(
+      new SKOutputNumber("environment.outside.temperature"));
 
-  // Do the same for the barometric pressure value. Its read_delay is longer, since barometric pressure can't
-  // change all that quickly. It could be much longer for that reason.
-  auto* pBMPpressure = new BMP280value(pBMP280, pressure,  pressure_read_delay, "/Outside/Pressure");
-      
-      pBMPpressure->connectTo(new SKOutputNumber("environment.outside.pressure"));
+  // Do the same for the barometric pressure value. Its read_delay is longer,
+  // since barometric pressure can't change all that quickly. It could be much
+  // longer for that reason.
+  auto* bmp_pressure = new BMP280value(bmp280, pressure, pressure_read_delay,
+                                       "/Outside/Pressure");
 
+  bmp_pressure->connectTo(new SKOutputNumber("environment.outside.pressure"));
 
-    sensesp_app->enable();
+  sensesp_app->enable();
 });

--- a/examples/fuel_flow_meter.cpp
+++ b/examples/fuel_flow_meter.cpp
@@ -3,15 +3,15 @@
 #include "sensesp_app.h"
 #include "wiring_helpers.h"
 
-ReactESP app([] () {
-  #ifndef SERIAL_DEBUG_DISABLED
+ReactESP app([]() {
+#ifndef SERIAL_DEBUG_DISABLED
   Serial.begin(115200);
 
   // A small delay and one debugI() are required so that
   // the serial output displays everything
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
+#endif
   delay(100);
   debugI("Serial debug enabled");
 

--- a/examples/fuel_level_sensor/main.cpp
+++ b/examples/fuel_level_sensor/main.cpp
@@ -1,19 +1,20 @@
 #include <Arduino.h>
+
 #include "sensesp_app.h"
 #include "sensors/analog_input.h"
-#include "transforms/moving_average.h"
 #include "signalk/signalk_output.h"
+#include "transforms/moving_average.h"
 
 #define SERIAL_DEBUG_DISABLED = true
 
-ReactESP app([] () {
-  #ifndef SERIAL_DEBUG_DISABLED
-    Serial.begin(115200);
-    // A small arbitrary delay is required to let the
-    // serial port catch up
-    delay(100);
-    Debug.setSerialEnabled(true);
-  #endif
+ReactESP app([]() {
+#ifndef SERIAL_DEBUG_DISABLED
+  Serial.begin(115200);
+  // A small arbitrary delay is required to let the
+  // serial port catch up
+  delay(100);
+  Debug.setSerialEnabled(true);
+#endif
 
   // Set up sensesp
   sensesp_app = new SensESPApp();
@@ -24,15 +25,16 @@ ReactESP app([] () {
   AnalogInput* input = new AnalogInput();
 
   // scale factor. this will depend on your circuit:
-  // 1. Take the maximum analog input value (i.e. value when sensor is at the high end)
+  // 1. Take the maximum analog input value (i.e. value when sensor is at the
+  // high end)
   // 2. Divide 1 by max value. In my case: 1 / 870 = 0.001149425
   float scale = 0.001149425F;
 
   // Takes a moving average for every 10 values, with scale factor
   MovingAverage* avg = new MovingAverage(10, scale);
 
-  input -> connectTo(avg) -> connectTo(new SKOutputNumber("tanks.fuel.0.currentLevel"));
+  input->connectTo(avg)->connectTo(
+      new SKOutputNumber("tanks.fuel.0.currentLevel"));
 
   sensesp_app->enable();
-
 });

--- a/examples/gps_compass.cpp
+++ b/examples/gps_compass.cpp
@@ -1,11 +1,10 @@
 #include <Arduino.h>
 
 #include "SoftwareSerial.h"
-
 #include "sensesp_app.h"
 #include "wiring_helpers.h"
 
-ReactESP app([] () {
+ReactESP app([]() {
   sensesp_app = new SensESPApp();
 
   // Hardware serial port is reserved for serial terminal
@@ -21,10 +20,10 @@ ReactESP app([] () {
   // Software serial port is used for receiving NMEA data
   // ESP8266 pins are specified as DX
   // ESP32 pins are specified as just the X in GPIOX
-  SoftwareSerial* swSerial = new SoftwareSerial(D7, SW_SERIAL_UNUSED_PIN);
-  swSerial->begin(38400, SWSERIAL_8N1);
-  
-  setup_gps(swSerial);
+  SoftwareSerial* sw_serial = new SoftwareSerial(D7, -1);
+  sw_serial->begin(38400, SWSERIAL_8N1);
+
+  setup_gps(sw_serial);
 
   sensesp_app->enable();
 });

--- a/examples/ina219_example.cpp
+++ b/examples/ina219_example.cpp
@@ -7,60 +7,69 @@
 #define USE_LIB_WEBSOCKET true
 
 #include "sensesp_app.h"
-#include "signalk/signalk_output.h"
 #include "sensors/ina219.h"
+#include "signalk/signalk_output.h"
 
-ReactESP app([] () {
-  #ifndef SERIAL_DEBUG_DISABLED
+ReactESP app([]() {
+#ifndef SERIAL_DEBUG_DISABLED
   Serial.begin(115200);
 
   // A small delay and one debugI() are required so that
   // the serial output displays everything
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
+#endif
   delay(100);
   debugI("Serial debug enabled");
 
-  // Create the SensESPApp with whatever "standard sensors" you want: noStdSensors, allStdSensors, or uptimeOnly.
-  // The default is allStdSensors.
-  sensesp_app = new SensESPApp(allStdSensors);
+  sensesp_app = new SensESPApp();
 
   // Create an INA219, which represents the physical sensor.
-  // 0x40 is the default address. Chips can be modified to use 0x41 (shown here), 0x44, or 0x45.
-  // The default volt and amp ranges are 32V and 2A (cal32_2). Here, 32v and 1A is specified with cal32_1.
-  auto* pINA219 = new INA219(0x41, cal32_1);
+  // 0x40 is the default address. Chips can be modified to use 0x41 (shown
+  // here), 0x44, or 0x45. The default volt and amp ranges are 32V and 2A
+  // (cal32_2). Here, 32v and 1A is specified with cal32_1.
+  auto* ina219 = new INA219(0x41, cal32_1);
 
+  // Define the read_delay you're going to use, if other than the default of 500
+  // ms.
+  const uint read_delay = 1000;  // once per second
 
-  // Define the read_delay you're going to use, if other than the default of 500 ms.
-  const uint read_delay = 1000; // once per second
+  // Create an INA219value, which is used to read a specific value from the
+  // INA219, and send its output to SignalK as a number (float). This one is for
+  // the bus voltage.
+  auto* ina219_bus_voltage = new INA219value(ina219, bus_voltage, read_delay,
+                                             "/someElectricDevice/busVoltage");
 
-  // Create an INA219value, which is used to read a specific value from the INA219, and send its output
-  // to SignalK as a number (float). This one is for the bus voltage.
-  auto* pINA219busVoltage = new INA219value(pINA219, bus_voltage, read_delay, "/someElectricDevice/busVoltage");
-      
-      pINA219busVoltage->connectTo(new SKOutputNumber("electrical.someelectricdevice.busVoltage"));
+  ina219_bus_voltage->connectTo(
+      new SKOutputNumber("electrical.someelectricdevice.busVoltage"));
 
   // Do the same for the shunt voltage.
-  auto* pINA219shuntVoltage = new INA219value(pINA219, shunt_voltage, read_delay, "/someElectricDevice/shuntVoltage");
-      
-      pINA219shuntVoltage->connectTo(new SKOutputNumber("electrical.someelectricdevice.shuntVoltage"));
+  auto* ina219_shunt_voltage = new INA219value(
+      ina219, shunt_voltage, read_delay, "/someElectricDevice/shuntVoltage");
+
+  ina219_shunt_voltage->connectTo(
+      new SKOutputNumber("electrical.someelectricdevice.shuntVoltage"));
 
   // Do the same for the current (amperage).
-  auto* pINA219current = new INA219value(pINA219, current, read_delay, "/someElectricDevice/current");
-      
-      pINA219current->connectTo(new SKOutputNumber("electrical.someelectricdevice.current"));   
+  auto* ina219_current = new INA219value(ina219, current, read_delay,
+                                         "/someElectricDevice/current");
+
+  ina219_current->connectTo(
+      new SKOutputNumber("electrical.someelectricdevice.current"));
 
   // Do the same for the power (watts).
-  auto* pINA219power = new INA219value(pINA219, power, read_delay, "/someElectricDevice/power");
-      
-      pINA219power->connectTo(new SKOutputNumber("electrical.someelectricdevice.power"));  
+  auto* ina219_power =
+      new INA219value(ina219, power, read_delay, "/someElectricDevice/power");
+
+  ina219_power->connectTo(
+      new SKOutputNumber("electrical.someelectricdevice.power"));
 
   // Do the same for the load voltage.
-  auto* pINA219loadVoltage = new INA219value(pINA219, load_voltage, read_delay, "/someElectricDevice/loadVoltage");
-      
-      pINA219loadVoltage->connectTo(new SKOutputNumber("electrical.someelectricdevice.loadVoltage"));         
+  auto* ina219_load_voltage = new INA219value(
+      ina219, load_voltage, read_delay, "/someElectricDevice/loadVoltage");
 
+  ina219_load_voltage->connectTo(
+      new SKOutputNumber("electrical.someelectricdevice.loadVoltage"));
 
   sensesp_app->enable();
 });

--- a/examples/platformio.ini
+++ b/examples/platformio.ini
@@ -1,0 +1,59 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+; NOTE: This is an example platformio.ini file to be used as a template for
+; derived projects. Do not use the file within the SensESP directory tree but
+; instead create a new project in PlatformIO and copy this file and one of the
+; example source files there.
+
+[platformio]
+;set default_envs to whichever board(s) you use. Build/Run/etc processes those envs
+default_envs = 
+   esp32dev
+   d1_mini
+;   esp-wrover-kit
+
+[env]
+; Global data for all [env:***]
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+  https://github.com/SignalK/SensESP.git
+
+[espressif8266_base]
+;this section has config items common to all ESP8266 boards
+platform = espressif8266
+build_flags =
+   -Wl,-Teagle.flash.4m1m.ld
+   -Wall
+   -Wno-reorder
+
+[env:d1_mini]
+extends = espressif8266_base
+board = d1_mini
+board_build.f_cpu = 160000000L
+upload_resetmethod = nodemcu
+upload_speed = 460800  
+
+[espressif32_base]
+;this section has config items common to all ESP32 boards
+platform = espressif32
+build_unflags = -Werror=reorder
+board_build.partitions = min_spiffs.csv
+monitor_filters = esp32_exception_decoder
+
+[env:esp32dev]
+extends = espressif32_base
+board = esp32dev
+
+[env:esp-wrover-kit]
+extends = espressif32_base
+board = esp-wrover-kit
+upload_speed = 460800

--- a/examples/relay_control.cpp
+++ b/examples/relay_control.cpp
@@ -36,10 +36,10 @@ ReactESP app([]() {
 
   // Create the global SensESPApp() object.
   sensesp_app = builder.set_hostname("relay")
-    ->set_sk_server("10.10.10.1", 3000)
-    ->set_wifi("yourSSID", "yourPassword")
-    ->set_standard_sensors()
-    ->get_app();
+                    ->set_sk_server("10.10.10.1", 3000)
+                    ->set_wifi("yourSSID", "yourPassword")
+                    ->set_standard_sensors()
+                    ->get_app();
 
   // Define the SK Path you want to listen to
   const char* sk_path = "environment.outside.illuminance";
@@ -58,8 +58,8 @@ ReactESP app([]() {
   // Wire up the output of the float value on server
   // "environment.outside.illuminance" to the NumericThreshold, and then output
   // the transformed float to boolean to DigitalOutput
-  auto* pListener = new SKNumericListener(sk_path);
-  pListener->connectTo(new NumericThreshold(0.0f, 100.0f, true, config_path))
+  auto* listener = new SKNumericListener(sk_path);
+  listener->connectTo(new NumericThreshold(0.0f, 100.0f, true, config_path))
       ->connectTo(new DigitalOutput(5));
 
   // Start the SensESP application running

--- a/examples/rpm_counter.cpp
+++ b/examples/rpm_counter.cpp
@@ -2,11 +2,10 @@
 
 //#define SERIAL_DEBUG_DISABLED
 
-#include "sensors/digital_input.h"
 #include "sensesp_app.h"
-#include "transforms/frequency.h"
+#include "sensors/digital_input.h"
 #include "signalk/signalk_output.h"
-
+#include "transforms/frequency.h"
 
 // SensESP builds upon the ReactESP framework. Every ReactESP application
 // defines an "app" object vs defining a "main()" method.
@@ -18,22 +17,21 @@ ReactESP app([]() {
   // the serial output displays everything
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
+#endif
   delay(100);
   debugI("Serial debug enabled");
 
   sensesp_app = new SensESPApp();
 
-  // The "SignalK path" identifies the output of the sensor to the SignalK network.
-  // If you have multiple sensors connected to your microcontoller (ESP), each one of them
-  // will (probably) have its own SignalK path variable. For example, if you have two
-  // propulsion engines, and you want the RPM of each of them to go to SignalK, you might
-  // have sk_path_portEngine = "propulsion.port.revolutions"
-  // and sk_path_starboardEngine = "propulsion.starboard.revolutions"
-  // In this example, there is only one propulsion engine, and its RPM is the only thing
-  // being reported to SignalK.
+  // The "SignalK path" identifies the output of the sensor to the SignalK
+  // network. If you have multiple sensors connected to your microcontoller
+  // (ESP), each one of them will (probably) have its own SignalK path variable.
+  // For example, if you have two propulsion engines, and you want the RPM of
+  // each of them to go to SignalK, you might have sk_path_portEngine =
+  // "propulsion.port.revolutions" and sk_path_starboardEngine =
+  // "propulsion.starboard.revolutions" In this example, there is only one
+  // propulsion engine, and its RPM is the only thing being reported to SignalK.
   const char* sk_path = "propulsion.main.revolutions";
-
 
   // The "Configuration path" is combined with "/config" to formulate a URL
   // used by the RESTful API for retrieving or setting configuration data.
@@ -46,40 +44,43 @@ ReactESP app([]() {
   // you will need to specify a configuration path.
   // As with the SignalK path, if you have multiple configurable sensors
   // connected to the microcontroller, you will have a configuration path
-  // for each of them, such as config_path_portEngine = "/sensors/portEngine/rpm"
-  // and config_path_starboardEngine = "/sensor/starboardEngine/rpm".
+  // for each of them, such as config_path_portEngine =
+  // "/sensors/portEngine/rpm" and config_path_starboardEngine =
+  // "/sensor/starboardEngine/rpm".
   const char* config_path = "/sensors/engine_rpm";
 
-  // These two are necessary until a method is created to synthesize them. Everything
-  // after "/sensors" in each of these ("/engine_rpm/calibrate" and "/engine_rpm/sk")
-  // is simply a label to display what you're configuring in the Configuration UI. 
+  // These two are necessary until a method is created to synthesize them.
+  // Everything after "/sensors" in each of these ("/engine_rpm/calibrate" and
+  // "/engine_rpm/sk") is simply a label to display what you're configuring in
+  // the Configuration UI.
   const char* config_path_calibrate = "/sensors/engine_rpm/calibrate";
   const char* config_path_skpath = "/sensors/engine_rpm/sk";
 
-
-//////////
-// connect a RPM meter. A DigitalInputCounter implements an interrupt
-// to count pulses and reports the readings every read_delay ms
-// (500 in the example). A Frequency
-// transform takes a number of pulses and converts that into
-// a frequency. The sample multiplier converts the 97 tooth
-// tach output into Hz, SK native units.
-const float multiplier = 1.0 / 97.0;
-const uint read_delay = 500;
-
+  //////////
+  // connect a RPM meter. A DigitalInputCounter implements an interrupt
+  // to count pulses and reports the readings every read_delay ms
+  // (500 in the example). A Frequency
+  // transform takes a number of pulses and converts that into
+  // a frequency. The sample multiplier converts the 97 tooth
+  // tach output into Hz, SK native units.
+  const float multiplier = 1.0 / 97.0;
+  const uint read_delay = 500;
 
   // Wire it all up by connecting the producer directly to the consumer
   // ESP8266 pins are specified as DX
   // ESP32 pins are specified as just the X in GPIOX
-  auto* pSensor = new DigitalInputCounter(D5, INPUT_PULLUP, RISING, read_delay);
+  auto* sensor = new DigitalInputCounter(D5, INPUT_PULLUP, RISING, read_delay);
 
-  pSensor->connectTo(new Frequency(multiplier, config_path_calibrate))  // connect the output of pSensor to the input of Frequency()
-        ->connectTo(new SKOutputNumber(sk_path, config_path_skpath));   // connect the output of Frequency() to a SignalK Output as a number
+  sensor
+      ->connectTo(new Frequency(
+          multiplier, config_path_calibrate))  // connect the output of sensor
+                                               // to the input of Frequency()
+      ->connectTo(new SKOutputNumber(
+          sk_path, config_path_skpath));  // connect the output of Frequency()
+                                          // to a SignalK Output as a number
 
-
-  // Start the SensESP application running. Because of everything that's been set up above,
-  // it constantly monitors the interrupt pin, and every read_delay ms, it sends the 
-  // calculated frequency to SignalK.
+  // Start the SensESP application running. Because of everything that's been
+  // set up above, it constantly monitors the interrupt pin, and every
+  // read_delay ms, it sends the calculated frequency to SignalK.
   sensesp_app->enable();
 });
-

--- a/examples/sht31_example.cpp
+++ b/examples/sht31_example.cpp
@@ -7,45 +7,45 @@
 #define USE_LIB_WEBSOCKET true
 
 #include "sensesp_app.h"
-#include "signalk/signalk_output.h"
 #include "sensors/sht31.h"
+#include "signalk/signalk_output.h"
 
-ReactESP app([] () {
-  #ifndef SERIAL_DEBUG_DISABLED
+ReactESP app([]() {
+#ifndef SERIAL_DEBUG_DISABLED
   Serial.begin(115200);
 
   // A small delay and one debugI() are required so that
   // the serial output displays everything
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
+#endif
   delay(100);
   debugI("Serial debug enabled");
 
-  // Create the SensESPApp with whatever "standard sensors" you want: noStdSensors, allStdSensors, or uptimeOnly.
-  // The default is allStdSensors.
-  sensesp_app = new SensESPApp(noStdSensors);
+  sensesp_app = new SensESPApp();
 
   // Create a SHT31, which represents the physical sensor.
   // 0x44 is the default address. Some chips use 0x45, which is shown here.
-  auto* pSHT31 = new SHT31(0x45);
-
+  auto* sht31 = new SHT31(0x45);
 
   // Define the read_delay you're going to use. The default is 500 ms.
   const uint read_delay = 1000;
 
-  // Create a SHT31value, which is used to read a specific value from the SHT31, and send its output
-  // to SignalK as a Number (float). This one is for the temperature reading.
-  auto* pSHT31temperature = new SHT31value(pSHT31, temperature, read_delay, "/fridge/temperature");
-      
-        pSHT31temperature->connectTo(new SKOutputNumber("environment.inside.refrigerator.temperature"));
+  // Create a SHT31value, which is used to read a specific value from the SHT31,
+  // and send its output to SignalK as a Number (float). This one is for the
+  // temperature reading.
+  auto* sht31_temperature =
+      new SHT31value(sht31, temperature, read_delay, "/fridge/temperature");
 
+  sht31_temperature->connectTo(
+      new SKOutputNumber("environment.inside.refrigerator.temperature"));
 
   // Do the same for the humidity value.
-  auto* pSHT31humidity = new SHT31value(pSHT31, humidity,  read_delay, "/fridge/humidity");
-      
-        pSHT31humidity->connectTo(new SKOutputNumber("environment.inside.refrigerator.humidity"));
+  auto* sht31_humidity =
+      new SHT31value(sht31, humidity, read_delay, "/fridge/humidity");
 
+  sht31_humidity->connectTo(
+      new SKOutputNumber("environment.inside.refrigerator.humidity"));
 
   sensesp_app->enable();
 });

--- a/examples/temperature_sender.cpp
+++ b/examples/temperature_sender.cpp
@@ -1,152 +1,167 @@
 #include <Arduino.h>
 
 #include "sensesp_app.h"
-#include "transforms/linear.h"
+#include "sensesp_app_builder.h"
 #include "sensors/analog_input.h"
-
-#include "transforms/analogvoltage.h"
-#include "transforms/voltagedivider.h"
-#include "transforms/curveinterpolator.h"
 #include "signalk/signalk_output.h"
+#include "transforms/analogvoltage.h"
+#include "transforms/curveinterpolator.h"
+#include "transforms/linear.h"
+#include "transforms/voltagedivider.h"
 
 /*
-  Illustrates a custom transform that takes a resistance value in ohms and returns the estimated
-  temperature in Kelvin. Sample data in this example were taken from a Westerbeke generator
-  temperature sender and gauge.
-  Note that you will never instantiate CurveInterpolator in your own SensESP
-  project - you will always need to create a descendant class of it, like
-  TemperatureInterpreter in this example. The constructor needs to do only two things:
-  call clearSamples(), then call addSample() at least twice. (This class can't function
-  without at least two samples.) You can call addSample() as many times as you like,
-  and the more samples you have, the more accurately this transform will emulate the
-  analog sensor. Note, however, that since all transforms inherit from class
-  Configurable, you can make its data configurable in the Config UI, and that means
-  not only that you can edit (at runtime) whatever samples you add in the constructor,
-  but also that you can add more samples at runtime.
-  
-  One of your samples should be at the lowest value for the input,and one should be at
-  the highest value, so the input to CurveInterpolator will always be between two values.
-   
-  This example is a bit complex because of the need for the VoltageDivider2 transform,
-  but that also makes it an excellent "advanced" example. 
+  Illustrates a custom transform that takes a resistance value in ohms and
+  returns the estimated temperature in Kelvin. Sample data in this example were
+  taken from a Westerbeke generator temperature sender and gauge. Note that you
+  will never instantiate CurveInterpolator in your own SensESP project - you
+  will always need to create a descendant class of it, like
+  TemperatureInterpreter in this example. The constructor needs to do only two
+  things: call clearSamples(), then call addSample() at least twice. (This class
+  can't function without at least two samples.) You can call addSample() as many
+  times as you like, and the more samples you have, the more accurately this
+  transform will emulate the analog sensor. Note, however, that since all
+  transforms inherit from class Configurable, you can make its data configurable
+  in the Config UI, and that means not only that you can edit (at runtime)
+  whatever samples you add in the constructor, but also that you can add more
+  samples at runtime.
+
+  One of your samples should be at the lowest value for the input,and one should
+  be at the highest value, so the input to CurveInterpolator will always be
+  between two values.
+
+  This example is a bit complex because of the need for the VoltageDivider2
+  transform, but that also makes it an excellent "advanced" example.
 */
 
 class TemperatureInterpreter : public CurveInterpolator {
-
-    public:
-        TemperatureInterpreter(String config_path="") :
-           CurveInterpolator(NULL, config_path ) {
-
-          // Populate a lookup table tp translate the ohm values returned by
-          // our temperature sender to degrees Kelvin
-          clearSamples();
-          // addSample(CurveInterpolator::Sample(knownOhmValue, knownKelvin));
-          addSample(CurveInterpolator::Sample(0, 418.9));
-          addSample(CurveInterpolator::Sample(5, 414.71));
-          addSample(CurveInterpolator::Sample(36, 388.71));
-          addSample(CurveInterpolator::Sample(56, 371.93));
-          addSample(CurveInterpolator::Sample(59, 366.48));
-          addSample(CurveInterpolator::Sample(81, 355.37));
-          addSample(CurveInterpolator::Sample(112, 344.26));
-          addSample(CurveInterpolator::Sample(240, 322.04));
-          addSample(CurveInterpolator::Sample(550, 255.37));
-          addSample(CurveInterpolator::Sample(10000, 237.6));
-
-        }
+ public:
+  TemperatureInterpreter(String config_path = "")
+      : CurveInterpolator(NULL, config_path) {
+    // Populate a lookup table tp translate the ohm values returned by
+    // our temperature sender to degrees Kelvin
+    clearSamples();
+    // addSample(CurveInterpolator::Sample(knownOhmValue, knownKelvin));
+    addSample(CurveInterpolator::Sample(0, 418.9));
+    addSample(CurveInterpolator::Sample(5, 414.71));
+    addSample(CurveInterpolator::Sample(36, 388.71));
+    addSample(CurveInterpolator::Sample(56, 371.93));
+    addSample(CurveInterpolator::Sample(59, 366.48));
+    addSample(CurveInterpolator::Sample(81, 355.37));
+    addSample(CurveInterpolator::Sample(112, 344.26));
+    addSample(CurveInterpolator::Sample(240, 322.04));
+    addSample(CurveInterpolator::Sample(550, 255.37));
+    addSample(CurveInterpolator::Sample(10000, 237.6));
+  }
 };
 
 // SensESP builds upon the ReactESP framework. Every ReactESP application
 // defines an "app" object vs defining a "main()" method.
-ReactESP app([] () {
+ReactESP app([]() {
 
-  // Some initialization boilerplate when in debug mode...
-  #ifndef SERIAL_DEBUG_DISABLED
+// Some initialization boilerplate when in debug mode...
+#ifndef SERIAL_DEBUG_DISABLED
   Serial.begin(115200);
 
   // A small delay and one debugI() are required so that
   // the serial output displays everything
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
+#endif
   delay(100);
   debugI("Serial debug enabled");
 
- // Create the global SensESPApp() object. If you add the line ->set_wifi("your ssid", "your password") you can specify
-  // the wifi parameters in the builder. If you do not do that, the SensESP device wifi configuration hotspot will appear and you can use a web 
-  // browser pointed to 192.168.4.1 to configure the wifi parameters. 
-  // You can use NONE, UPTIME, FREQUENCY, FREE_MEMORY, WIFI_SIGNAL or ALL instead if IP_ADDRESS in set_standard_sensors().
+  // Create the global SensESPApp() object. If you add the line ->set_wifi("your
+  // ssid", "your password") you can specify the wifi parameters in the builder.
+  // If you do not do that, the SensESP device wifi configuration hotspot will
+  // appear and you can use a web browser pointed to 192.168.4.1 to configure
+  // the wifi parameters. You can use NONE, UPTIME, FREQUENCY, FREE_MEMORY,
+  // WIFI_SIGNAL or ALL instead if IP_ADDRESS in set_standard_sensors().
+
+  // Create a builder object
+  SensESPAppBuilder builder;
 
   sensesp_app = builder.set_hostname("your device name")
-                ->set_standard_sensors(IP_ADDRESS)
-                ->set_sk_server("your server address", your_server_port) 
-                ->get_app();
-  
-  // The "SignalK path" identifies the output of this sensor to the SignalK network.
+                    ->set_standard_sensors("192.168.1.2")
+                    ->set_sk_server("your server address", 80)
+                    ->get_app();
+
+  // The "SignalK path" identifies the output of this sensor to the SignalK
+  // network.
 
   const char* sk_path = "electrical.generator.engine.water.temp";
-  
+
   /*
-  Connecting a physical temperature sender to the MCU involves using a "voltage divider" circuit. 
-  A resistor (R1) is connected to the voltage output of the board (3.3v or 5v, specified in Vin)
-  to an intersection of two wires. One wire connects to the AnalogInput pin of the MCU, and the
-  other wire connects to the sending unit doing the measurement. The sender is itself a variable
-  resistor that is then connected to ground, forming the "R2" of a voltage divider circuit.
-  The transform "VoltageDividerR2" takes a known voltage in (3.3 in this example), a known value
-  for resistor R1 (51 ohms in this example), and based on the voltage read from AnalogInput,
-  computes the resistance of the sender (R2), in ohms.
-   
-  One important point: the value of the output from the AnalogIn pin is not in volts, as 
-  implied above. It's a value in the range 0 - 1023, and it represents the voltage in the range
-  0.0V - 3.3V. But we need to send an actual voltage to VoltageDivider2(), which means we 
-  need to first convert the value of AnalogInput to volts, which is done with AnalogVoltage().
-   
-  Although complex, this example pefectly illustrates the normal "chain" for getting a value
-  from a sensor all the way to the SignalK server:
+  Connecting a physical temperature sender to the MCU involves using a "voltage
+  divider" circuit. A resistor (R1) is connected to the voltage output of the
+  board (3.3v or 5v, specified in Vin) to an intersection of two wires. One wire
+  connects to the AnalogInput pin of the MCU, and the other wire connects to the
+  sending unit doing the measurement. The sender is itself a variable resistor
+  that is then connected to ground, forming the "R2" of a voltage divider
+  circuit. The transform "VoltageDividerR2" takes a known voltage in (3.3 in
+  this example), a known value for resistor R1 (51 ohms in this example), and
+  based on the voltage read from AnalogInput, computes the resistance of the
+  sender (R2), in ohms.
+
+  One important point: the value of the output from the AnalogIn pin is not in
+  volts, as implied above. It's a value in the range 0 - 1023, and it represents
+  the voltage in the range 0.0V - 3.3V. But we need to send an actual voltage to
+  VoltageDivider2(), which means we need to first convert the value of
+  AnalogInput to volts, which is done with AnalogVoltage().
+
+  Although complex, this example pefectly illustrates the normal "chain" for
+  getting a value from a sensor all the way to the SignalK server:
   - A real-world sensor sends its output to an input pin on the microcontroller
-  - The value read from that pin gives us our actual input to the program. In this example,
-    that's an AnalogInput().
-  - That input is then sent through one or more transforms so that the end result is the value
-    we want to send to SignalK. In this example, the transforms are AnalogVoltage(), then
-    VoltageDivider2(), then TemperatureInterpreter(), then Linear().
-  - Finally, the value we want is sent to the final "consumer", in this case SKOutputNumber().
-  
-  Notice the Linear() transport in the chain below. It's there in case you need to calibrate 
-  the final output of your sensor, after it's gone through all the other transforms. For example,
-  if you know your temperature sender always reports a temp that's about 5 degrees Fahrenheit
-  too cold, you can calibrate its output here. A difference of 5 degrees F is a difference of
-  2.78 degrees Kelvin, and all temps are sent to SignalK in Kelvin. So the Linear() below 
-  would be Linear(1.0, 2.78, "gen/temp/calibrate") - 1.0 is the multiplier (so it does nothing),
-  and 2.78 is the offset, so it's added to the output of TemperatureInterpreter() just before
-  the value is sent to SignalK. ("gen/temp/calibrate" tells the Config UI how to display it.)
+  - The value read from that pin gives us our actual input to the program. In
+  this example, that's an AnalogInput().
+  - That input is then sent through one or more transforms so that the end
+  result is the value we want to send to SignalK. In this example, the
+  transforms are AnalogVoltage(), then VoltageDivider2(), then
+  TemperatureInterpreter(), then Linear().
+  - Finally, the value we want is sent to the final "consumer", in this case
+  SKOutputNumber().
+
+  Notice the Linear() transport in the chain below. It's there in case you need
+  to calibrate the final output of your sensor, after it's gone through all the
+  other transforms. For example, if you know your temperature sender always
+  reports a temp that's about 5 degrees Fahrenheit too cold, you can calibrate
+  its output here. A difference of 5 degrees F is a difference of 2.78 degrees
+  Kelvin, and all temps are sent to SignalK in Kelvin. So the Linear() below
+  would be Linear(1.0, 2.78, "gen/temp/calibrate") - 1.0 is the multiplier (so
+  it does nothing), and 2.78 is the offset, so it's added to the output of
+  TemperatureInterpreter() just before the value is sent to SignalK.
+  ("gen/temp/calibrate" tells the Config UI how to display it.)
   */
 
-  // Voltage sent into the voltage divider circuit that includes the analog sender
-  const float Vin = 3.3; 
-  // The resistance, in ohms, of the fixed resistor (R1) in the voltage divider circuit
-  const float R1 = 51.0; 
+  // Voltage sent into the voltage divider circuit that includes the analog
+  // sender
+  const float Vin = 3.3;
+  // The resistance, in ohms, of the fixed resistor (R1) in the voltage divider
+  // circuit
+  const float R1 = 51.0;
 
-  // An AnalogInput gets the value from the microcontroller's AnalogIn pin, which is
-  // a value from 0 to 1023.
-  // The AnalogIn pin on ESP8266 is always A0, but ESP32 has many pins that can be
-  // used for AnalogIn, and they're expressed here as the XX in GPIOXX.
-  auto* pAnalogInput = new AnalogInput(A0);
+  // An AnalogInput gets the value from the microcontroller's AnalogIn pin,
+  // which is a value from 0 to 1023. The AnalogIn pin on ESP8266 is always A0,
+  // but ESP32 has many pins that can be used for AnalogIn, and they're
+  // expressed here as the XX in GPIOXX.
+  auto* analog_input = new AnalogInput(A0);
 
-  /* Translating the number returned by AnalogInput into a temperature, and sending it to SignalK,
-     requires several transforms. Wire them up in sequence:
+  /* Translating the number returned by AnalogInput into a temperature, and
+     sending it to SignalK, requires several transforms. Wire them up in
+     sequence:
      - convert the value from the AnalogIn pin into an AnalogVoltage()
      - convert voltage into ohms with VoltageDividerR2()
-     - find the Kelvin value for the given ohms value with TemperatureInterpreter()
+     - find the Kelvin value for the given ohms value with
+     TemperatureInterpreter()
      - use Linear() in case you want to calibrate the output at runtime
      - send calibrated Kelvin value to SignalK with SKOutputNumber()
   */
-  pAnalogInput->connectTo(new AnalogVoltage()) -> 
-                connectTo(new VoltageDividerR2(R1, Vin, "/gen/temp/sender")) -> 
-                connectTo(new TemperatureInterpreter("/gen/temp/curve")) -> 
-                connectTo(new Linear(1.0, 0.0, "/gen/temp/calibrate")) -> 
-                connectTo(new SKOutputNumber(sk_path, "/gen/temp/sk")); 
+  analog_input->connectTo(new AnalogVoltage())
+      ->connectTo(new VoltageDividerR2(R1, Vin, "/gen/temp/sender"))
+      ->connectTo(new TemperatureInterpreter("/gen/temp/curve"))
+      ->connectTo(new Linear(1.0, 0.0, "/gen/temp/calibrate"))
+      ->connectTo(new SKOutputNumber(sk_path, "/gen/temp/sk"));
 
-
-  // Start the SensESP application running, which simply activates everything that's been set up above
+  // Start the SensESP application running, which simply activates everything
+  // that's been set up above
   sensesp_app->enable();
-
 });

--- a/examples/thermocouple_temperature_sensor/max31856TC_example.cpp
+++ b/examples/thermocouple_temperature_sensor/max31856TC_example.cpp
@@ -1,10 +1,10 @@
+#include <Adafruit_MAX31856.h>
 #include <Arduino.h>
 
 #include "sensesp_app.h"
-#include "transforms/linear.h"
-#include "signalk/signalk_output.h"
 #include "sensors/max31856TC_input.h"
-#include <Adafruit_MAX31856.h>
+#include "signalk/signalk_output.h"
+#include "transforms/linear.h"
 
 #define SPI_CS_PIN 15
 #define SPI_MOSI_PIN 13
@@ -14,30 +14,27 @@
 
 // SensESP builds upon the ReactESP framework. Every ReactESP application
 // defines an "app" object vs defining a "main()" method.
-ReactESP app([] () {
+ReactESP app([]() {
 
-  // Some initialization boilerplate when in debug mode...
-  #ifndef SERIAL_DEBUG_DISABLED
+// Some initialization boilerplate when in debug mode...
+#ifndef SERIAL_DEBUG_DISABLED
   Serial.begin(115200);
 
   // A small arbitrary delay is required to let the
   // serial port catch up
   delay(100);
   Debug.setSerialEnabled(true);
-  #endif
-  
-  debugI("\nSerial debug enabled\n");
+#endif
 
+  debugI("\nSerial debug enabled\n");
 
   // Create the global SensESPApp() object.
   sensesp_app = new SensESPApp();
-
 
   // The "SignalK path" identifies this sensor to the SignalK server. Leaving
   // this blank would indicate this particular sensor (or transform) does not
   // broadcast SignalK data.
   const char* sk_path = "propulsion.Main_Engine.temperature";
-
 
   // The "Configuration path" is combined with "/config" to formulate a URL
   // used by the RESTful API for retrieving or setting configuration data.
@@ -47,27 +44,32 @@ ReactESP app([] () {
   // that indicates this sensor or transform does not have any
   // configuration to save, or that you're not interested in doing
   // run-time configuration.
-  
-  const char* temperature_in_config_path = "/propulsion/Main_Engine/temperature_in/read_delay";
-  //const char* linear_config_path = "/propulsion/Main_Engine/temperature_in/linear";
 
+  const char* temperature_in_config_path =
+      "/propulsion/Main_Engine/temperature_in/read_delay";
+  // const char* linear_config_path =
+  // "/propulsion/Main_Engine/temperature_in/linear";
 
-  // Create a sensor that is the source of our data, that will be read every 1000 ms. 
+  // Create a sensor that is the source of our data, that will be read every
+  // 1000 ms.
   const uint readDelay = 1000;
-  //tcType:  MAX31856_TCTYPE_K;   // other types can be B, E, J, N, R, S, T
-  auto* pMAX31856TC = new MAX31856TC(SPI_CS_PIN, SPI_MOSI_PIN, SPI_MISO_PIN, SPI_CLK_PIN, DRDY_PIN, MAX31856_TCTYPE_K, readDelay, temperature_in_config_path);
+  // tcType:  MAX31856_TCTYPE_K;   // other types can be B, E, J, N, R, S, T
+  auto* max31856tc = new MAX31856TC(SPI_CS_PIN, SPI_MOSI_PIN, SPI_MISO_PIN,
+                                    SPI_CLK_PIN, DRDY_PIN, MAX31856_TCTYPE_K,
+                                    readDelay, temperature_in_config_path);
 
-  // A Linear transform takes its input, multiplies it by the multiplier, then adds the offset,
-  // to calculate its output. The MAX31856TC produces temperatures in degrees Celcius. We need to change
-  // them to Kelvin for compatibility with SignalK.
- 
+  // A Linear transform takes its input, multiplies it by the multiplier, then
+  // adds the offset, to calculate its output. The MAX31856TC produces
+  // temperatures in degrees Celcius. We need to change them to Kelvin for
+  // compatibility with SignalK.
+
   const float multiplier = 1.0;
   const float offset = 273.16;
 
   // Wire up the output of the analog input to the Linear transform,
   // and then output the results to the SignalK server.
-  pMAX31856TC -> connectTo(new Linear(multiplier, offset, ""))
-               -> connectTo(new SKOutputNumber(sk_path));
+  max31856tc->connectTo(new Linear(multiplier, offset, ""))
+      ->connectTo(new SKOutputNumber(sk_path));
 
   // Start the SensESP application running
   sensesp_app->enable();

--- a/examples/ultrasonic_level_sensor/ultrasonic_DVP_example.cpp
+++ b/examples/ultrasonic_level_sensor/ultrasonic_DVP_example.cpp
@@ -54,7 +54,7 @@ ReactESP app([]() {
   // The sensor is mounted at the top of a water tank that is 25 cm deep.
   uint read_delay = 1000;
 
-  auto* pUltrasonicSens = new UltrasonicSens(TRIGGER_PIN, INPUT_PIN, read_delay, ultrasonic_in_config_path);
+  auto* ultrasonic_sensor = new UltrasonicSens(TRIGGER_PIN, INPUT_PIN, read_delay, ultrasonic_in_config_path);
 
   // A Linear transform takes its input, multiplies it by the multiplier, then adds the offset,
   // to calculate its output. In this example, we want to see the final output presented
@@ -68,7 +68,7 @@ ReactESP app([]() {
 
   // Wire up the output of the analog input to the Linear transform,
   // and then output the results to the SignalK server.
-  pUltrasonicSens->connectTo(new Linear(multiplier, offset, linear_config_path))
+  ultrasonic_sensor->connectTo(new Linear(multiplier, offset, linear_config_path))
       ->connectTo(new MovingAverage(10, scale, ultrasonic_ave_samples))
       ->connectTo(new SKOutputNumber(sk_path));
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,11 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+; IMPORTANT: This file defines the environment for building SensESP
+; itself when doing feature development. It must NOT be used as a template
+; for projects merely based on SensESP. For that purpose, use the file
+; examples/platformio.ini instead.
+
 [platformio]
 ;set default_envs to whichever board(s) you use. Build/Run/etc processes those envs
 default_envs = 
@@ -43,29 +48,27 @@ lib_deps =
    EspSoftwareSerial
    https://github.com/JoaoLopesF/RemoteDebug.git#0b5a9c1a49fd2ade0e3cadc3a3707781e819359a
 
-[env:d1_mini]
+[espressif8266_base]
+;this section has config items common to all ESP8266 boards
 platform = espressif8266
-board = d1_mini
-board_build.f_cpu = 160000000L
-upload_resetmethod = nodemcu
 build_flags =
    -Wl,-Teagle.flash.4m1m.ld
    -Wall
    -Wno-reorder
-upload_speed = 460800  
-; un-comment the following if you have extra actions contained in script 
 extra_scripts = extra_script.py
 
+[env:d1_mini]
+extends = espressif8266_base
+board = d1_mini
+board_build.f_cpu = 160000000L
+upload_resetmethod = nodemcu
+upload_speed = 460800  
+
 [espressif32_base]
-;this section has config items common to the espressif32 platform
+;this section has config items common to all ESP32 boards
 platform = espressif32
-; Un-comment the following if you get an error about [-Werror=reorder]
 build_unflags = -Werror=reorder
-; Un-comment the following if you get an error about
-; insufficient memory after compiling and linking:
-board_build.partitions = no_ota.csv
-; Un-comment the following if you want more 
-; details about runtime errors:
+board_build.partitions = min_spiffs.csv
 monitor_filters = esp32_exception_decoder
 
 [env:esp32dev]
@@ -76,4 +79,3 @@ board = esp32dev
 extends = espressif32_base
 board = esp-wrover-kit
 upload_speed = 460800
-


### PR DESCRIPTION
Provide a sample `platformio.ini` file in `examples`. Also reformat and standardize variable naming for all examples.