### PR TITLE
Split SensESPApp initialization to separate constructor and setup calls

### DIFF
--- a/examples/hysteresis.cpp
+++ b/examples/hysteresis.cpp
@@ -10,7 +10,7 @@ ReactESP app([]() {
   SetupSerialDebug(115200);
 
   sensesp_app = new SensESPApp("sensesp-hysteresis-example", "My WiFi SSID",
-                               "my_wifi_password", "skserver.lan", 80, NONE);
+                               "my_wifi_password", "skserver.lan", 80);
 
   const char* sk_path = "environment.indoor.illuminance";
   const char* analog_in_config_path = "/indoor_illuminance/analog_in";

--- a/examples/lambda_transform.cpp
+++ b/examples/lambda_transform.cpp
@@ -13,7 +13,7 @@ ReactESP app([]() {
   // an equivalent alternative to using the SensESPAppBuilder class.
 
   sensesp_app = new SensESPApp("sensesp-illum-example", "My WiFi SSID",
-                               "my_wifi_password", "skdev.lan", 80, NONE);
+                               "my_wifi_password", "skdev.lan", 80);
 
   // To find valid Signal K Paths that fits your need you look at this link:
   // https://signalk.org/specification/1.4.0/doc/vesselsBranch.html

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -36,12 +36,23 @@ void SetupSerialDebug(uint32_t baudrate) {
 
 static char* permission_strings[] = {"readonly", "readwrite", "admin"};
 
+/*
+ * This constructor must be only used in SensESPAppBuilder
+ */
+SensESPApp::SensESPApp(bool defer_setup) {}
+
 SensESPApp::SensESPApp(String preset_hostname, String ssid,
                        String wifi_password, String sk_server_address,
-                       uint16_t sk_server_port, StandardSensors sensors,
-                       int led_pin, bool enable_led, int led_ws_connected,
-                       int led_wifi_connected, int led_offline,
-                       SKPermissions permissions) {
+                       uint16_t sk_server_port)
+    : preset_hostname{preset_hostname},
+      ssid{ssid},
+      wifi_password{wifi_password},
+      sk_server_address{sk_server_address},
+      sk_server_port{sk_server_port} {
+  setup();
+}
+
+void SensESPApp::setup() {
   // initialize filesystem
 #ifdef ESP8266
   if (!SPIFFS.begin()) {
@@ -79,7 +90,7 @@ SensESPApp::SensESPApp(String preset_hostname, String ssid,
 
   this->ws_client =
       new WSClient("/system/sk", sk_delta, sk_server_address, sk_server_port,
-                                 permission_strings[(int)permissions]);
+                                 permission_strings[(int)requested_permissions]);
 
   // create a led blinker and connect it to its data sources
 

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -44,11 +44,10 @@ void SetupSerialDebug(uint32_t baudrate);
 
 class SensESPApp {
  public:
+  SensESPApp(bool defer_setup);
   SensESPApp(String hostname = "SensESP", String ssid = "", String wifi_password = "",
-             String sk_server_address = "", uint16_t sk_server_port = 0,
-             StandardSensors sensors = ALL, int led_pin = LED_PIN,
-             bool enable_led = ENABLE_LED, int led_ws_connected = 200,
-             int led_wifi_connected = 1000, int led_offline = 2000, SKPermissions permissions = READWRITE);
+             String sk_server_address = "", uint16_t sk_server_port = 0);
+  void setup();
   void enable();
   void reset();
   String get_hostname();
@@ -84,7 +83,36 @@ class SensESPApp {
    */
   bool isSignalKConnected() { return ws_client->is_connected(); }
 
+ protected:
+  // setters for all constructor arguments
+
+  const SensESPApp* set_preset_hostname(String preset_hostname) { this->preset_hostname = preset_hostname; }
+  const SensESPApp* set_ssid(String ssid) { this->ssid = ssid; }
+  const SensESPApp* set_wifi_password(String wifi_password) { this->wifi_password = wifi_password; }
+  const SensESPApp* set_sk_server_address(String sk_server_address) { this->sk_server_address = sk_server_address; }
+  const SensESPApp* set_sk_server_port(uint16_t sk_server_port) { this->sk_server_port = sk_server_port; }
+  const SensESPApp* set_sensors(StandardSensors sensors) { this->sensors = sensors; }
+  const SensESPApp* set_led_pin(int led_pin) { this->led_pin = led_pin; }
+  const SensESPApp* set_enable_led(bool enable_led) { this->enable_led = enable_led; }
+  const SensESPApp* set_led_ws_connected(int led_ws_connected) { this->led_ws_connected = led_ws_connected; }
+  const SensESPApp* set_led_wifi_connected(int led_wifi_connected) { this->led_wifi_connected = led_wifi_connected; }
+  const SensESPApp* set_led_offline(int led_offline) { this->led_offline = led_offline; }
+  const SensESPApp* set_requested_permissions(SKPermissions permissions) { this->requested_permissions = permissions; }
+
  private:
+  String preset_hostname = "SensESP";
+  String ssid = "";
+  String wifi_password = "";
+  String sk_server_address = "";
+  uint16_t sk_server_port = 0;
+  StandardSensors sensors = ALL;
+  int led_pin = LED_PIN;
+  bool enable_led = ENABLE_LED;
+  int led_ws_connected = 200;
+  int led_wifi_connected = 1000;
+  int led_offline = 2000;
+  SKPermissions requested_permissions = READWRITE;
+
   void initialize();
   void setup_standard_sensors(ObservableValue<String>* hostname,
                               StandardSensors enabled_sensors = ALL);

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -18,45 +18,47 @@ class SensESPAppBuilder {
   int led_offline = 5000;
   SKPermissions sk_server_permissions = READWRITE;
 
+  SensESPApp* app;
+
  public:
-  SensESPAppBuilder() {}
+  SensESPAppBuilder() {
+    app = new SensESPApp(true);
+  }
   SensESPAppBuilder* set_wifi(String ssid, String password) {
-    this->ssid = ssid;
-    this->password = password;
+    app->set_ssid(ssid);
+    app->set_wifi_password(password);
     return this;
   }
   SensESPAppBuilder* set_sk_server(String address, uint16_t port, SKPermissions permissions = READWRITE) {
-    this->sk_server_address = address;
-    this->sk_server_port = port;
-    this->sk_server_permissions = permissions;
+    app->set_sk_server_address(address);
+    app->set_sk_server_port(port);
+    app->set_requested_permissions(permissions);
     return this;
   }
   SensESPAppBuilder* set_standard_sensors(StandardSensors sensors = ALL) {
-    this->sensors = sensors;
+    app->set_sensors(sensors);
     return this;
   }
   SensESPAppBuilder* set_led_pin(int led_pin) {
-    this->led_pin = led_pin;
+    app->set_led_pin(led_pin);
     return this;
   }
   SensESPAppBuilder* set_led_blinker(bool enabled, int websocket_connected,
                                      int wifi_connected, int offline) {
-    this->enable_led = enabled;
-    this->led_ws_connected = websocket_connected;
-    this->led_wifi_connected = wifi_connected;
-    this->led_offline = offline;
+    app->set_enable_led(enabled);
+    app->set_led_ws_connected(websocket_connected);
+    app->set_led_wifi_connected(wifi_connected);
+    app->set_led_offline(offline);
     return this;
   }
   SensESPAppBuilder* set_hostname(String hostname) {
-    this->hostname = hostname;
+    app->set_preset_hostname(hostname);
     return this;
   }
 
   SensESPApp* get_app() {
-    return new SensESPApp(hostname, ssid, password, sk_server_address,
-                          sk_server_port, sensors, led_pin, enable_led,
-                          led_ws_connected, led_wifi_connected, led_offline,
-                          sk_server_permissions);
+    app->setup();
+    return app;
   }
 };
 


### PR DESCRIPTION
The SensESPApp constructor had a rather long argument list, with most arguments being rather inessential. This wasn't great as a public interface and would've caused future refactoring of the arguments always break the public interface.

This change is required to limit the growth of the constructor argument list length, to maintain separation of public and non-public interfaces and to only have the essential arguments in the public constructor.