### PR TITLE
build_flags added, each board can have dedicated pin definitions

### DIFF
--- a/examples/analog_input.cpp
+++ b/examples/analog_input.cpp
@@ -6,6 +6,18 @@
 #include "signalk/signalk_output.h"
 #include "transforms/linear.h"
 
+#ifdef D1MINI
+#define ANALOG A0  //Always A0
+#endif
+
+#ifdef ESP32DEV
+#define ANALOG 36 //ADC1_0
+#endif
+
+#ifdef ESPWROVERKIT
+#define ANALOG 0 //ADC2_1
+#endif
+
 // SensESP builds upon the ReactESP framework. Every ReactESP application
 // defines an "app" object vs defining a "main()" method.
 ReactESP app([]() {
@@ -42,7 +54,7 @@ ReactESP app([]() {
   // used for AnalogIn, and they're expressed here as the XX in GPIOXX.
   // When it's dark, the sensor's output (as read by analogRead()) is 120, and
   // when it's bright, the output is 850, for a range of 730.
-  uint8_t pin = A0;
+  uint8_t pin = ANALOG;
   uint read_delay = 500;
 
   auto* analog_input = new AnalogInput(pin, read_delay, analog_in_config_path);

--- a/platformio.ini
+++ b/platformio.ini
@@ -68,6 +68,7 @@ board = d1_mini
 board_build.f_cpu = 160000000L
 upload_resetmethod = nodemcu
 upload_speed = 460800  
+build_flags = -DD1MINI
 
 [espressif32_base]
 ;this section has config items common to all ESP32 boards
@@ -79,8 +80,10 @@ monitor_filters = esp32_exception_decoder
 [env:esp32dev]
 extends = espressif32_base
 board = esp32dev
+build_flags = -DESP32DEV
 
 [env:esp-wrover-kit]
 extends = espressif32_base
 board = esp-wrover-kit
 upload_speed = 460800
+build_flags = -DESPWROVERKIT


### PR DESCRIPTION
Can we add following build_flags to platformio.ini to enable dedicated pin definition for each boards independently?
I added example usage of this modification to analog_input.cpp.