### PR TITLE
Stop using deprecated HTTPClient::begin(String)

### DIFF
--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -227,16 +227,13 @@ void WSClient::connect() {
 
 void WSClient::test_token(const String server_address,
                           const uint16_t server_port) {
-  // Needed for HTTPClient::begin, below
-  WiFiClient client;
-  
   // FIXME: implement async HTTP client!
   HTTPClient http;
 
   String url = String("http://") + server_address + ":" + server_port +
                "/signalk/v1/api/";
   debugD("Testing token with url %s", url.c_str());
-  http.begin(client, url);
+  http.begin(wifi_client, url);
   String full_token = String("JWT ") + auth_token;
   http.addHeader("Authorization", full_token.c_str());
   int httpCode = http.GET();
@@ -286,14 +283,11 @@ void WSClient::send_access_request(const String server_address,
   String json_req = "";
   serializeJson(doc, json_req);
 
-  // Needed for HTTPClient::begin, below
-  WiFiClient client;
-  
   HTTPClient http;
 
   String url = String("http://") + server_address + ":" + server_port +
                "/signalk/v1/access/requests";
-  http.begin(client, url);
+  http.begin(wifi_client, url);
   http.addHeader("Content-Type", "application/json");
   int httpCode = http.POST(json_req);
   String payload = http.getString();
@@ -335,13 +329,10 @@ void WSClient::poll_access_request(const String server_address,
                                    const String href) {
   debugD("Polling SK Server for authentication token");
 
-  // Needed for HTTPClient::begin, below
-  WiFiClient client;
-  
   HTTPClient http;
 
   String url = String("http://") + server_address + ":" + server_port + href;
-  http.begin(client, url);
+  http.begin(wifi_client, url);
   int httpCode = http.GET();
   if (httpCode == 200 or httpCode == 202) {
     String payload = http.getString();

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -227,13 +227,16 @@ void WSClient::connect() {
 
 void WSClient::test_token(const String server_address,
                           const uint16_t server_port) {
+  // Needed for HTTPClient::begin, below
+  WiFiClient client;
+  
   // FIXME: implement async HTTP client!
   HTTPClient http;
 
   String url = String("http://") + server_address + ":" + server_port +
                "/signalk/v1/api/";
   debugD("Testing token with url %s", url.c_str());
-  http.begin(url);
+  http.begin(client, url);
   String full_token = String("JWT ") + auth_token;
   http.addHeader("Authorization", full_token.c_str());
   int httpCode = http.GET();
@@ -283,11 +286,14 @@ void WSClient::send_access_request(const String server_address,
   String json_req = "";
   serializeJson(doc, json_req);
 
+  // Needed for HTTPClient::begin, below
+  WiFiClient client;
+  
   HTTPClient http;
 
   String url = String("http://") + server_address + ":" + server_port +
                "/signalk/v1/access/requests";
-  http.begin(url);
+  http.begin(client, url);
   http.addHeader("Content-Type", "application/json");
   int httpCode = http.POST(json_req);
   String payload = http.getString();
@@ -329,10 +335,13 @@ void WSClient::poll_access_request(const String server_address,
                                    const String href) {
   debugD("Polling SK Server for authentication token");
 
+  // Needed for HTTPClient::begin, below
+  WiFiClient client;
+  
   HTTPClient http;
 
   String url = String("http://") + server_address + ":" + server_port + href;
-  http.begin(url);
+  http.begin(client, url);
   int httpCode = http.GET();
   if (httpCode == 200 or httpCode == 202) {
     String payload = http.getString();

--- a/src/net/ws_client.h
+++ b/src/net/ws_client.h
@@ -48,6 +48,7 @@ class WSClient : public Configurable {
 
   // FIXME: replace with a single connection_state enum
   ConnectionState connection_state = disconnected;
+  WiFiClient wifi_client;
   WebSocketsClient client;
   SKDelta* sk_delta;
   void connect_loop();


### PR DESCRIPTION
Discussed w/ @mairas - we're not sure what the `WiFiClient client` does, but it allows the use of the current `HTTPClient::begin()`, and gets rid of the compiler warning about using a deprecated version (Issue #179). 

Tested with ESP8266 and ESP32 - data flows all the way to the SK Server, so it seems to work as it did before.