### PR TITLE
Hysteresis: Move the param_info array out of the inherited class

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,23 +10,23 @@ jobs:
       matrix:
         example: [
           examples/ads1x15_volt_meter.cpp,
-          examples/ina219_example.cpp,
           examples/analog_input.cpp,
-          examples/lambda_transform.cpp,
           examples/bme280_example.cpp,
           examples/bmp280_example.cpp,
+          examples/fuel_flow_meter.cpp,
+          examples/fuel_level_sensor/fuel_level_sensor_example.cpp,
+          examples/gps_compass.cpp,
+          examples/hysteresis.cpp,
+          examples/ina219_example.cpp,
+          examples/lambda_transform.cpp,
+          examples/milone_level_sensor/milone_level_sensor.cpp,
+          examples/onewire_temperature/onewire_temperature_example.cpp,
           examples/relay_control.cpp,
+          examples/rpm_counter.cpp,
           examples/sht31_example.cpp,
           examples/temperature_sender.cpp,
-          examples/gps_compass.cpp,
-          examples/fuel_flow_meter.cpp,
-          examples/rpm_counter.cpp,
-          examples/fuel_level_sensor/fuel_level_sensor_example.cpp,
-          examples/onewire_temperature/onewire_temperature_example.cpp,
-          examples/milone_level_sensor/milone_level_sensor.cpp,
           examples/thermocouple_temperature_sensor/max31856_thermocouple_example.cpp,
           examples/ultrasonic_level_sensor/ultrasonic_dvp_example.cpp]
-          # examples/hysteresis.cpp,
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python

--- a/src/transforms/hysteresis.h
+++ b/src/transforms/hysteresis.h
@@ -3,14 +3,21 @@
 
 #include "lambda_transform.h"
 
+// Web UI parameter name definition
+const ParamInfo hysteresis_param_info[4] = {
+    {"lower_threshold", "Lower threshold"},
+    {"upper_threshold", "Upper threshold"},
+    {"low_output", "Low output"},
+    {"high_output", "High output"}};
+
 /**
  * @brief Hysteresis function
- * 
+ *
  * Hysteresis is a threshold switch with a dead zone: to prevent switching
  * back and forth at the threshold value, input has to rise above the
  * upper threshold before being switched high, and has to decrease below
  * the lower threshold before being switched back low.
- * 
+ *
  * @tparam IN Input variable type
  * @tparam OUT Output variable type
  * @param[in] lower_threshold Lower threshold value
@@ -27,15 +34,9 @@ class Hysteresis : public LambdaTransform<IN, OUT, IN, IN, OUT, OUT> {
              OUT high_output, String config_path = "")
       : LambdaTransform<IN, OUT, IN, IN, OUT, OUT>(
             &(Hysteresis::function), lower_threshold, upper_threshold,
-            low_output, high_output, this->param_info, config_path) {}
+            low_output, high_output, hysteresis_param_info, config_path) {}
 
  private:
-  // Web UI parameter name definition
-  const ParamInfo param_info[4] = {{"lower_threshold", "Lower threshold"},
-                                   {"upper_threshold", "Upper threshold"},
-                                   {"low_output", "Low output"},
-                                   {"high_output", "High output"}};
-
   // Function implementing the actual hysteresis logic
   static OUT function(IN input, IN lower_threshold, IN upper_threshold,
                       OUT low_output, OUT high_output) {


### PR DESCRIPTION
There is a difference between ESP8266 and ESP32
SDK gcc compilers in how the template class base class constructor
calls work. The original code wouldn't work on ESP8266 (gcc 4.8.2)
but did work on ESP32 (gcc 5.2.0). Pulling the array out of the
class makes it work for both.

Fixes #222.