### PR TITLE
Changed to a non-global fusion filter

### DIFF
--- a/src/sensors/sensor_nxp_fxos8700_fxas21002.cpp
+++ b/src/sensors/sensor_nxp_fxos8700_fxas21002.cpp
@@ -15,10 +15,6 @@
 #define FXAS_CR1_ODR_BITS_LOC (2) //ODR bits are in positions 4:2
 #define N2K_INVALID_FLOAT (-1e-9) //NMEA2000 value for unavailable parameters
 
-Adafruit_NXPSensorFusion filter;  // when placed inside class, results from this
-                                  // filter return Heading=0.0 always. Other two
-                                  // filters (see below) work OK inside class
-
 //  Constructor creates an accelerometer/magnetometer object (fxos_)
 //  and a gyroscope object (fxas_)
 SensorNXP_FXOS8700_FXAS21002::SensorNXP_FXOS8700_FXAS21002()

--- a/src/sensors/sensor_nxp_fxos8700_fxas21002.h
+++ b/src/sensors/sensor_nxp_fxos8700_fxas21002.h
@@ -28,8 +28,6 @@
 //   please support PJRC and open-source hardware by purchasing products
 //   from PJRC!  Written by PJRC, adapted by Limor Fried for Adafruit Industries.
 
-// Last edits by Bjarne Hansen 2020-10-20
-
 // Relies on Serial object existing for sending data/diagnostics to serial port
 
 #include <stdint.h>
@@ -65,7 +63,7 @@ class SensorNXP_FXOS8700_FXAS21002 {
   // why. Currently declared in *.cpp file  The other two filters are fine when
   // declared inside class. Adafruit_NXP_SensorFusion filter runs fine on ESP32.
   // Adafruit_Madgwick filter;  // faster than NXP
-  // Adafruit_Mahony filter;    // fastest/smallest
+  Adafruit_Mahony filter;    // fastest/smallest
 
   Adafruit_FXOS8700 fxos_;    // the combined magnetometer + accelerometer
   Adafruit_FXAS21002C fxas_;  // the gyroscope


### PR DESCRIPTION
The default fusion filter selected in the orientation sensor files has been changed from Adafruit_NXPSensorFusion (which was global) to Adafruit_Mahony (which is part of the class). This can save runtime RAM in cases where SensESP is not using the orientation sensor yet the orientation code is linked in anyway. Testing suggests this doesn't happen on ESP32 boards but may on ESP8266. 