### PR TITLE
Increase output buffer size on ESP32

### DIFF
--- a/src/net/http.cpp
+++ b/src/net/http.cpp
@@ -175,10 +175,12 @@ void HTTPServer::handle_not_found(AsyncWebServerRequest* request) {
 }
 
 void HTTPServer::handle_config_list(AsyncWebServerRequest* request) {
+  // to save memory, guesstimate the required output buffer size based
+  // on the number of elements
+  auto output_buffer_size = 200 * configurables.size();
   AsyncResponseStream* response =
       request->beginResponseStream("application/json");
-  DynamicJsonDocument json_doc(1024);
-  // JsonObject root = json_doc.as<JsonObject>();
+  DynamicJsonDocument json_doc(output_buffer_size);
   JsonArray arr = json_doc.createNestedArray("keys");
   for (auto it = configurables.begin(); it != configurables.end(); ++it) {
     arr.add(it->first);


### PR DESCRIPTION
As reported by @KEGustafsson :

The web config UI wouldn't work with more than six sensors. The
culprit was found to be the output buffer size. It's now increased
to 4096 on ESP32. On ESP8266 memory is at premium and the amount
of sensors likely less anyway, so there the buffer size was left at
1024.