### PR TITLE
Stop using [[deprecated]] attributes due to too old GCC

### DIFF
--- a/src/sensors/ads1x15.h
+++ b/src/sensors/ads1x15.h
@@ -46,9 +46,11 @@ class ADS1x15Value : public NumericSensor {
 typedef ADS1x15Value<ADS1015> ADS1015Value;
 typedef ADS1x15Value<ADS1115> ADS1115Value;
 
-[[deprecated("Use ADS1015Value instead.")]]
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use ADS1015Value instead.")]]
 typedef ADS1015Value ADS1015value;
-[[deprecated("Use ADS1115Value instead.")]]
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use ADS1115Value instead.")]]
 typedef ADS1115Value ADS1115value;
 
 #endif

--- a/src/sensors/bme280.h
+++ b/src/sensors/bme280.h
@@ -47,7 +47,8 @@ class BME280Value : public NumericSensor {
   virtual String get_config_schema() override;
 };
 
-[[deprecated("Use BME280Value instead.")]]
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use BME280Value instead.")]]
 typedef BME280Value BME280value;
 
 #endif

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -46,7 +46,8 @@ class BMP280Value : public NumericSensor {
   virtual String get_config_schema() override;
 };
 
-[[deprecated("Use BMP280Value instead.")]]
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use BMP280Value instead.")]]
 typedef BMP280Value BMP280value;
 
 #endif

--- a/src/sensors/ina219.h
+++ b/src/sensors/ina219.h
@@ -45,7 +45,8 @@ class INA219Value : public NumericSensor {
   virtual String get_config_schema() override;
 };
 
-[[deprecated("Use INA219Value instead.")]]
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use INA219Value instead.")]]
 typedef INA219Value INA219value;
 
 #endif

--- a/src/sensors/sht31.h
+++ b/src/sensors/sht31.h
@@ -42,7 +42,8 @@ class SHT31Value : public NumericSensor {
   virtual String get_config_schema() override;
 };
 
-[[deprecated("Use SHT31Value instead.")]]
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use SHT31Value instead.")]]
 typedef SHT31Value SHT31value;
 
 #endif

--- a/src/sensors/ultrasonic_distance.h
+++ b/src/sensors/ultrasonic_distance.h
@@ -18,7 +18,8 @@ class UltrasonicDistance : public NumericSensor {
   virtual String get_config_schema() override;
 };
 
-[[deprecated("Use UltrasonicDistance instead.")]]
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use UltrasonicDistance instead.")]]
 typedef UltrasonicDistance UltrasonicSens;
 
 #endif

--- a/src/system/enable.h
+++ b/src/system/enable.h
@@ -5,6 +5,8 @@
 
 #include <queue>
 
+#include "sensesp.h"
+
 /**
  * Classes that implement "Enable" will have their enable() method
  * called automatically at startup when the SensESP app itself
@@ -38,8 +40,10 @@ class Enable {
    */
   static void enable_all();
 
-  [[deprecated("Use enable_all() instead.")]]
+  // FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+  // [[deprecated("Use enable_all() instead.")]]
   static void enableAll() {
+    debugW("Use enable_all() instead.");
     enable_all();
   };
 

--- a/src/system/valueconsumer.h
+++ b/src/system/valueconsumer.h
@@ -3,7 +3,7 @@
 
 #include <ArduinoJson.h>
 #include <stdint.h>
-
+#include "sensesp.h"
 template <typename T>
 class ValueProducer;
 
@@ -40,9 +40,11 @@ class ValueConsumer {
       this->set_input(producer->get(), input_channel);
     });
   }
-  [[deprecated("Use connect_from() instead.")]]
+  // FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+  // [[deprecated("Use connect_from() instead.")]]
   void connectFrom(
       ValueProducer<T>* producer, uint8_t input_channel = 0) {
+    debugW("Use connect_from() instead.");
     connect_from(producer, input_channel);
   }
 };

--- a/src/system/valueproducer.h
+++ b/src/system/valueproducer.h
@@ -41,9 +41,11 @@ class ValueProducer : virtual public Observable {
     });
   }
 
-  [[deprecated("Use connect_to() instead.")]]
+  // FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+  // [[deprecated("Use connect_to() instead.")]]
   void connectTo(
       ValueConsumer<T>* consumer, uint8_t input_channel = 0) {
+    debugW("Use connect_to() instead.");
     connect_to(consumer, input_channel);
   }
 
@@ -68,9 +70,11 @@ class ValueProducer : virtual public Observable {
   }
 
   template <typename T2>
-  [[deprecated("Use connect_to(...) instead.")]]
+  // FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+  //[[deprecated("Use connect_to(...) instead.")]]
   Transform<T, T2>* connectTo(
       Transform<T, T2>* consumer_producer, uint8_t input_channel = 0) {
+    debugW("Use connect_to(...) instead.");
     return connect_to(consumer_producer, input_channel);
   }
 

--- a/src/transforms/curveinterpolator.h
+++ b/src/transforms/curveinterpolator.h
@@ -40,14 +40,18 @@ class CurveInterpolator : public NumericTransform {
 
   // For manually adding sample points
   void clear_samples();
-  [[deprecated("Use clear_samples() instead.")]]
+  // FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+  // [[deprecated("Use clear_samples() instead.")]]
   void clearSamples() {
+    debugW("Use clear_samples() instead.");
     clear_samples();
   }
   void add_sample(const Sample& new_sample);
-  [[deprecated("Use add_sample() instead.")]]
+  // FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+  // [[deprecated("Use add_sample(...) instead.")]]
   void addSample(
       const Sample& new_sample) {
+    debugW("Use add_sample(...) instead");
     add_sample(new_sample);
   }
 


### PR DESCRIPTION
This PR takes care of a lot of compiler warnings.

Commenting code out should generally be avoided but I resorted to that with a clear FIXME message to indicate that those lines should be restored once the toolchain allows that.