### PR TITLE
ValueProducer::emit(value)

### DIFF
--- a/src/sensors/analog_input.cpp
+++ b/src/sensors/analog_input.cpp
@@ -14,8 +14,7 @@ AnalogInput::AnalogInput(uint8_t pin, uint read_delay, String config_path,
 }
 
 void AnalogInput::update() {
-  output = output_scale * analog_reader->read();
-  this->notify();
+  this->emit(output_scale * analog_reader->read());
 }
 
 void AnalogInput::enable() {

--- a/src/sensors/bme280.cpp
+++ b/src/sensors/bme280.cpp
@@ -49,8 +49,9 @@ void BME280Value::enable() {
       output = bme280->adafruit_bme280->readPressure();
     } else if (val_type == humidity) {
       output = bme280->adafruit_bme280->readHumidity();
-    } else
+    } else {
       output = 0.0;
+    }
 
     notify();
   });

--- a/src/sensors/bmp280.cpp
+++ b/src/sensors/bmp280.cpp
@@ -34,8 +34,9 @@ void BMP280Value::enable() {
                273.15;  // Kelvin is Celsius + 273.15
     } else if (val_type == pressure) {
       output = bmp280->adafruit_bmp280->readPressure();
-    } else
+    } else {
       output = 0.0;
+    }
 
     notify();
   });

--- a/src/sensors/digital_input.cpp
+++ b/src/sensors/digital_input.cpp
@@ -21,8 +21,7 @@ DigitalInputValue::DigitalInputValue(uint8_t pin, int pin_mode,
 
 void DigitalInputValue::enable() {
   app.onRepeat(read_delay, [this]() {
-    output = digitalRead(pin);
-    notify();
+    emit(digitalRead(pin));
   });
 }
 

--- a/src/sensors/max31856_thermocouple.cpp
+++ b/src/sensors/max31856_thermocouple.cpp
@@ -26,8 +26,7 @@ void MAX31856Thermocouple::enable() {
       delay(25);
     }
     float temp = max31856->readThermocoupleTemperature();
-    output = temp;
-    this->notify();
+    this->emit(temp);
   });
 }
 

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -136,8 +136,7 @@ void OneWireTemperature::update() {
 
 void OneWireTemperature::read_value() {
   // getTempC returns degrees Celsius but Signal K expects Kelvins
-  output = dts->sensors->getTempC(address.data()) + 273.15;
-  this->notify();
+  this->emit(dts->sensors->getTempC(address.data()) + 273.15);
 }
 
 void OneWireTemperature::get_configuration(JsonObject& root) {

--- a/src/sensors/sht31.cpp
+++ b/src/sensors/sht31.cpp
@@ -34,8 +34,9 @@ void SHT31Value::enable() {
                273.15;  // Kelvin is Celsius + 273.15
     } else if (val_type == humidity) {
       output = sht31->adafruit_sht31->readHumidity();
-    } else
+    } else {
       output = 0.0;
+    }
 
     notify();
   });

--- a/src/sensors/system_info.cpp
+++ b/src/sensors/system_info.cpp
@@ -30,8 +30,7 @@ void SystemHz::enable() {
 }
 
 void FreeMem::update() {
-  output = ESP.getFreeHeap();
-  this->notify();
+  this->emit(ESP.getFreeHeap());
 }
 
 void FreeMem::enable() {
@@ -39,8 +38,7 @@ void FreeMem::enable() {
 }
 
 void Uptime::update() {
-  output = millis() / 1000.;
-  this->notify();
+  this->emit(millis() / 1000.);
 }
 
 void Uptime::enable() {
@@ -48,8 +46,7 @@ void Uptime::enable() {
 }
 
 void IPAddrDev::update() {
-  output = WiFi.localIP().toString();
-  this->notify();
+  this->emit(WiFi.localIP().toString());
 }
 
 void IPAddrDev::enable() {
@@ -61,6 +58,5 @@ void WifiSignal::enable() {
 }
 
 void WifiSignal::update() {
-  output = WiFi.RSSI();
-  this->notify();
+  this->emit(WiFi.RSSI());
 }

--- a/src/sensors/ultrasonic_distance.cpp
+++ b/src/sensors/ultrasonic_distance.cpp
@@ -17,8 +17,8 @@ UltrasonicDistance::UltrasonicDistance(int8_t trig_pin, int8_t input_pin,
 void UltrasonicDistance::enable() {
   app.onRepeat(read_delay, [this]() {
     digitalWrite(trigger_pin, HIGH);
-    long lastTime = micros();
-    while (micros() - lastTime < 100) {
+    long last_time = micros();
+    while (micros() - last_time < 100) {
       yield();
     }
     digitalWrite(trigger_pin, LOW);

--- a/src/sensors/ultrasonic_distance.cpp
+++ b/src/sensors/ultrasonic_distance.cpp
@@ -22,8 +22,7 @@ void UltrasonicDistance::enable() {
       yield();
     }
     digitalWrite(trigger_pin, LOW);
-    output = pulseIn(input_pin, HIGH);
-    this->notify();
+    this->emit(pulseIn(input_pin, HIGH));
   });
 }
 

--- a/src/signalk/signalk_output.h
+++ b/src/signalk/signalk_output.h
@@ -24,8 +24,7 @@ class SKOutput : public SKEmitter, public SymmetricTransform<T> {
   }
 
   virtual void set_input(T new_value, uint8_t input_channel = 0) override {
-    ValueProducer<T>::output = new_value;
-    this->notify();
+    this->ValueProducer<T>::emit(new_value);
   }
 
   virtual String as_signalk() override {

--- a/src/signalk/signalk_value_listener.h
+++ b/src/signalk/signalk_value_listener.h
@@ -21,8 +21,7 @@ class SKValueListener : public SKListener, public ValueProducer<T> {
   }
 
   void parse_value(JsonObject& json) override {
-    this->output = (T)json["value"];
-    notify();
+    this->emit((T)json["value"]);
   }
 };
 

--- a/src/system/observablevalue.h
+++ b/src/system/observablevalue.h
@@ -16,8 +16,7 @@ class ObservableValue : public ValueProducer<T> {
   ObservableValue(const T& value) { ValueProducer<T>::output = value; }
 
   void set(const T& value) {
-    ValueProducer<T>::output = value;
-    Observable::notify();
+    this->ValueProducer<T>::emit(value);
   }
 
   const T& operator=(const T& value) {

--- a/src/system/valueproducer.h
+++ b/src/system/valueproducer.h
@@ -78,6 +78,14 @@ class ValueProducer : virtual public Observable {
     return connect_to(consumer_producer, input_channel);
   }
 
+  /*
+   * Set a new output value and notify consumers about it
+   */
+  void emit(T new_value) {
+    this->output = new_value;
+    Observable::notify();
+  }
+
  protected:
   /**
    * The current value of this producer is stored here in this output member

--- a/src/transforms/analogvoltage.cpp
+++ b/src/transforms/analogvoltage.cpp
@@ -10,8 +10,8 @@ AnalogVoltage::AnalogVoltage(float max_voltage, float multiplier, float offset,
 }
 
 void AnalogVoltage::set_input(float input, uint8_t inputChannel) {
-  output = ((input * (max_voltage / MAX_ANALOG_OUTPUT)) * multiplier) + offset;
-  notify();
+  this->emit(((input * (max_voltage / MAX_ANALOG_OUTPUT)) * multiplier) +
+             offset);
 }
 
 void AnalogVoltage::get_configuration(JsonObject& root) {

--- a/src/transforms/angle_correction.cpp
+++ b/src/transforms/angle_correction.cpp
@@ -17,9 +17,7 @@ void AngleCorrection::set_input(float input, uint8_t inputChannel) {
   if (x < 0) {
     x += 2 * M_PI;
   }
-  output = x + min_angle;
-
-  notify();
+  this->emit(x + min_angle);
 }
 
 void AngleCorrection::get_configuration(JsonObject& root) {

--- a/src/transforms/change_filter.cpp
+++ b/src/transforms/change_filter.cpp
@@ -21,9 +21,8 @@ ChangeFilter::ChangeFilter(float min_delta, float max_delta, int max_skips,
 void ChangeFilter::set_input(float new_value, uint8_t input_channel) {
   float delta = absf(new_value - output);
   if ((delta >= min_delta && delta <= max_delta) || skips > max_skips) {
-    output = new_value;
     skips = 0;
-    notify();
+    this->emit(new_value);
   } else {
     skips++;
   }

--- a/src/transforms/debounce.cpp
+++ b/src/transforms/debounce.cpp
@@ -8,8 +8,7 @@ Debounce::Debounce(int ms_min_delay, String config_path)
 void Debounce::set_input(bool newValue, uint8_t inputChannel) {
   int elapsed = millis() - last_time;
   if (newValue != output || elapsed > ms_min_delay) {
-    output = newValue;
     last_time = millis();
-    notify();
+    this->emit(newValue);
   }
 }

--- a/src/transforms/difference.cpp
+++ b/src/transforms/difference.cpp
@@ -11,9 +11,8 @@ void Difference::set_input(float input, uint8_t inputChannel) {
   inputs[inputChannel] = input;
   received |= 1 << inputChannel;
   if (received == 0b11) {
-    output = k1 * inputs[0] - k2 * inputs[1];
     received = 0;
-    notify();
+    this->emit(k1 * inputs[0] - k2 * inputs[1]);
   }
 }
 

--- a/src/transforms/frequency.cpp
+++ b/src/transforms/frequency.cpp
@@ -12,9 +12,8 @@ void Frequency::enable() { last_update = millis(); }
 void Frequency::set_input(int input, uint8_t inputChannel) {
   unsigned long cur_millis = millis();
   unsigned long elapsed_millis = cur_millis - last_update;
-  output = k * input / (elapsed_millis / 1000.);
   last_update = cur_millis;
-  notify();
+  this->emit(k * input / (elapsed_millis / 1000.));
 }
 
 void Frequency::get_configuration(JsonObject& root) {

--- a/src/transforms/integrator.cpp
+++ b/src/transforms/integrator.cpp
@@ -5,8 +5,7 @@
 // Integrator
 
 Integrator::Integrator(float k, float value, String config_path)
-    : NumericTransform(config_path), k{k} {
-  output = value;
+    : NumericTransform(config_path), k{k}, value{value} {
   load_configuration();
 }
 
@@ -18,13 +17,13 @@ void Integrator::enable() {
 }
 
 void Integrator::set_input(float input, uint8_t inputChannel) {
-  output += input;
-  notify();
+  value += input;
+  this->emit(value);
 }
 
 void Integrator::get_configuration(JsonObject& root) {
   root["k"] = k;
-  root["value"] = output;
+  root["value"] = value;
 }
 
 static const char SCHEMA[] PROGMEM = R"({
@@ -45,6 +44,6 @@ bool Integrator::set_configuration(const JsonObject& config) {
     }
   }
   k = config["k"];
-  output = config["value"];
+  value = config["value"];
   return true;
 }

--- a/src/transforms/integrator.h
+++ b/src/transforms/integrator.h
@@ -14,6 +14,7 @@ class Integrator : public NumericTransform {
   virtual String get_config_schema() override;
 
  private:
+  float value = 0;
   float k;
 };
 

--- a/src/transforms/timestring.cpp
+++ b/src/transforms/timestring.cpp
@@ -7,6 +7,5 @@ TimeString::TimeString(String config_path)
 void TimeString::set_input(time_t input, uint8_t inputChannel) {
   char buf[sizeof "2011-10-08T07:07:09Z"];
   strftime(buf, sizeof buf, "%FT%TZ", gmtime(&input));
-  output = String(buf);
-  notify();
+  this->emit(String(buf));
 }

--- a/src/transforms/voltage_multiplier.cpp
+++ b/src/transforms/voltage_multiplier.cpp
@@ -6,8 +6,7 @@ VoltageMultiplier::VoltageMultiplier(uint16_t R1, uint16_t R2,
 
 void VoltageMultiplier::set_input(float input, uint8_t inputChannel) {
   // Ohms Law at work!
-  output = input * (((float)R1 + (float)R2) / (float)R2);
-  notify();
+  this->emit(input * (((float)R1 + (float)R2) / (float)R2));
 }
 
 void VoltageMultiplier::get_configuration(JsonObject& root) {

--- a/src/transforms/voltagedivider.cpp
+++ b/src/transforms/voltagedivider.cpp
@@ -6,8 +6,7 @@ VoltageDividerR1::VoltageDividerR1(float R2, float Vin, String config_path)
 }
 
 void VoltageDividerR1::set_input(float Vout, uint8_t ignored) {
-  output = (Vin - Vout) * R2 / Vout;
-  notify();
+  this->emit((Vin - Vout) * R2 / Vout);
 }
 
 void VoltageDividerR1::get_configuration(JsonObject& root) {
@@ -48,8 +47,7 @@ VoltageDividerR2::VoltageDividerR2(float R1, float Vin, String config_path)
 }
 
 void VoltageDividerR2::set_input(float Vout, uint8_t ignored) {
-  output = (Vout * R1) / (Vin - Vout);
-  notify();
+  this->emit((Vout * R1) / (Vin - Vout));
 }
 
 void VoltageDividerR2::get_configuration(JsonObject& root) {


### PR DESCRIPTION
Most sensors keep repeating the following pattern:

    output = some_value;
    notify();

This PR implements `ValueProducer::emit(value)` that changes the pattern to the following:

    this->emit(some_value);
