### PR TITLE
Add load_configuration() to DigitalInputValue constructor

### DIFF
--- a/src/sensors/digital_input.cpp
+++ b/src/sensors/digital_input.cpp
@@ -15,7 +15,9 @@ DigitalInputValue::DigitalInputValue(uint8_t pin, int pin_mode,
                                      String config_path)
     : DigitalInput{pin, pin_mode, interrupt_type, config_path},
       IntegerProducer(),
-      read_delay{read_delay} {}
+      read_delay{read_delay} {
+  load_configuration();      
+}
 
 void DigitalInputValue::enable() {
   app.onRepeat(read_delay, [this]() {


### PR DESCRIPTION
While testing another PR, I noticed this issue. It goes back to PR #125, when DigitalInputValue was first made configurable by the addition of read_delay, but load_configuration() wasn't added to the constructor at that time.