### PR TITLE
Linear transform reimplemented as a LambdaTransform

### DIFF
--- a/src/transforms/lambda_transform.cpp
+++ b/src/transforms/lambda_transform.cpp
@@ -1,0 +1,26 @@
+#include "lambda_transform.h"
+
+template <class T>
+const char* get_schema_type_string(const T dummy) {
+  return "string";
+}
+
+template <>
+const char* get_schema_type_string(const int dummy) {
+  return "number";
+}
+
+template <>
+const char* get_schema_type_string(const float dummy) {
+  return "number";
+}
+
+template <>
+const char* get_schema_type_string(const String dummy) {
+  return "string";
+}
+
+template <>
+const char* get_schema_type_string(const bool dummy) {
+  return "boolean";
+}

--- a/src/transforms/lambda_transform.h
+++ b/src/transforms/lambda_transform.h
@@ -154,7 +154,7 @@ class LambdaTransform : public Transform<IN, OUT> {
         param2{param2},
         param3{param3},
         param4{param4},
-        param4{param5},
+        param5{param5},
         num_params{5},
         param_info{param_info} {
     this->load_configuration();

--- a/src/transforms/lambda_transform.h
+++ b/src/transforms/lambda_transform.h
@@ -19,29 +19,19 @@ static const char kLambdaTransformSchemaTail[] PROGMEM = R"(
  * template specializations.
  **/
 template <class T>
-const char* get_schema_type_string(const T dummy) {
-  return "string";
-}
+const char* get_schema_type_string(const T dummy);
 
 template <>
-const char* get_schema_type_string(const int dummy) {
-  return "number";
-}
+const char* get_schema_type_string(const int dummy);
 
 template <>
-const char* get_schema_type_string(const float dummy) {
-  return "number";
-}
+const char* get_schema_type_string(const float dummy);
 
 template <>
-const char* get_schema_type_string(const String dummy) {
-  return "string";
-}
+const char* get_schema_type_string(const String dummy);
 
 template <>
-const char* get_schema_type_string(const bool dummy) {
-  return "boolean";
-}
+const char* get_schema_type_string(const bool dummy);
 
 /**
  * Configuration parameter information struct

--- a/src/transforms/linear.cpp
+++ b/src/transforms/linear.cpp
@@ -1,42 +1,17 @@
 #include "linear.h"
 
-// Linear
+// Keys and descriptions of constant parameters
+
+const ParamInfo Linear::param_info[] = {{"k", "Multiplier"},
+                                        {"c", "Constant offset"}};
+
+// Function implementing the linear transform
+
+float (*Linear::function)(float, float, float) =
+    [](float input, float k, float c) { return k * input + c; };
+
+// Constructor definition
 
 Linear::Linear(float k, float c, String config_path)
-    : NumericTransform(config_path), k{k}, c{c} {
-  load_configuration();
-}
-
-void Linear::set_input(float input, uint8_t inputChannel) {
-  output = k * input + c;
-  notify();
-}
-
-void Linear::get_configuration(JsonObject& root) {
-  root["k"] = k;
-  root["c"] = c;
-  root["value"] = output;
-}
-
-static const char SCHEMA[] PROGMEM = R"({
-    "type": "object",
-    "properties": {
-        "k": { "title": "Multiplier", "type": "number" },
-        "c": { "title": "Constant offset", "type": "number" },
-        "value": { "title": "Last value", "type" : "number", "readOnly": true }
-    }
-  })";
-
-String Linear::get_config_schema() { return FPSTR(SCHEMA); }
-
-bool Linear::set_configuration(const JsonObject& config) {
-  String expected[] = {"k", "c"};
-  for (auto str : expected) {
-    if (!config.containsKey(str)) {
-      return false;
-    }
-  }
-  k = config["k"];
-  c = config["c"];
-  return true;
-}
+    : LambdaTransform<float, float, float, float>(function, k, c, param_info,
+                                                  config_path) {}

--- a/src/transforms/linear.h
+++ b/src/transforms/linear.h
@@ -1,22 +1,20 @@
 #ifndef _linear_H_
 #define _linear_H_
 
-#include "transform.h"
+#include "lambda_transform.h"
 
-// Perform a linear transform on the input value. The transform
-// is of the form \f$y = k * x + c\f$, where k is the input
-// coefficient and c is a bias value.
-class Linear : public NumericTransform {
+/**
+ * Perform a linear transform on the input value. The transform
+ * is of the form \f$y = k * x + c\f$, where k is the input
+ * coefficient and c is a bias (offset) value.
+ **/
+class Linear : public LambdaTransform<float, float, float, float> {
  public:
   Linear(float k, float c, String config_path = "");
-  virtual void set_input(float input, uint8_t inputChannel = 0) override;
-  virtual void get_configuration(JsonObject& doc) override;
-  virtual bool set_configuration(const JsonObject& config) override;
-  virtual String get_config_schema() override;
 
  private:
-  float k;
-  float c;
+  static float (*function)(float, float, float);
+  static const ParamInfo param_info[];
 };
 
 #endif


### PR DESCRIPTION
This is a reimplementation of the `Linear` transform class, illustrating the potential benefits of implementing the basic transforms using `LambdaTransform`.

The first commit is a bugfix for `LambdaTransform` implementation. If desired, I can make it a separate PR but this Linear transform reimplementation depends on it.