### PR TITLE
Specify the correct OneWire library

### DIFF
--- a/library.json
+++ b/library.json
@@ -57,7 +57,8 @@
       "name": "WebSockets"
     },
     {
-      "name": "OneWire"
+      "name": "OneWire",
+      "version": "paulstoffregen/OneWire"
     },
     {
       "name": "DallasTemperature"


### PR DESCRIPTION
This is to fix the first compiler warning identified in Issue #179.