### PR TITLE
platformio.ini should no longer peg ArduinoJson to v5

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -33,7 +33,7 @@ lib_deps =
    ESP8266WiFi
    ESP8266mDNS
    ESPAsyncWifiManager
-   ArduinoJson@^5.0.0
+   ArduinoJson
    WebSockets
    OneWire
    DallasTemperature


### PR DESCRIPTION
This is required to build SensESP locally.