### PR TITLE
Replace deprecated build flag

### DIFF
--- a/examples/platformio.ini
+++ b/examples/platformio.ini
@@ -31,8 +31,8 @@ lib_deps =
 [espressif8266_base]
 ;this section has config items common to all ESP8266 boards
 platform = espressif8266
+board_build.ldscript = eagle.flash.4m1m.ld
 build_flags =
-   -Wl,-Teagle.flash.4m1m.ld
    -Wall
    -Wno-reorder
 


### PR DESCRIPTION
Addresses Issue #156 .

After making this change in my project's platformio.ini, I erased the flash on my ESP8266 (D1 Mini) and reloaded. Then I brought up the Config UI and changed a couple of the configurable items in my project and saved them. Restarted the ESP and checked the Config UI to confirm my changes had been saved. Then I changed them back, restarted the ESP again, and made sure those changes had been saved. Everything worked as expected.