### PR TITLE
Allow device to fill in requested permissions in token request to server

### DIFF
--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -40,8 +40,9 @@ void webSocketClientEvent(WStype_t type, uint8_t* payload, size_t length) {
 }
 
 WSClient::WSClient(String config_path, SKDelta* sk_delta, String server_address,
-                   uint16_t server_port, std::function<void(bool)> connected_cb,
-                   void_cb_func delta_cb)
+                   uint16_t server_port,
+                   std::function<void(bool)> connected_cb,
+                   void_cb_func delta_cb, String permission)
     : Configurable{config_path} {
   this->sk_delta = sk_delta;
 
@@ -52,6 +53,8 @@ WSClient::WSClient(String config_path, SKDelta* sk_delta, String server_address,
 
   this->connected_cb = connected_cb;
   this->delta_cb = delta_cb;
+
+  this->sk_permission = permission;
   // set the singleton object pointer
   ws_client = this;
 
@@ -280,6 +283,7 @@ void WSClient::send_access_request(const String server_address,
   DynamicJsonDocument doc(1024);
   doc["clientId"] = client_id;
   doc["description"] = String("SensESP device: ") + sensesp_app->get_hostname();
+  doc["permissions"] = this->sk_permission;
   String json_req = "";
   serializeJson(doc, json_req);
 

--- a/src/net/ws_client.h
+++ b/src/net/ws_client.h
@@ -17,7 +17,7 @@ class WSClient : public Configurable {
  public:
   WSClient(String config_path, SKDelta* sk_delta, String server_address,
            uint16_t server_port, std::function<void(bool)> connected_cb,
-           void_cb_func delta_cb);
+           void_cb_func delta_cb, String sk_permission = "readwrite");
   void enable();
   void on_disconnected();
   void on_error();
@@ -44,6 +44,7 @@ class WSClient : public Configurable {
   String client_id = "";
   String polling_href = "";
   String auth_token = NULL_AUTH_TOKEN;
+  String sk_permission;
   bool server_detected = false;
 
   // FIXME: replace with a single connection_state enum

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -38,7 +38,8 @@ SensESPApp::SensESPApp(String preset_hostname, String ssid,
                        String wifi_password, String sk_server_address,
                        uint16_t sk_server_port, StandardSensors sensors,
                        int led_pin, bool enable_led, int led_ws_connected,
-                       int led_wifi_connected, int led_offline) {
+                       int led_wifi_connected, int led_offline,
+                       SKPermissions permissions) {
   // initialize filesystem
 #ifdef ESP8266
   if (!SPIFFS.begin()) {
@@ -84,8 +85,9 @@ SensESPApp::SensESPApp(String preset_hostname, String ssid,
     }
   };
   auto ws_delta_cb = [this]() { this->led_blinker->flip(); };
-  this->ws_client = new WSClient("/system/sk", sk_delta, sk_server_address,
-                                 sk_server_port, ws_connected_cb, ws_delta_cb);
+  this->ws_client =
+      new WSClient("/system/sk", sk_delta, sk_server_address, sk_server_port,
+                   ws_connected_cb, ws_delta_cb, get_permission_string(permissions));
 }
 
 void SensESPApp::setup_standard_sensors(ObservableValue<String>* hostname,
@@ -178,6 +180,26 @@ void SensESPApp::reset() {
   networking->reset_settings();
   SPIFFS.format();
   app.onDelay(1000, []() { ESP.restart(); });
+}
+
+String SensESPApp::get_permission_string(SKPermissions permission) 
+{
+  if(permission == READONLY)
+  {
+    return "readonly";
+  }
+  else if(permission == READWRITE)
+  {
+    return "readwrite";
+  }
+  else if(permission == ADMIN)
+  {
+    return "admin";
+  }
+  else
+  {
+    return "";
+  }  
 }
 
 String SensESPApp::get_hostname() { return networking->get_hostname()->get(); }

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -34,6 +34,8 @@ void SetupSerialDebug(uint32_t baudrate) {
   debugI("\nSerial debug enabled");
 }
 
+static char* permission_strings[] = {"readonly", "readwrite", "admin"};
+
 SensESPApp::SensESPApp(String preset_hostname, String ssid,
                        String wifi_password, String sk_server_address,
                        uint16_t sk_server_port, StandardSensors sensors,
@@ -85,9 +87,9 @@ SensESPApp::SensESPApp(String preset_hostname, String ssid,
     }
   };
   auto ws_delta_cb = [this]() { this->led_blinker->flip(); };
-  this->ws_client =
-      new WSClient("/system/sk", sk_delta, sk_server_address, sk_server_port,
-                   ws_connected_cb, ws_delta_cb, get_permission_string(permissions));
+  this->ws_client = new WSClient("/system/sk", sk_delta, sk_server_address,
+                                 sk_server_port, ws_connected_cb, ws_delta_cb,
+                                 permission_strings[(int)permissions]);
 }
 
 void SensESPApp::setup_standard_sensors(ObservableValue<String>* hostname,
@@ -180,26 +182,6 @@ void SensESPApp::reset() {
   networking->reset_settings();
   SPIFFS.format();
   app.onDelay(1000, []() { ESP.restart(); });
-}
-
-String SensESPApp::get_permission_string(SKPermissions permission) 
-{
-  if(permission == READONLY)
-  {
-    return "readonly";
-  }
-  else if(permission == READWRITE)
-  {
-    return "readwrite";
-  }
-  else if(permission == ADMIN)
-  {
-    return "admin";
-  }
-  else
-  {
-    return "";
-  }  
 }
 
 String SensESPApp::get_hostname() { return networking->get_hostname()->get(); }

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -33,16 +33,22 @@ enum StandardSensors {
   ALL = 0x1F
 };
 
+enum SKPermissions
+{
+  READONLY,
+  READWRITE,
+  ADMIN
+};
+
 void SetupSerialDebug(uint32_t baudrate);
 
 class SensESPApp {
  public:
-  SensESPApp(String hostname = "SensESP", String ssid = "",
-             String wifi_password = "", String sk_server_address = "",
-             uint16_t sk_server_port = 0, StandardSensors sensors = ALL,
-             int led_pin = LED_PIN, bool enable_led = ENABLE_LED,
-             int led_ws_connected = 200, int led_wifi_connected = 1000,
-             int led_offline = 2000);
+  SensESPApp(String hostname = "SensESP", String ssid = "", String wifi_password = "",
+             String sk_server_address = "", uint16_t sk_server_port = 0,
+             StandardSensors sensors = ALL, int led_pin = LED_PIN,
+             bool enable_led = ENABLE_LED, int led_ws_connected = 200,
+             int led_wifi_connected = 1000, int led_offline = 2000, SKPermissions permissions = READWRITE);
   void enable();
   void reset();
   String get_hostname();
@@ -88,6 +94,7 @@ class SensESPApp {
   Networking* networking;
   SKDelta* sk_delta;
   WSClient* ws_client;
+  String get_permission_string(SKPermissions permission);
 
   void set_wifi(String ssid, String password);
 

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -25,9 +25,10 @@ class SensESPAppBuilder {
     this->password = password;
     return this;
   }
-  SensESPAppBuilder* set_sk_server(String address, uint16_t port) {
+  SensESPAppBuilder* set_sk_server(String address, uint16_t port, SKPermissions permissions = READWRITE) {
     this->sk_server_address = address;
     this->sk_server_port = port;
+    this->sk_server_permissions = permissions;
     return this;
   }
   SensESPAppBuilder* set_standard_sensors(StandardSensors sensors = ALL) {
@@ -48,11 +49,6 @@ class SensESPAppBuilder {
   }
   SensESPAppBuilder* set_hostname(String hostname) {
     this->hostname = hostname;
-    return this;
-  }
-
-  SensESPAppBuilder* set_server_permissions(SKPermissions permissions) {
-    this->sk_server_permissions = permissions;
     return this;
   }
 

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -16,6 +16,7 @@ class SensESPAppBuilder {
   int led_ws_connected = 200;
   int led_wifi_connected = 1000;
   int led_offline = 5000;
+  SKPermissions sk_server_permissions = READWRITE;
 
  public:
   SensESPAppBuilder() {}
@@ -49,10 +50,17 @@ class SensESPAppBuilder {
     this->hostname = hostname;
     return this;
   }
+
+  SensESPAppBuilder* set_server_permissions(SKPermissions permissions) {
+    this->sk_server_permissions = permissions;
+    return this;
+  }
+
   SensESPApp* get_app() {
     return new SensESPApp(hostname, ssid, password, sk_server_address,
                           sk_server_port, sensors, led_pin, enable_led,
-                          led_ws_connected, led_wifi_connected, led_offline);
+                          led_ws_connected, led_wifi_connected, led_offline,
+                          sk_server_permissions);
   }
 };
 


### PR DESCRIPTION
Hi Guys,

I've implemented sending permissions in token request to SignalK server - tested with readwrite (default) permission and also with admin permission. Solves issue #173 

I've changed set_sk_server method on Builder and added third parameter permission with default READWRITE value. I've have changed SensESPApp ctor paramteters to add permision. Same with WSClient.

Let me know what you think!
Jan