### PR TITLE
Missing magnetometer dependencies

### DIFF
--- a/examples/platformio.ini
+++ b/examples/platformio.ini
@@ -23,6 +23,7 @@ default_envs =
 [env]
 ; Global data for all [env:***]
 framework = arduino
+lib_ldf_mode = deep
 monitor_speed = 115200
 lib_deps =
   https://github.com/SignalK/SensESP.git

--- a/library.json
+++ b/library.json
@@ -79,6 +79,15 @@
     { 
       "name": "Adafruit BMP280 Library"
     },
+    { 
+      "name": "Adafruit FXAS21002C"
+    },
+    { 
+      "name": "Adafruit FXOS8700"
+    },
+    {
+      "name": "Adafruit Sensor Calibration"
+    },
     {
       "name": "Adafruit SHT31 Library"
     },

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,7 @@ default_envs =
 [env]
 ; Global data for all [env:***]
 framework = arduino
+lib_ldf_mode = deep
 monitor_speed = 115200
 lib_deps =
    ReactESP

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,6 +43,9 @@ lib_deps =
    Adafruit AHRS
    Adafruit BME280 Library
    Adafruit BMP280 Library
+   Adafruit FXAS21002C
+   Adafruit FXOS8700
+   Adafruit Sensor Calibration
    Adafruit SHT31 Library
    Adafruit INA219
    Adafruit MAX31856 Library


### PR DESCRIPTION
Some dependencies were missing from the previous magnetometer PR and new builds broke due to that. This PR fixes that. Unfortunately, PlatformIO's Library Dependency Finder (LDF) is no longer able to find all dependencies with the default settings, so changes to `platformio.ini` are required.