### PR TITLE
ESP32AnalogInput addition

### DIFF
--- a/examples/esp32analog_input.cpp
+++ b/examples/esp32analog_input.cpp
@@ -1,0 +1,56 @@
+#include <Arduino.h>
+
+#include "sensesp_app.h"
+#include "sensesp_app_builder.h"
+
+#include "signalk/signalk_output.h"
+
+#include "sensors/esp32_analog_input.h"
+
+ReactESP app([] () {
+
+  // Some initialization boilerplate when in debug mode...
+  #ifndef SERIAL_DEBUG_DISABLED
+  Serial.begin(115200);
+
+  // A small delay and one debugI() are required so that
+  // the serial output displays everything
+  delay(100);
+  Debug.setSerialEnabled(true);
+  #endif
+  delay(100);
+  debugI("Serial debug enabled");
+
+  // Create the global SensESPApp() object. 
+  // If you add the line ->set_wifi("your ssid", "your password") you can specify
+  // the wifi parameters in the builder. If you do not do that, the SensESP 
+  // device wifi configuration hotspot will appear and you can use a web 
+  // browser pointed to 192.168.4.1 to configure the wifi parameters. 
+  // You can use NONE, UPTIME, FREQUENCY, FREE_MEMORY, WIFI_SIGNAL or ALL 
+  // instead of IP_ADDRESS in set_standard_sensors().
+
+  // Create a builder object
+  SensESPAppBuilder builder;
+
+  sensesp_app = builder.set_hostname("test_unit")
+                ->set_wifi("MysticBlue", "passwors1234")
+                //->set_standard_sensors(IP_ADDRESS)
+                ->set_standard_sensors(NONE)
+                ->set_sk_server("192.168.1.141", 3000) 
+                ->get_app();
+  
+// In the test setup the input voltage was 0.651 in which case all of the options below all 
+// produced a similar ouput although the difference in resolution between the first and 
+// last statement is clear - as expected.
+
+  auto* pAnalogInput = new ESP32AnalogInput(34, ADC_WIDTH_BIT_12, ADC_ATTEN_DB_0, 1000);
+//  auto* pAnalogInput = new ESP32AnalogInput(34, ADC_WIDTH_BIT_9, ADC_ATTEN_DB_0, 1000);
+//  auto* pAnalogInput = new ESP32AnalogInput(34, ADC_WIDTH_BIT_12, ADC_ATTEN_DB_0, 1000);
+//  auto* pAnalogInput = new ESP32AnalogInput(34, ADC_WIDTH_BIT_9, ADC_ATTEN_DB_11, 1000);
+  
+  pAnalogInput->connectTo(new SKOutputNumber("voltage")); 
+
+
+  sensesp_app->enable();
+  
+});

--- a/src/sensors/esp32_analog_input.cpp
+++ b/src/sensors/esp32_analog_input.cpp
@@ -1,0 +1,87 @@
+#include "esp32_analog_input.h"
+
+#include "Arduino.h"
+#include "sensesp.h"
+#include <RemoteDebug.h>
+
+ESP32AnalogInput::ESP32AnalogInput(uint8_t pin, adc_bits_width_t adc_width, 
+                                   adc_atten_t adc_attenuation,
+                                   uint read_delay, String config_path)
+
+    : NumericSensor(config_path), pin{pin}, read_delay{read_delay} {
+
+  associatePin(pin, adc_width, adc_attenuation);
+  className = "ESP32AnalogInput";
+  load_configuration();
+}
+
+void ESP32AnalogInput::associatePin(int pin, adc_bits_width_t adc_width, 
+                                    adc_atten_t adc_attenuation) {
+
+  // Configure width across all channels on ADC1
+  adc1_config_width(adc_width);
+  
+  // Set channel attenuation
+  adc1_channel = (adc1_channel_t) digitalPinToAnalogChannel(pin);
+  adc1_config_channel_atten(adc1_channel, adc_attenuation);
+
+  // Characterize/calibrate the ADC
+  cal_type = esp_adc_cal_characterize(ADC_UNIT_1, adc_attenuation, 
+                                      adc_width, V_REF, &characteristics);
+  
+  if (cal_type == ESP_ADC_CAL_VAL_EFUSE_VREF) {
+      cal_type_str = "eFuse Vref";
+  } else if (cal_type == ESP_ADC_CAL_VAL_EFUSE_TP) {
+      cal_type_str = "Two Point";
+  } else {
+      cal_type_str = "Default";
+  }
+
+  // Setup the channel for calling the readVolts function
+  adc_channel = (adc_channel_t) digitalPinToAnalogChannel(pin);
+  
+  configured = true;
+}
+
+
+float ESP32AnalogInput::readVolts() {
+	uint32_t mV = 0;
+	esp_adc_cal_get_voltage(adc_channel, &characteristics, &mV); // returns mV
+	return  mV*0.001;
+}
+
+void ESP32AnalogInput::update() {
+  //output = analogRead(pin);
+  output = readVolts();
+  this->notify();
+}
+
+void ESP32AnalogInput::enable() {
+  app.onRepeat(read_delay, [this]() { this->update(); });
+}
+
+void ESP32AnalogInput::get_configuration(JsonObject& root) {
+  root["read_delay"] = read_delay;
+  root["value"] = output;
+};
+
+static const char SCHEMA[] PROGMEM = R"###({
+    "type": "object",
+    "properties": {
+        "read_delay": { "title": "Read delay", "type": "number", "description": "Number of milliseconds between each analogRead(32)" },
+        "value": { "title": "Last value", "type" : "number", "readOnly": true }
+    }
+  })###";
+
+String ESP32AnalogInput::get_config_schema() { return FPSTR(SCHEMA); }
+
+bool ESP32AnalogInput::set_configuration(const JsonObject& config) {
+  String expected[] = {"read_delay"};
+  for (auto str : expected) {
+    if (!config.containsKey(str)) {
+      return false;
+    }
+  }
+  read_delay = config["read_delay"];
+  return true;
+}

--- a/src/sensors/esp32_analog_input.h
+++ b/src/sensors/esp32_analog_input.h
@@ -1,0 +1,118 @@
+/*
+This sensor outputs a voltage unlike the AnalogInput which ouputs a raw ADC value 
+
+This sensor is required to deal with the specific setup of the ESP32 ADC's.
+
+The decisions are:
+1) Whether to use ADC1 or ADC2.
+
+This code does not support ADC2 because the use of ADC2 requires interaction with the WiFi 
+code as ADC2 is shared with the wifi driver.
+
+The pins associated with ADC1 are 32 to 39.
+
+If the internal Hall sensor is used then pins 36 & 39 should not be used. 
+Pins 36 & 39 are also associated with the power switching of ADC2 for wifi and will have 
+short "pull down" events of 89nS. While this is probably not critical to most applications 
+its advisable to only use these pins if no others are available.
+
+2) The next decision is what resolution is required for your application. The resolution 
+ranges from 9 bits (512) to 12 bits (4096). In most cases the highest resolution would be 
+applicable. The default is 12 bits.
+
+Note that the ESP32-S2 allows only a 13 bit (8192) resolution setting.
+!! NB When using the ESP32-S2 the default of 12 bits must be overidden with 
+   ADC_WIDTH_13Bit !!
+
+3) The most critical consideration is the attenuation option. The ESP32 ADC's allow the user 
+to apply an attenuator in order to increase the "full-scale range" of the input from 1.1v to
+3.9V.
+
+This obviously impacts on the resolution of the reading. For example, if your input is never 
+going to exceed 950mV then you would set for zero attenuation. The selected resolution 
+would apply to the range corresponding with the selected attenuation.
+
+If your range exceeds 950mV then you have the option to apply attenuation as per the diagram 
+below. The ability to set attenuation also may have an impact on the accuracy of your 
+readings as per this diagram:
+
+    +----------+------------+--------------------------+
+    |   SoC    | attenuation|   suggested range (mV)   |
+    +==========+============+==========================+
+    |          |  0dB       |     100 ~ 950            |
+    |          +------------+--------------------------+
+    |          |  2.5dB     |     100 ~ 1250           |
+    |   ESP32  +------------+--------------------------+
+    |          |  6dB       |     150 ~ 1750           |
+    |          +------------+--------------------------+
+    |          |  11dB      |     150 ~ 2450           |
+    +----------+------------+--------------------------+
+    |          |  0dB       |     100 ~ 800            |
+    |          +------------+--------------------------+
+    |          |  2.5dB     |     100 ~ 1100           |
+    | ESP32-S2 +------------+--------------------------+
+    |          |  6dB       |     150 ~ 1350           |
+    |          +------------+--------------------------+
+    |          |  11dB      |     150 ~ 2600           |
+    +----------+------------+--------------------------+
+
+The default is 11db attenuation (ADC_ATTEN_DB_11)
+
+The diagram above indicates that using the portion of the range indicated is highly
+recommended. The careful selection of reference/volatage divider resistors in conjunction 
+with attenuation settings can greatly improve the accuracy of the ESP32 analog input.
+
+The main difference between ESP32 and ESP8266 is the requirement to "characterise" the ADC.
+This is essentially an internal calibration of the ADC using the selected ADC resolution, 
+selected ADC attenuation and the voltage reference which can be a nominal 1100mV value, a
+single point coefficient value stored in eFuse memory or a two point reference coefficients 
+also stored in eFuse memory. A calibration call must be made prior to calling any read 
+functions.
+
+The lack of applying the characterisation of the ADC has greatly contributed to the bad rap 
+of the ESP32 for analog input.
+
+*/
+
+
+
+#ifndef _esp32_analog_input_H_
+#define _esp32_analog_input_H_
+
+#include "sensor.h"
+#include "esp_adc_cal.h"
+
+#define V_REF 1100
+
+class ESP32AnalogInput : public NumericSensor {
+
+public:
+  ESP32AnalogInput(uint8_t pin = 32, adc_bits_width_t adc_width = ADC_WIDTH_12Bit, 
+              adc_atten_t adc_attenuation = ADC_ATTEN_11db, uint read_delay = 200, 
+              String config_path = "");
+  void enable() override final;
+
+private:
+  uint8_t pin;
+  uint read_delay;
+ 	int adc_width = ADC_WIDTH_BIT_12;
+	int adc_attenuation = ADC_ATTEN_DB_11;
+	esp_adc_cal_characteristics_t characteristics;
+	adc_channel_t adc_channel ;  // for reading voltage
+  adc1_channel_t adc1_channel; // for configuring the ADC1 channel
+	boolean configured = false;
+  esp_adc_cal_value_t cal_type;  
+  String cal_type_str;
+  
+  // cal_type holds the type of calibration - Two point, eFuse Vref or default vref
+
+ 	void associatePin(int pin, adc_bits_width_t adc_width, adc_atten_t adc_attenuation);
+  float readVolts();
+
+  virtual void get_configuration(JsonObject& doc) override;
+  virtual bool set_configuration(const JsonObject& config) override;
+  virtual String get_config_schema() override;
+  void update();
+};
+
+#endif


### PR DESCRIPTION
The ESP32 requires a characterisation / calibration of the ADC before reads can be called. So accomodating it is not a matter of modifying the analog_voltage code.

It also has options that are not available with the ESP8266 which are correctly handled in this code.
