### PR TITLE
Fix bme280 config path

### DIFF
--- a/examples/bme280_example.cpp
+++ b/examples/bme280_example.cpp
@@ -55,7 +55,7 @@ ReactESP app([]() {
 
   // Do the same for the humidity value.
   auto* bme_humidity =
-      new BME280Value(bme280, humidity, read_delay, "Outside/Humidity");
+      new BME280Value(bme280, humidity, read_delay, "/Outside/Humidity");
 
   bme_humidity->connect_to(new SKOutputNumber("environment.outside.humidity"));
 


### PR DESCRIPTION
There was a missing / in config path for humidity value.