### PR TITLE
Networking and WSClient objects report their state via ValueProducers

### DIFF
--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -63,8 +63,7 @@ void Networking::setup() {
 
 void Networking::setup_saved_ssid() {
   WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
-  this->output = kWifiDisconnected;
-  this->notify();
+  this->emit(kWifiDisconnected);
 
   uint32_t timer_start = millis();
 
@@ -83,8 +82,7 @@ void Networking::setup_saved_ssid() {
     debugI("Connected to wifi, SSID: %s (signal: %d)", WiFi.SSID().c_str(),
            WiFi.RSSI());
     debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
-    this->output = kWifiConnectedToAP;
-    this->notify();
+    this->emit(kWifiConnectedToAP);
     WiFi.mode(WIFI_STA);
   }
 }
@@ -110,22 +108,19 @@ void Networking::setup_wifi_manager() {
   config_ssid = "Configure " + config_ssid;
   const char* pconfig_ssid = config_ssid.c_str();
 
-  this->output = kExecutingWifiManager;
-  this->notify();
+  this->emit(kExecutingWifiManager);
 
   if (!wifi_manager->autoConnect(pconfig_ssid)) {
     debugE("Failed to connect to wifi and config timed out. Restarting...");
 
-    this->output = kWifiDisconnected;
-    this->notify();
+    this->emit(kWifiDisconnected);
 
     ESP.restart();
   }
 
   debugI("Connected to wifi,");
   debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
-  this->output = kWifiConnectedToAP;
-  this->notify();
+  this->emit(kWifiConnectedToAP);
 
   if (should_save_config) {
     String new_hostname = custom_hostname.getValue();

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -20,7 +20,7 @@ Networking::Networking(String config_path, String ssid, String password,
     : Configurable{config_path} {
   this->hostname = new ObservableValue<String>(hostname);
 
-  this->output = kNoAP;
+  this->output = kWifiNoAP;
 
   preset_ssid = ssid;
   preset_password = password;
@@ -45,7 +45,7 @@ void Networking::check_connection() {
 
     // Might be futile to notify about a disconnection if it results in
     // a reboot anyway
-    this->emit(kDisconnected);
+    this->emit(kWifiDisconnected);
 
     ESP.restart();
   }
@@ -63,7 +63,7 @@ void Networking::setup() {
 
 void Networking::setup_saved_ssid() {
   WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
-  this->output = kDisconnected;
+  this->output = kWifiDisconnected;
   this->notify();
 
   uint32_t timer_start = millis();
@@ -83,7 +83,7 @@ void Networking::setup_saved_ssid() {
     debugI("Connected to wifi, SSID: %s (signal: %d)", WiFi.SSID().c_str(),
            WiFi.RSSI());
     debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
-    this->output = kConnectedToAP;
+    this->output = kWifiConnectedToAP;
     this->notify();
     WiFi.mode(WIFI_STA);
   }
@@ -110,13 +110,13 @@ void Networking::setup_wifi_manager() {
   config_ssid = "Configure " + config_ssid;
   const char* pconfig_ssid = config_ssid.c_str();
 
-  this->output = kWifiManager;
+  this->output = kExecutingWifiManager;
   this->notify();
 
   if (!wifi_manager->autoConnect(pconfig_ssid)) {
     debugE("Failed to connect to wifi and config timed out. Restarting...");
 
-    this->output = kDisconnected;
+    this->output = kWifiDisconnected;
     this->notify();
 
     ESP.restart();
@@ -124,7 +124,7 @@ void Networking::setup_wifi_manager() {
 
   debugI("Connected to wifi,");
   debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
-  this->output = kConnectedToAP;
+  this->output = kWifiConnectedToAP;
   this->notify();
 
   if (should_save_config) {

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -20,6 +20,8 @@ Networking::Networking(String config_path, String ssid, String password,
     : Configurable{config_path} {
   this->hostname = new ObservableValue<String>(hostname);
 
+  this->output = kNoAP;
+
   preset_ssid = ssid;
   preset_password = password;
   preset_hostname = hostname;
@@ -40,22 +42,30 @@ void Networking::check_connection() {
   if (WiFi.status() != WL_CONNECTED) {
     // if connection is lost, simply restart
     debugD("Wifi disconnected: restarting...");
+
+    // Might be futile to notify about a disconnection if it results in
+    // a reboot anyway
+    this->output = kDisconnected;
+    this->notify();
+
     ESP.restart();
   }
 }
 
-void Networking::setup(std::function<void(bool)> connection_cb) {
+void Networking::setup() {
   if (ap_ssid != "" && ap_password != "") {
-    setup_saved_ssid(connection_cb);
+    setup_saved_ssid();
   }
   if (ap_ssid == "" && WiFi.status() != WL_CONNECTED) {
-    setup_wifi_manager(connection_cb);
+    setup_wifi_manager();
   }
   app.onRepeat(1000, std::bind(&Networking::check_connection, this));
 }
 
-void Networking::setup_saved_ssid(std::function<void(bool)> connection_cb) {
+void Networking::setup_saved_ssid() {
   WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
+  this->output = kDisconnected;
+  this->notify();
 
   uint32_t timer_start = millis();
 
@@ -74,12 +84,13 @@ void Networking::setup_saved_ssid(std::function<void(bool)> connection_cb) {
     debugI("Connected to wifi, SSID: %s (signal: %d)", WiFi.SSID().c_str(),
            WiFi.RSSI());
     debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
-    connection_cb(true);
+    this->output = kConnectedToAP;
+    this->notify();
     WiFi.mode(WIFI_STA);
   }
 }
 
-void Networking::setup_wifi_manager(std::function<void(bool)> connection_cb) {
+void Networking::setup_wifi_manager() {
   should_save_config = false;
 
   // set config save notify callback
@@ -100,14 +111,22 @@ void Networking::setup_wifi_manager(std::function<void(bool)> connection_cb) {
   config_ssid = "Configure " + config_ssid;
   const char* pconfig_ssid = config_ssid.c_str();
 
+  this->output = kWifiManager;
+  this->notify();
+
   if (!wifi_manager->autoConnect(pconfig_ssid)) {
     debugE("Failed to connect to wifi and config timed out. Restarting...");
+
+    this->output = kDisconnected;
+    this->notify();
+
     ESP.restart();
   }
 
   debugI("Connected to wifi,");
   debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
-  connection_cb(true);
+  this->output = kConnectedToAP;
+  this->notify();
 
   if (should_save_config) {
     String new_hostname = custom_hostname.getValue();

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -45,8 +45,7 @@ void Networking::check_connection() {
 
     // Might be futile to notify about a disconnection if it results in
     // a reboot anyway
-    this->output = kDisconnected;
-    this->notify();
+    this->emit(kDisconnected);
 
     ESP.restart();
   }

--- a/src/net/networking.h
+++ b/src/net/networking.h
@@ -9,22 +9,30 @@
 
 #include "system/configurable.h"
 #include "system/observablevalue.h"
+#include "system/valueproducer.h"
 
-class Networking : public Configurable {
+enum WifiState {
+  kNoAP = 0,
+  kDisconnected,
+  kConnectedToAP,
+  kWifiManager
+};
+
+class Networking : public Configurable, public ValueProducer<WifiState> {
  public:
   Networking(String config_path, String ssid, String password, String hostname);
-  void setup(std::function<void(bool)> connection_cb);
+  void setup();
   ObservableValue<String>* get_hostname();
   virtual void get_configuration(JsonObject& doc) override final;
   virtual bool set_configuration(const JsonObject& config) override final;
   virtual String get_config_schema() override;
-
+  
   void reset_settings();
 
  protected:
   void check_connection();
-  void setup_saved_ssid(std::function<void(bool)> connection_cb);
-  void setup_wifi_manager(std::function<void(bool)> connection_cb);
+  void setup_saved_ssid();
+  void setup_wifi_manager();
 
  private:
   AsyncWebServer* server;

--- a/src/net/networking.h
+++ b/src/net/networking.h
@@ -12,10 +12,10 @@
 #include "system/valueproducer.h"
 
 enum WifiState {
-  kNoAP = 0,
-  kDisconnected,
-  kConnectedToAP,
-  kWifiManager
+  kWifiNoAP = 0,
+  kWifiDisconnected,
+  kWifiConnectedToAP,
+  kExecutingWifiManager
 };
 
 class Networking : public Configurable, public ValueProducer<WifiState> {

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -142,28 +142,15 @@ void SensESPApp::enable() {
   debugI("Enabling subsystems");
 
   // FIXME: Setting up mDNS discovery before networking can't work!
-  debugI("Subsystem: setup_discovery()");
   setup_discovery(networking->get_hostname()->get().c_str());
 
-  debugI("Subsystem: networking->setup()");
-  networking->setup([this](bool connected) {
-    if (connected) {
-      this->led_blinker->set_wifi_connected();
-    } else {
-      this->led_blinker->set_wifi_disconnected();
-      debugD("Not connected to wifi");
-    }
-  });
+  networking->setup();
+  networking->connect_to(led_blinker);
 
-  debugI("Subsystem: setup_OTA()");
   setup_ota();
 
-  debugI("Subsystem: http_server()");
   this->http_server->enable();
-  debugI("Subsystem: ws_client()");
   this->ws_client->enable();
-
-  debugI("WS client enabled");
 
   // initialize remote debugging
 

--- a/src/system/led_blinker.cpp
+++ b/src/system/led_blinker.cpp
@@ -38,7 +38,29 @@ void LedBlinker::set_input(WifiState new_value, uint8_t input_channel) {
       break;
   }
 }
+
+void LedBlinker::set_input(WSConnectionState new_value, uint8_t input_channel) {
+  switch (new_value) {
+    case kWSDisconnected:
+      this->set_server_disconnected();
+      break;
+    case kWSConnecting:
+      this->set_server_disconnected();
+      break;
+    case kWSAuthorizing:
+      this->set_server_disconnected();
+      break;
+    case kWSConnected:
+      this->set_server_connected();
+      break;
+    default:
+      this->set_server_disconnected();
+      break;
   }
+}
+
+void LedBlinker::set_input(int new_value, uint8_t input_channel) {
+  this->flip();
 }
 
 void LedBlinker::remove_blinker() {

--- a/src/system/led_blinker.cpp
+++ b/src/system/led_blinker.cpp
@@ -1,6 +1,7 @@
 
 #include "led_blinker.h"
 
+#include "net/networking.h"
 #include "sensesp.h"
 #include "sensesp_app.h"
 
@@ -15,6 +16,28 @@ LedBlinker::LedBlinker(int pin, bool enabled, int ws_connected_interval,
   if (enabled) {
     pinMode(pin, OUTPUT);
     this->set_state(0);
+  }
+}
+
+void LedBlinker::set_input(WifiState new_value, uint8_t input_channel) {
+  switch (new_value) {
+    case kNoAP:
+      this->set_wifi_disconnected();
+      break;
+    case kDisconnected:
+      this->set_wifi_disconnected();
+      break;
+    case kConnectedToAP:
+      this->set_wifi_connected();
+      break;
+    case kWifiManager:
+      this->set_wifi_disconnected();
+      break;
+    default:
+      this->set_wifi_disconnected();
+      break;
+  }
+}
   }
 }
 

--- a/src/system/led_blinker.cpp
+++ b/src/system/led_blinker.cpp
@@ -21,16 +21,16 @@ LedBlinker::LedBlinker(int pin, bool enabled, int ws_connected_interval,
 
 void LedBlinker::set_input(WifiState new_value, uint8_t input_channel) {
   switch (new_value) {
-    case kNoAP:
+    case kWifiNoAP:
       this->set_wifi_disconnected();
       break;
-    case kDisconnected:
+    case kWifiDisconnected:
       this->set_wifi_disconnected();
       break;
-    case kConnectedToAP:
+    case kWifiConnectedToAP:
       this->set_wifi_connected();
       break;
-    case kWifiManager:
+    case kExecutingWifiManager:
       this->set_wifi_disconnected();
       break;
     default:

--- a/src/system/led_blinker.h
+++ b/src/system/led_blinker.h
@@ -3,7 +3,9 @@
 
 #include <ReactESP.h>
 
-class LedBlinker {
+#include "net/networking.h"
+
+class LedBlinker : public ValueConsumer<WifiState> {
  private:
   int current_state = 0;
   int pin = 0;
@@ -25,6 +27,7 @@ class LedBlinker {
   void flip();
   LedBlinker(int pin, bool enabled, int ws_connected_interval = 100,
              int wifi_connected_interval = 1000, int offline_interval = 2000);
+  void set_input(WifiState new_value, uint8_t input_channel = 0) override;
 };
 
 #endif

--- a/src/system/led_blinker.h
+++ b/src/system/led_blinker.h
@@ -4,8 +4,11 @@
 #include <ReactESP.h>
 
 #include "net/networking.h"
+#include "net/ws_client.h"
 
-class LedBlinker : public ValueConsumer<WifiState> {
+class LedBlinker : public ValueConsumer<WifiState>,
+                   public ValueConsumer<WSConnectionState>,
+                   public ValueConsumer<int> {
  private:
   int current_state = 0;
   int pin = 0;
@@ -27,7 +30,15 @@ class LedBlinker : public ValueConsumer<WifiState> {
   void flip();
   LedBlinker(int pin, bool enabled, int ws_connected_interval = 100,
              int wifi_connected_interval = 1000, int offline_interval = 2000);
+  // ValueConsumer interface for ValueConsumer<WifiState> (Networking object
+  // state updates)
   void set_input(WifiState new_value, uint8_t input_channel = 0) override;
+  // ValueConsumer interface for ValueConsumer<WSConnectionState>
+  // (WSClient object state updates)
+  void set_input(WSConnectionState new_value, uint8_t input_channel = 0) override;
+  // ValueConsumer interface for ValueConsumer<int> (delta count producer
+  // updates)
+  void set_input(int new_value, uint8_t input_channel = 0) override;
 };
 
 #endif

--- a/src/system/observablevalue.h
+++ b/src/system/observablevalue.h
@@ -4,10 +4,23 @@
 #include "observable.h"
 #include "valueproducer.h"
 
-///////////////////
-// ObservableValue is simply a value that notifies its observers if
-// it gets changed.
+// forward declaration for the operator overloading functions
+template <class T>
+class ObservableValue;
 
+template <class T>
+bool operator==(ObservableValue<T> const& lhs, T const& rhs) {
+  return lhs.output == rhs;
+}
+
+template <class T>
+bool operator!=(ObservableValue<T> const& lhs, T const& rhs) {
+  return lhs.output != rhs;
+}
+
+/*
+ * ObservableValue is a value that notifies its observers if it gets changed.
+ */
 template <class T>
 class ObservableValue : public ValueProducer<T> {
  public:
@@ -15,14 +28,17 @@ class ObservableValue : public ValueProducer<T> {
 
   ObservableValue(const T& value) { ValueProducer<T>::output = value; }
 
-  void set(const T& value) {
-    this->ValueProducer<T>::emit(value);
-  }
+  void set(const T& value) { this->ValueProducer<T>::emit(value); }
 
   const T& operator=(const T& value) {
     set(value);
     return value;
   }
+
+  template <class U>
+  friend bool operator==(ObservableValue<U> const& lhs, U const& rhs);
+  template <class U>
+  friend bool operator!=(ObservableValue<U> const& lhs, U const& rhs);
 };
 
 #endif


### PR DESCRIPTION
Previously, Networking and WSClient objects reported their state using callbacks which wasn't in line with the rest of the architecture and was also quite limiting in what you could do.

Now, Networking and WSClient are both ValueProducers that notify their consumers of state changes. LedBlinker is one such consumer.

This change in itself is not a very significant one but paves way for refactoring the LedBlinker class and also, with a bit of further refactoring, allows for example for having the device state to be displayed on a small I2C OLED display.