### PR TITLE
Moved uint read_delay to private and below the declarations for other parameters.

### DIFF
--- a/src/sensors/ultrasonic_distance.h
+++ b/src/sensors/ultrasonic_distance.h
@@ -8,11 +8,11 @@ class UltrasonicDistance : public NumericSensor {
   UltrasonicDistance(int8_t trigger_pin, int8_t input_pin,
                      uint read_delay = 1000, String config_path = "");
   void enable() override final;
-  uint read_delay;
 
  private:
   int8_t trigger_pin;
   int8_t input_pin;
+  uint read_delay;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;


### PR DESCRIPTION
featherexp32 would not compile without this change although the other environments had no problems.

I also had to add the line extends = expressif32_base to the environment section for featheresp32 as it was generated by the "New Project" procedure in platformIO. If this wasnot done, the memory image for the featheresp32 environment was too large and generated an error.

Should this be noted in the instructions?