### PR TITLE
Lambda Transform

### DIFF
--- a/examples/lambda_transform.cpp
+++ b/examples/lambda_transform.cpp
@@ -1,0 +1,68 @@
+#include <Arduino.h>
+
+#include "math.h"
+#include "sensesp_app.h"
+#include "sensors/analog_input.h"
+#include "signalk/signalk_output.h"
+#include "transforms/lambda_transform.h"
+
+ReactESP app([]() {
+  SetupSerialDebug(115200);
+
+  sensesp_app = new SensESPApp("sensesp-illum-example", "My WiFi SSID",
+                               "my_wifi_password", "skdev.lan", 80, NONE);
+
+  const char* sk_path = "indoor.illumination";
+  const char* analog_in_config_path = "/indoor_illumination/analog_in";
+
+  uint read_delay = 500;
+
+#ifdef ESP8266
+  uint8_t pin = A0;
+#elif defined(ESP32)
+  uint8_t pin = 32;
+#endif
+
+  float output_scale = 3.3;
+
+  // Use AnalogInput as an example sensor. Connect it e.g. to a photoresistor
+  // or a potentiometer with a voltage divider to get an illustrative test
+  // input.
+
+  auto* analog_input =
+      new AnalogInput(pin, read_delay, analog_in_config_path, output_scale);
+
+  // This is our transform function. The example is artificial; a log transform
+  // with configurable multiplier, base, and offset parameters.
+
+  auto log_function = [](float input, float multiplier, float base,
+                         float offset) -> float {
+    return multiplier * log(input) / log(base) + offset;
+  };
+
+  // This is an array of parameter information, providing the keys and
+  // descriptions required to display user-friendly values in the configuration
+  // interface.
+
+  const ParamInfo* log_lambda_param_data = new ParamInfo[3]{
+      {"multiplier", "Multiplier"}, {"base", "Base"}, {"offset", "Offset"}};
+
+  // Here we create a new LambdaTransform objects. The template parameters
+  // (four floats in this example) correspond to the following types:
+  // 1. Output type of the transform function
+  // 2. Input type of the transoform function
+  // 3. Type of parameter 1
+  // 4. Type of parameter 2
+
+  auto log_transform = new LambdaTransform<float, float, float, float>(
+      log_function, 10, 2, 100, log_lambda_arg_data, "/transforms/log");
+      log_function, 10, 2, 100, log_lambda_param_data, "/transforms/log");
+
+  // Finally, connect the analog input via the freshly-generated log_transform
+  // to an SKOutputNumber object
+
+  analog_input->connect_to(log_transform)
+      ->connect_to(new SKOutputNumber(sk_path));
+
+  sensesp_app->enable();
+});

--- a/examples/lambda_transform.cpp
+++ b/examples/lambda_transform.cpp
@@ -52,14 +52,21 @@ ReactESP app([]() {
       {"multiplier", "Multiplier"}, {"base", "Base"}, {"offset", "Offset"}};
 
   // Here we create a new LambdaTransform objects. The template parameters
-  // (four floats in this example) correspond to the following types:
+  // (five floats in this example) correspond to the following types:
+  //
   // 1. Output type of the transform function
-  // 2. Input type of the transoform function
+  // 2. Input type of the transform function
   // 3. Type of parameter 1
   // 4. Type of parameter 2
+  // 5. Type of parameter 3
+  //
+  // The function arguments are:
+  // 1. The tranform function
+  // 2-4. Default values for parameters
+  // 5. Parameter data for the web config UI
+  // 6. Configuration path for the transform
 
-  auto log_transform = new LambdaTransform<float, float, float, float>(
-      log_function, 10, 2, 100, log_lambda_arg_data, "/transforms/log");
+  auto log_transform = new LambdaTransform<float, float, float, float, float>(
       log_function, 10, 2, 100, log_lambda_param_data, "/transforms/log");
 
   // Finally, connect the analog input via the freshly-generated log_transform

--- a/examples/lambda_transform.cpp
+++ b/examples/lambda_transform.cpp
@@ -9,6 +9,9 @@
 ReactESP app([]() {
   SetupSerialDebug(115200);
 
+  // Create a new SensESPApp object. This is the direct constructor call, and
+  // an equivalent alternative to using the SensESPAppBuilder class.
+
   sensesp_app = new SensESPApp("sensesp-illum-example", "My WiFi SSID",
                                "my_wifi_password", "skdev.lan", 80, NONE);
 

--- a/examples/lambda_transform.cpp
+++ b/examples/lambda_transform.cpp
@@ -36,7 +36,8 @@ ReactESP app([]() {
       new AnalogInput(pin, read_delay, analog_in_config_path, output_scale);
 
   // This is our transform function. The example is artificial; a log transform
-  // with configurable multiplier, base, and offset parameters.
+  // with configurable multiplier, base, and offset parameters. The 
+  // final "-> float" refers to the return type of the function.
 
   auto log_function = [](float input, float multiplier, float base,
                          float offset) -> float {

--- a/src/transforms/lambda_transform.h
+++ b/src/transforms/lambda_transform.h
@@ -3,18 +3,36 @@
 
 #include "transform.h"
 
-static const char kLambdaTransformSchema[] PROGMEM = R"({
+static const char kLambdaTransformSchemaHead[] PROGMEM = R"({
     "type": "object",
     "properties": {
-      "value": { "title": "Last value", "type": "number", "readOnly": true }
+  )";
+
+static const char kLambdaTransformSchemaRow[] PROGMEM = R"(
+      "%s": { "title": "%s", "type": "%s", "readOnly": %s }
+  )";
+
+static const char kLambdaTransformSchemaTail[] PROGMEM = R"(
     }
   })";
 
+template<typename T>
+const char* get_schema_type_string(const T dummy) { return "string"; }
+
+template<>
+const char* get_schema_type_string(const int dummy) { return "number"; }
+
+template<>
+const char* get_schema_type_string(const float dummy) { return "number"; }
+
+template<>
+const char* get_schema_type_string(const String dummy) { return "string"; }
+
+template<>
+const char* get_schema_type_string(const bool dummy) { return "boolean"; }
+
 template <typename I, typename O>
 class LambdaTransform : public Transform<I, O> {
- private:
-  O (*function)(I input);
-
  public:
   LambdaTransform(O (*function)(I input), String config_path = "")
       : Transform<I, O>(config_path) {
@@ -23,11 +41,44 @@ class LambdaTransform : public Transform<I, O> {
 
   void set_input(I input, uint8_t input_channel = 0) override {
     this->output = (*function)(input);
+    Observable::notify();
   }
 
-  void get_configuration(JsonObject& doc) override {}
-  bool set_configuration(const JsonObject& config) override {}
-  String get_config_schema() override { return FPSTR(kLambdaTransformSchema); }
+  void get_configuration(JsonObject& doc) override {
+    doc["value"] = this->output;
+  }
+
+  bool set_configuration(const JsonObject& config) override { return true; }
+
+  String get_config_schema() override {
+    // FIXME: The heavy use of Strings puts a lot of faith in that class's
+    // ability to not leak or corrupt memory. Would be better to receive
+    // a character array pointer as an argument for writing the output to.
+    String output = "";
+
+    output.concat(FPSTR(kLambdaTransformSchemaHead));
+    output.concat(format_schema_row(
+        "value", "Last value", get_schema_type_string(this->output), true));
+    output.concat(FPSTR(kLambdaTransformSchemaTail));
+
+    return output;
+  }
+
+ private:
+  O (*function)(I input);
+
+  static String format_schema_row(const char key[], const char title[],
+                                  const char type[], const bool read_only) {
+    char row[100] = "";
+    const char* read_only_str = read_only ? "true" : "false";
+
+    sprintf_P(row, PSTR(kLambdaTransformSchemaRow), key, title, type,
+              read_only_str);
+
+    return String(row);
+  }
 };
+
+template <>
 
 #endif

--- a/src/transforms/lambda_transform.h
+++ b/src/transforms/lambda_transform.h
@@ -1,0 +1,33 @@
+#ifndef _lambda_transform_H_
+#define _lambda_transform_H_
+
+#include "transform.h"
+
+static const char kLambdaTransformSchema[] PROGMEM = R"({
+    "type": "object",
+    "properties": {
+      "value": { "title": "Last value", "type": "number", "readOnly": true }
+    }
+  })";
+
+template <typename I, typename O>
+class LambdaTransform : public Transform<I, O> {
+ private:
+  O (*function)(I input);
+
+ public:
+  LambdaTransform(O (*function)(I input), String config_path = "")
+      : Transform<I, O>(config_path) {
+    this->function = function;
+  }
+
+  void set_input(I input, uint8_t input_channel = 0) override {
+    this->output = (*function)(input);
+  }
+
+  void get_configuration(JsonObject& doc) override {}
+  bool set_configuration(const JsonObject& config) override {}
+  String get_config_schema() override { return FPSTR(kLambdaTransformSchema); }
+};
+
+#endif

--- a/src/transforms/lambda_transform.h
+++ b/src/transforms/lambda_transform.h
@@ -63,37 +63,37 @@ struct ParamInfo {
  * possible configuration parameters values and configuration parameter
  * metadata (key names and descriptions).
  *
- * @tparam I Transform function input value type
- * @tparam O Transform function output value type
- * @tparam T1 Transform function parameter 1 type
- * @tparam T2 Transform function parameter 2 type
- * @tparam T3 Transform function parameter 3 type
- * @tparam T4 Transform function parameter 4 type
- * @tparam T5 Transform function parameter 5 type
- * @tparam T6 Transform function parameter 6 type
+ * @tparam IN Transform function input value type
+ * @tparam OUT Transform function output value type
+ * @tparam P1 Transform function parameter 1 type
+ * @tparam P2 Transform function parameter 2 type
+ * @tparam P3 Transform function parameter 3 type
+ * @tparam P4 Transform function parameter 4 type
+ * @tparam P5 Transform function parameter 5 type
+ * @tparam P6 Transform function parameter 6 type
  * */
-template <class I, class O, class T1 = float, class T2 = float,
-          class T3 = float, class T4 = float, class T5 = float,
-          class T6 = float>
-class LambdaTransform : public Transform<I, O> {
+template <class IN, class OUT, class P1 = float, class P2 = float,
+          class P3 = float, class P4 = float, class P5 = float,
+          class P6 = float>
+class LambdaTransform : public Transform<IN, OUT> {
  public:
-  LambdaTransform(O (*function)(I input), String config_path = "")
-      : Transform<I, O>(config_path), function0{function}, num_params{0} {
+  LambdaTransform(OUT (*function)(IN input), String config_path = "")
+      : Transform<IN, OUT>(config_path), function0{function}, num_params{0} {
     this->load_configuration();
   }
 
-  LambdaTransform(O (*function)(I input), const ParamInfo* param_info,
+  LambdaTransform(OUT (*function)(IN input), const ParamInfo* param_info,
                   String config_path = "")
-      : Transform<I, O>(config_path),
+      : Transform<IN, OUT>(config_path),
         function0{function},
         num_params{0},
         param_info{param_info} {
     this->load_configuration();
   }
 
-  LambdaTransform(O (*function)(I input, T1 param1), T1 param1,
+  LambdaTransform(OUT (*function)(IN input, P1 param1), P1 param1,
                   const ParamInfo* param_info, String config_path = "")
-      : Transform<I, O>(config_path),
+      : Transform<IN, OUT>(config_path),
         function1{function},
         param1{param1},
         num_params{1},
@@ -114,10 +114,10 @@ class LambdaTransform : public Transform<I, O> {
    * @param param_info Keys and Descriptions of each configuration parameter
    * @param config_path Configuration path for the transform
    **/
-  LambdaTransform(O (*function)(I input, T1 param1, T2 param2), T1 param1,
-                  T2 param2, const ParamInfo* param_info,
+  LambdaTransform(OUT (*function)(IN input, P1 param1, P2 param2), P1 param1,
+                  P2 param2, const ParamInfo* param_info,
                   String config_path = "")
-      : Transform<I, O>(config_path),
+      : Transform<IN, OUT>(config_path),
         function2{function},
         param1{param1},
         param2{param2},
@@ -126,10 +126,10 @@ class LambdaTransform : public Transform<I, O> {
     this->load_configuration();
   }
 
-  LambdaTransform(O (*function)(I input, T1 param1, T2 param2, T3 param3),
-                  T1 param1, T2 param2, T3 param3, const ParamInfo* param_info,
+  LambdaTransform(OUT (*function)(IN input, P1 param1, P2 param2, P3 param3),
+                  P1 param1, P2 param2, P3 param3, const ParamInfo* param_info,
                   String config_path = "")
-      : Transform<I, O>(config_path),
+      : Transform<IN, OUT>(config_path),
         function3{function},
         param1{param1},
         param2{param2},
@@ -139,11 +139,11 @@ class LambdaTransform : public Transform<I, O> {
     this->load_configuration();
   }
 
-  LambdaTransform(O (*function)(I input, T1 param1, T2 param2, T3 param3,
-                                T4 param4),
-                  T1 param1, T2 param2, T3 param3, T4 param4,
+  LambdaTransform(OUT (*function)(IN input, P1 param1, P2 param2, P3 param3,
+                                P4 param4),
+                  P1 param1, P2 param2, P3 param3, P4 param4,
                   const ParamInfo* param_info, String config_path = "")
-      : Transform<I, O>(config_path),
+      : Transform<IN, OUT>(config_path),
         function4{function},
         param1{param1},
         param2{param2},
@@ -154,11 +154,11 @@ class LambdaTransform : public Transform<I, O> {
     this->load_configuration();
   }
 
-  LambdaTransform(O (*function)(I input, T1 param1, T2 param2, T3 param3,
-                                T4 param4, T5 param5),
-                  T1 param1, T2 param2, T3 param3, T4 param4, T5 param5,
+  LambdaTransform(OUT (*function)(IN input, P1 param1, P2 param2, P3 param3,
+                                P4 param4, P5 param5),
+                  P1 param1, P2 param2, P3 param3, P4 param4, P5 param5,
                   const ParamInfo* param_info, String config_path = "")
-      : Transform<I, O>(config_path),
+      : Transform<IN, OUT>(config_path),
         function4{function},
         param1{param1},
         param2{param2},
@@ -170,12 +170,12 @@ class LambdaTransform : public Transform<I, O> {
     this->load_configuration();
   }
 
-  LambdaTransform(O (*function)(I input, T1 param1, T2 param2, T3 param3,
-                                T4 param4, T5 param5, T6 param6),
-                  T1 param1, T2 param2, T3 param3, T4 param4, T5 param5,
-                  T6 param6, const ParamInfo* param_info,
+  LambdaTransform(OUT (*function)(IN input, P1 param1, P2 param2, P3 param3,
+                                P4 param4, P5 param5, P6 param6),
+                  P1 param1, P2 param2, P3 param3, P4 param4, P5 param5,
+                  P6 param6, const ParamInfo* param_info,
                   String config_path = "")
-      : Transform<I, O>(config_path),
+      : Transform<IN, OUT>(config_path),
         function4{function},
         param1{param1},
         param2{param2},
@@ -188,7 +188,7 @@ class LambdaTransform : public Transform<I, O> {
     this->load_configuration();
   }
 
-  void set_input(I input, uint8_t input_channel = 0) override {
+  void set_input(IN input, uint8_t input_channel = 0) override {
     switch (num_params) {
       case 0:
         this->output = (*function0)(input);
@@ -327,24 +327,24 @@ class LambdaTransform : public Transform<I, O> {
   }
 
  private:
-  T1 param1;
-  T2 param2;
-  T3 param3;
-  T4 param4;
-  T5 param5;
-  T6 param6;
+  P1 param1;
+  P2 param2;
+  P3 param3;
+  P4 param4;
+  P5 param5;
+  P6 param6;
   int num_params;
   const ParamInfo* param_info;
 
-  O (*function0)(I input);
-  O (*function1)(I input, T1 param1);
-  O (*function2)(I input, T1 param1, T2 param2);
-  O (*function3)(I input, T1 param1, T2 param2, T3 param3);
-  O (*function4)(I input, T1 param1, T2 param2, T3 param3, T4 param4);
-  O(*function5)
-  (I input, T1 param1, T2 param2, T3 param3, T4 param4, T5 param5);
-  O(*function6)
-  (I input, T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6);
+  OUT (*function0)(IN input);
+  OUT (*function1)(IN input, P1 param1);
+  OUT (*function2)(IN input, P1 param1, P2 param2);
+  OUT (*function3)(IN input, P1 param1, P2 param2, P3 param3);
+  OUT (*function4)(IN input, P1 param1, P2 param2, P3 param3, P4 param4);
+  OUT(*function5)
+  (IN input, P1 param1, P2 param2, P3 param3, P4 param4, P5 param5);
+  OUT(*function6)
+  (IN input, P1 param1, P2 param2, P3 param3, P4 param4, P5 param5, P6 param6);
 
   static String format_schema_row(const char key[], const char title[],
                                   const char type[], const bool read_only) {

--- a/src/transforms/lambda_transform.h
+++ b/src/transforms/lambda_transform.h
@@ -3,52 +3,272 @@
 
 #include "transform.h"
 
+// template snippets for configuration schema
+
 static const char kLambdaTransformSchemaHead[] PROGMEM = R"({
     "type": "object",
     "properties": {
-  )";
-
-static const char kLambdaTransformSchemaRow[] PROGMEM = R"(
-      "%s": { "title": "%s", "type": "%s", "readOnly": %s }
   )";
 
 static const char kLambdaTransformSchemaTail[] PROGMEM = R"(
     }
   })";
 
-template<typename T>
-const char* get_schema_type_string(const T dummy) { return "string"; }
+/**
+ * Convert the variable type to a string representation of the type using
+ * template specializations.
+ **/
+template <class T>
+const char* get_schema_type_string(const T dummy) {
+  return "string";
+}
 
-template<>
-const char* get_schema_type_string(const int dummy) { return "number"; }
+template <>
+const char* get_schema_type_string(const int dummy) {
+  return "number";
+}
 
-template<>
-const char* get_schema_type_string(const float dummy) { return "number"; }
+template <>
+const char* get_schema_type_string(const float dummy) {
+  return "number";
+}
 
-template<>
-const char* get_schema_type_string(const String dummy) { return "string"; }
+template <>
+const char* get_schema_type_string(const String dummy) {
+  return "string";
+}
 
-template<>
-const char* get_schema_type_string(const bool dummy) { return "boolean"; }
+template <>
+const char* get_schema_type_string(const bool dummy) {
+  return "boolean";
+}
 
-template <typename I, typename O>
+/**
+ * Configuration parameter information struct
+ **/
+struct ParamInfo {
+  const char* key;
+  const char* description;
+};
+
+// FIXME: This whole implementation should be written with variadic template
+//        parameters once the SDK gets updated past GCC 5.2.
+
+/**
+ * @brief Construct a new transform based on a single function
+ *
+ * LambdaTransform provides an easy way of creating custom transformations
+ * without having to create new Transform classes. You just create a transform
+ * function and feed that to a LambdaTransform constructor together with
+ * possible configuration parameters values and configuration parameter
+ * metadata (key names and descriptions).
+ *
+ * @tparam I Transform function input value type
+ * @tparam O Transform function output value type
+ * @tparam T1 Transform function parameter 1 type
+ * @tparam T2 Transform function parameter 2 type
+ * @tparam T3 Transform function parameter 3 type
+ * @tparam T4 Transform function parameter 4 type
+ * @tparam T5 Transform function parameter 5 type
+ * @tparam T6 Transform function parameter 6 type
+ * */
+template <class I, class O, class T1 = float, class T2 = float,
+          class T3 = float, class T4 = float, class T5 = float,
+          class T6 = float>
 class LambdaTransform : public Transform<I, O> {
  public:
   LambdaTransform(O (*function)(I input), String config_path = "")
-      : Transform<I, O>(config_path) {
-    this->function = function;
+      : Transform<I, O>(config_path), function0{function}, num_params{0} {
+    this->load_configuration();
+  }
+
+  LambdaTransform(O (*function)(I input), const ParamInfo* param_info,
+                  String config_path = "")
+      : Transform<I, O>(config_path),
+        function0{function},
+        num_params{0},
+        param_info{param_info} {
+    this->load_configuration();
+  }
+
+  LambdaTransform(O (*function)(I input, T1 param1), T1 param1,
+                  const ParamInfo* param_info, String config_path = "")
+      : Transform<I, O>(config_path),
+        function1{function},
+        param1{param1},
+        num_params{1},
+        param_info{param_info} {
+    this->load_configuration();
+  }
+
+  /**
+   * @brief LambdaTransform constructor for two-parameter function
+   *
+   * Construct a new LambdaTransform object which takes an input and two
+   * configuration parameters. Multiple overloaded constructors
+   * exist; their arguments can be extrapolated from this one.
+   *
+   * @param function Function to be executed for every new input value
+   * @param param1 Configuration parameter 1
+   * @param param2 Configuration parameter 2
+   * @param param_info Keys and Descriptions of each configuration parameter
+   * @param config_path Configuration path for the transform
+   **/
+  LambdaTransform(O (*function)(I input, T1 param1, T2 param2), T1 param1,
+                  T2 param2, const ParamInfo* param_info,
+                  String config_path = "")
+      : Transform<I, O>(config_path),
+        function2{function},
+        param1{param1},
+        param2{param2},
+        num_params{2},
+        param_info{param_info} {
+    this->load_configuration();
+  }
+
+  LambdaTransform(O (*function)(I input, T1 param1, T2 param2, T3 param3),
+                  T1 param1, T2 param2, T3 param3, const ParamInfo* param_info,
+                  String config_path = "")
+      : Transform<I, O>(config_path),
+        function3{function},
+        param1{param1},
+        param2{param2},
+        param3{param3},
+        num_params{3},
+        param_info{param_info} {
+    this->load_configuration();
+  }
+
+  LambdaTransform(O (*function)(I input, T1 param1, T2 param2, T3 param3,
+                                T4 param4),
+                  T1 param1, T2 param2, T3 param3, T4 param4,
+                  const ParamInfo* param_info, String config_path = "")
+      : Transform<I, O>(config_path),
+        function4{function},
+        param1{param1},
+        param2{param2},
+        param3{param3},
+        param4{param4},
+        num_params{4},
+        param_info{param_info} {
+    this->load_configuration();
+  }
+
+  LambdaTransform(O (*function)(I input, T1 param1, T2 param2, T3 param3,
+                                T4 param4, T5 param5),
+                  T1 param1, T2 param2, T3 param3, T4 param4, T5 param5,
+                  const ParamInfo* param_info, String config_path = "")
+      : Transform<I, O>(config_path),
+        function4{function},
+        param1{param1},
+        param2{param2},
+        param3{param3},
+        param4{param4},
+        param4{param5},
+        num_params{5},
+        param_info{param_info} {
+    this->load_configuration();
+  }
+
+  LambdaTransform(O (*function)(I input, T1 param1, T2 param2, T3 param3,
+                                T4 param4, T5 param5, T6 param6),
+                  T1 param1, T2 param2, T3 param3, T4 param4, T5 param5,
+                  T6 param6, const ParamInfo* param_info,
+                  String config_path = "")
+      : Transform<I, O>(config_path),
+        function4{function},
+        param1{param1},
+        param2{param2},
+        param3{param3},
+        param4{param4},
+        param5{param5},
+        param6{param6},
+        num_params{6},
+        param_info{param_info} {
+    this->load_configuration();
   }
 
   void set_input(I input, uint8_t input_channel = 0) override {
-    this->output = (*function)(input);
+    switch (num_params) {
+      case 0:
+        this->output = (*function0)(input);
+        break;
+      case 1:
+        this->output = (*function1)(input, param1);
+        break;
+      case 2:
+        this->output = (*function2)(input, param1, param2);
+        break;
+      case 3:
+        this->output = (*function3)(input, param1, param2, param3);
+        break;
+      case 4:
+        this->output = (*function4)(input, param1, param2, param3, param4);
+        break;
+      case 5:
+        this->output =
+            (*function5)(input, param1, param2, param3, param4, param5);
+        break;
+      case 6:
+        this->output =
+            (*function6)(input, param1, param2, param3, param4, param5, param6);
+        break;
+      default:
+        break;
+    }
     Observable::notify();
   }
 
   void get_configuration(JsonObject& doc) override {
+    switch (num_params) {
+      case 6:
+        doc[param_info[5].key] = param6;
+      case 5:
+        doc[param_info[4].key] = param5;
+      case 4:
+        doc[param_info[3].key] = param4;
+      case 3:
+        doc[param_info[2].key] = param3;
+      case 2:
+        doc[param_info[1].key] = param2;
+      case 1:
+        doc[param_info[0].key] = param1;
+      default:
+        break;
+    }
     doc["value"] = this->output;
   }
 
-  bool set_configuration(const JsonObject& config) override { return true; }
+  bool set_configuration(const JsonObject& config) override {
+    // test that each argument key (as defined by param_info)
+    // exists in the received Json object
+    debugD("Preparing to restore configuration from FS.");
+    for (int i = 0; i < num_params; i++) {
+      const char* expected = param_info[i].key;
+      if (!config.containsKey(expected)) {
+        debugD("Didn't find all keys.");
+        return false;
+      }
+    }
+    switch (num_params) {
+      case 6:
+        param6 = config[param_info[5].key];
+      case 5:
+        param5 = config[param_info[4].key];
+      case 4:
+        param4 = config[param_info[3].key];
+      case 3:
+        param3 = config[param_info[2].key];
+      case 2:
+        param2 = config[param_info[1].key];
+      case 1:
+        param1 = config[param_info[0].key];
+      default:
+        break;
+    }
+    debugD("Restored configuration");
+    return true;
+  }
 
   String get_config_schema() override {
     // FIXME: The heavy use of Strings puts a lot of faith in that class's
@@ -56,29 +276,89 @@ class LambdaTransform : public Transform<I, O> {
     // a character array pointer as an argument for writing the output to.
     String output = "";
 
+    debugD("Preparing config schema");
+
     output.concat(FPSTR(kLambdaTransformSchemaHead));
+    if (num_params > 0) {
+      debugD("getting param_info:");
+      debugD("%s -> %s", param_info[0].key, param_info[0].description);
+      output.concat(format_schema_row(param_info[0].key,
+                                      param_info[0].description,
+                                      get_schema_type_string(param1), false));
+      output.concat(",");
+    }
+    if (num_params > 1) {
+      output.concat(format_schema_row(param_info[1].key,
+                                      param_info[1].description,
+                                      get_schema_type_string(param2), false));
+      output.concat(",");
+    }
+    if (num_params > 2) {
+      output.concat(format_schema_row(param_info[2].key,
+                                      param_info[2].description,
+                                      get_schema_type_string(param3), false));
+      output.concat(",");
+    }
+    if (num_params > 3) {
+      output.concat(format_schema_row(param_info[3].key,
+                                      param_info[3].description,
+                                      get_schema_type_string(param4), false));
+      output.concat(",");
+    }
+    if (num_params > 4) {
+      output.concat(format_schema_row(param_info[4].key,
+                                      param_info[4].description,
+                                      get_schema_type_string(param5), false));
+      output.concat(",");
+    }
+    if (num_params > 5) {
+      output.concat(format_schema_row(param_info[5].key,
+                                      param_info[5].description,
+                                      get_schema_type_string(param6), false));
+      output.concat(",");
+    }
     output.concat(format_schema_row(
         "value", "Last value", get_schema_type_string(this->output), true));
     output.concat(FPSTR(kLambdaTransformSchemaTail));
+
+    debugD("Prepared config schema.");
 
     return output;
   }
 
  private:
-  O (*function)(I input);
+  T1 param1;
+  T2 param2;
+  T3 param3;
+  T4 param4;
+  T5 param5;
+  T6 param6;
+  int num_params;
+  const ParamInfo* param_info;
+
+  O (*function0)(I input);
+  O (*function1)(I input, T1 param1);
+  O (*function2)(I input, T1 param1, T2 param2);
+  O (*function3)(I input, T1 param1, T2 param2, T3 param3);
+  O (*function4)(I input, T1 param1, T2 param2, T3 param3, T4 param4);
+  O(*function5)
+  (I input, T1 param1, T2 param2, T3 param3, T4 param4, T5 param5);
+  O(*function6)
+  (I input, T1 param1, T2 param2, T3 param3, T4 param4, T5 param5, T6 param6);
 
   static String format_schema_row(const char key[], const char title[],
                                   const char type[], const bool read_only) {
     char row[100] = "";
     const char* read_only_str = read_only ? "true" : "false";
 
-    sprintf_P(row, PSTR(kLambdaTransformSchemaRow), key, title, type,
-              read_only_str);
+    static const char schema_row[] = R"(
+      "%s": { "title": "%s", "type": "%s", "readOnly": %s }
+  )";
+
+    sprintf(row, schema_row, key, title, type, read_only_str);
 
     return String(row);
   }
 };
-
-template <>
 
 #endif

--- a/src/transforms/lambda_transform.h
+++ b/src/transforms/lambda_transform.h
@@ -72,9 +72,9 @@ struct ParamInfo {
  * @tparam P5 Transform function parameter 5 type
  * @tparam P6 Transform function parameter 6 type
  * */
-template <class IN, class OUT, class P1 = float, class P2 = float,
-          class P3 = float, class P4 = float, class P5 = float,
-          class P6 = float>
+template <class IN, class OUT, class P1 = bool, class P2 = bool,
+          class P3 = bool, class P4 = bool, class P5 = bool,
+          class P6 = bool>
 class LambdaTransform : public Transform<IN, OUT> {
  public:
   LambdaTransform(OUT (*function)(IN input), String config_path = "")


### PR DESCRIPTION
Lambda Transform is a transform that can be defined using a transform function, without having to create a new transform class for each new transform. The transforms also allow for defining a number of configuration parameters that can be modified using the web interface.

The implementation could be cleaner: in particular, variadic template parameters could be used to remove pretty much all code duplication related to differing parameter list lengths. However, the current version of the GCC compiler provided by the Arduino Framework exposes a bug which I couldn't work around. Changing the implementation later wouldn't affect the public interface, though.