### PR TITLE
Define SetupSerialDebug in a cpp file

### DIFF
--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -23,6 +23,17 @@
 RemoteDebug Debug;
 #endif
 
+void SetupSerialDebug(uint32_t baudrate) {
+  Serial.begin(baudrate);
+
+  // A small delay and one debugI() are required so that
+  // the serial output displays everything
+  delay(100);
+  Debug.setSerialEnabled(true);
+  delay(100);
+  debugI("Serial debug enabled");
+}
+
 SensESPApp::SensESPApp(String preset_hostname, String ssid,
                        String wifi_password, String sk_server_address,
                        uint16_t sk_server_port, StandardSensors sensors,

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -1,5 +1,5 @@
-#ifndef _app_H_
-#define _app_H_
+#ifndef _sensesp_app_H_
+#define _sensesp_app_H_
 
 // Required for RemoteDebug
 #define USE_LIB_WEBSOCKET true
@@ -32,6 +32,8 @@ enum StandardSensors {
   WIFI_SIGNAL = 0x10,
   ALL = 0x1F
 };
+
+void SetupSerialDebug(uint32_t baudrate);
 
 class SensESPApp {
  public:
@@ -94,16 +96,5 @@ class SensESPApp {
 };
 
 extern SensESPApp* sensesp_app;
-
-void SetupSerialDebug(uint32_t baudrate) {
-  Serial.begin(baudrate);
-
-  // A small delay and one debugI() are required so that
-  // the serial output displays everything
-  delay(100);
-  Debug.setSerialEnabled(true);
-  delay(100);
-  debugI("Serial debug enabled");
-}
 
 #endif


### PR DESCRIPTION
Fixed a compile error: SetupSerialDebug was defined in the .hpp file, while it should've been just declared there and defined in the .cpp. file.