### PR TITLE
fix: ESP32 hostname for mDNS name

### DIFF
--- a/src/net/discovery.cpp
+++ b/src/net/discovery.cpp
@@ -18,7 +18,9 @@ void setup_discovery(const char* hostname) {
   } else {
     debugI("mDNS responder started at %s", hostname);
   }
-  mdns_instance_name_set(hostname);
+#ifdef ESP32
+  mdns_instance_name_set(hostname);   //mDNS hostname for ESP32
+#endif
   MDNS.addService("http", "tcp", 80);
   MDNS.addService("signalk-sensesp", "tcp", 80);
 }

--- a/src/net/discovery.cpp
+++ b/src/net/discovery.cpp
@@ -18,6 +18,7 @@ void setup_discovery(const char* hostname) {
   } else {
     debugI("mDNS responder started at %s", hostname);
   }
+  mdns_instance_name_set(hostname);
   MDNS.addService("http", "tcp", 80);
   MDNS.addService("signalk-sensesp", "tcp", 80);
 }


### PR DESCRIPTION
ESP32 SensESP is not using hostname for mDNS name at the moment. This fix the issue and show correctly user defined hostname also in mDNS name.