### PR TITLE
Fix some variable names that dodged the first round

### DIFF
--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -48,9 +48,9 @@ class SensESPApp {
   String get_hostname();
 
   template <typename T>
-  void connect(ValueProducer<T>* pProducer, ValueConsumer<T>* pConsumer,
+  void connect(ValueProducer<T>* producer, ValueConsumer<T>* consumer,
                uint8_t inputChannel = 0) {
-    pProducer->connect_to(pConsumer, inputChannel);
+    producer->connect_to(consumer, inputChannel);
   }
 
   template <typename T, typename U>

--- a/src/sensors/bme280.h
+++ b/src/sensors/bme280.h
@@ -14,7 +14,7 @@
 // the specified value. If you want to change any of the values with the
 // Adafruit_BME280::setSampling() method, it's public, so you can call that
 // after you instantiate the BME280 and before you start using it, with:
-// yourInstanceVariable->pAdafruitBME280->setSampling(); See the Adafruit
+// sensor_object->adafruit_bme280->setSampling(); See the Adafruit
 // library for details.
 // https://github.com/adafruit/Adafruit_BME280_Library/blob/master/Adafruit_BME280.h
 class BME280 : public Sensor {

--- a/src/sensors/ina219.h
+++ b/src/sensors/ina219.h
@@ -32,7 +32,7 @@ enum INA219ValType { bus_voltage, shunt_voltage, current, power, load_voltage };
 // INA219Value reads and outputs the specified value of a INA219 sensor.
 class INA219Value : public NumericSensor {
  public:
-  INA219Value(INA219* pINA219, INA219ValType val_type, uint read_delay = 500,
+  INA219Value(INA219* ina219, INA219ValType val_type, uint read_delay = 500,
               String config_path = "");
   void enable() override final;
   INA219* ina219;


### PR DESCRIPTION
Some member variables had still the Hungarian notation pointer prefixes. Removed in this PR.