### PR TITLE
Example platformio.ini environments

### DIFF
--- a/examples/platformio.ini
+++ b/examples/platformio.ini
@@ -41,6 +41,10 @@ board = d1_mini
 board_build.f_cpu = 160000000L
 upload_resetmethod = nodemcu
 upload_speed = 460800  
+; uncomment and change these if PlatformIO can't auto-detect
+; the ports
+;upload_port = /dev/tty.SLAB_USBtoUART
+;monitor_port = /dev/tty.SLAB_USBtoUART
 
 [espressif32_base]
 ;this section has config items common to all ESP32 boards
@@ -52,6 +56,13 @@ monitor_filters = esp32_exception_decoder
 [env:esp32dev]
 extends = espressif32_base
 board = esp32dev
+; Verify that this is the correct pin number for your board!
+build_flags = 
+   -D LED_BUILTIN=2
+; uncomment and change these if PlatformIO can't auto-detect
+; the ports
+;upload_port = /dev/tty.SLAB_USBtoUART
+;monitor_port = /dev/tty.SLAB_USBtoUART
 
 [env:esp-wrover-kit]
 extends = espressif32_base

--- a/examples/platformio.ini
+++ b/examples/platformio.ini
@@ -16,7 +16,7 @@
 [platformio]
 ;set default_envs to whichever board(s) you use. Build/Run/etc processes those envs
 default_envs = 
-   esp32dev
+   ;esp32dev
    d1_mini
 ;   esp-wrover-kit
 


### PR DESCRIPTION
I had accidentally enabled more than one environment in the example platformio.ini file, which probably was counterproductive. Fixed now. Also added commented out sections for setting upload ports and the builtin led in ESP32.