### PR TITLE
Add type of DeserializationError to Serial output

### DIFF
--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -340,7 +340,8 @@ void WSClient::poll_access_request(const String server_address,
     DynamicJsonDocument doc(1024);
     auto error = deserializeJson(doc, payload.c_str());
     if (error) {
-      debugW("WARNING: Could not deserialize http.");
+      debugW("WARNING: Could not deserialize http payload.");
+      debugW("DeserializationError: %s", error.c_str());
       return;  // TODO: return at this point, or keep going?
     }
     String state = doc["state"];


### PR DESCRIPTION
Trying to pinpoint the reason for the failure of an approved Security Token. (Issue #213 )