### PR TITLE
Remove global pointer from Orientation source

### DIFF
--- a/examples/fx8700_heading_example.cpp
+++ b/examples/fx8700_heading_example.cpp
@@ -81,8 +81,7 @@ ReactESP app([]() {
   */
 
   // Magnetic Heading data source, using 9 Degrees-of-freedom combination sensor
-  Orientation9DOF NXP9DOF =
-      Orientation9DOF(PIN_I2C_SDA, PIN_I2C_SCL, config_path_heading);
+  auto* NXP9DOF = new Orientation9DOF(PIN_I2C_SDA, PIN_I2C_SCL, config_path_heading);
 
   /*  Uncomment the following line during calibration - this will stream raw
      readings to serial port, where they can be intercepted by the Motion Sensor
@@ -92,7 +91,7 @@ ReactESP app([]() {
       After calibration values have been written to EEPROM/Flash, re-comment
      following line to restore normal program flow.
   */
-  //  NXP9DOF.stream_raw_values();  //continuous raw data collection. This call
+  //  NXP9DOF->stream_raw_values();  //continuous raw data collection. This call
   //  does not return.
 
   // Start periodic readings from orientation sensor. Note that the physical
@@ -103,18 +102,18 @@ ReactESP app([]() {
   //  or faster than any of the other parameters (otherwise those other
   //  parameters will not update at the rate you expect).
   auto* sensor_heading =
-      new Read9DOF(&NXP9DOF, compass_hdg, ORIENTATION_SAMPLING_INTERVAL_MS,
+      new Read9DOF(NXP9DOF, compass_hdg, ORIENTATION_SAMPLING_INTERVAL_MS,
                    config_path_heading);
   sensor_heading->connect_to(
       new SKOutputNumber(sk_path_heading, config_path_orientation_skpath));
 
   auto* sensor_pitch = new Read9DOF(
-      &NXP9DOF, pitch, ORIENTATION_SAMPLING_INTERVAL_MS * 5, config_path_pitch);
+      NXP9DOF, pitch, ORIENTATION_SAMPLING_INTERVAL_MS * 5, config_path_pitch);
   sensor_pitch->connect_to(
       new SKOutputNumber(sk_path_pitch, config_path_orientation_skpath));
 
   auto* sensor_roll = new Read9DOF(
-      &NXP9DOF, roll, ORIENTATION_SAMPLING_INTERVAL_MS * 5, config_path_roll);
+      NXP9DOF, roll, ORIENTATION_SAMPLING_INTERVAL_MS * 5, config_path_roll);
   sensor_roll->connect_to(
       new SKOutputNumber(sk_path_roll, config_path_orientation_skpath));
 
@@ -122,37 +121,37 @@ ReactESP app([]() {
       as well, uncomment the appropriate connections from the following.
 
  auto* sensor_turn_rate =
-      new Read9DOF(&NXP9DOF, rate_of_turn, ORIENTATION_SAMPLING_INTERVAL_MS*5,
+      new Read9DOF(NXP9DOF, rate_of_turn, ORIENTATION_SAMPLING_INTERVAL_MS*5,
                    config_path_turn_rate);
   sensor_turn_rate->connect_to(
       new SKOutputNumber(sk_path_turn_rate, config_path_orientation_skpath));
 
  auto* sensor_roll_rate =
-      new Read9DOF(&NXP9DOF, rate_of_roll, ORIENTATION_SAMPLING_INTERVAL_MS*5,
+      new Read9DOF(NXP9DOF, rate_of_roll, ORIENTATION_SAMPLING_INTERVAL_MS*5,
                    config_path_roll_rate);
   sensor_roll_rate->connect_to(
       new SKOutputNumber(sk_path_roll_rate, config_path_orientation_skpath));
 
  auto* sensor_pitch_rate =
-      new Read9DOF(&NXP9DOF, rate_of_pitch, ORIENTATION_SAMPLING_INTERVAL_MS*5,
+      new Read9DOF(NXP9DOF, rate_of_pitch, ORIENTATION_SAMPLING_INTERVAL_MS*5,
                    config_path_pitch_rate);
   sensor_pitch_rate->connect_to(
       new SKOutputNumber(sk_path_pitch_rate, config_path_orientation_skpath));
 
  auto* sensor_accel_x =
-      new Read9DOF(&NXP9DOF, acceleration_x, ORIENTATION_SAMPLING_INTERVAL_MS*5,
+      new Read9DOF(NXP9DOF, acceleration_x, ORIENTATION_SAMPLING_INTERVAL_MS*5,
                    config_path_accel_x);
   sensor_accel_x->connect_to(
       new SKOutputNumber(sk_path_accel_x, config_path_orientation_skpath));
 
  auto* sensor_accel_y =
-      new Read9DOF(&NXP9DOF, acceleration_y, ORIENTATION_SAMPLING_INTERVAL_MS*5,
+      new Read9DOF(NXP9DOF, acceleration_y, ORIENTATION_SAMPLING_INTERVAL_MS*5,
                    config_path_accel_y);
   sensor_accel_y->connect_to(
       new SKOutputNumber(sk_path_accel_y, config_path_orientation_skpath));
 
  auto* sensor_accel_z =
-      new Read9DOF(&NXP9DOF, acceleration_z, ORIENTATION_SAMPLING_INTERVAL_MS*5,
+      new Read9DOF(NXP9DOF, acceleration_z, ORIENTATION_SAMPLING_INTERVAL_MS*5,
                    config_path_accel_z);
   sensor_accel_z->connect_to(
       new SKOutputNumber(sk_path_accel_z, config_path_orientation_skpath));
@@ -171,7 +170,7 @@ ReactESP app([]() {
   Roll is rotation about the X-axis. Positive is rolling to starboard.
   Turn-rate is rotation about the Z-axis. Positive is increasing bearing.
   Roll-rate is rotation about the X-axis. Positive is rolling to starboard.
-  Pitch-rate is rotation about the Y-axis. Positive is ***bow falling.
+  Pitch-rate is rotation about the Y-axis. Positive is bow rising.
 
   If the sensor is mounted differently, or you prefer an alternate nomenclature,
   the get___() methods in sensor_NXP_FXOS8700_FXAS21002.cpp can be adjusted.

--- a/src/sensors/orientation_9dof_input.cpp
+++ b/src/sensors/orientation_9dof_input.cpp
@@ -4,10 +4,6 @@
 
 #include "sensesp.h"
 
-// pointer to physical sensor
-SensorNXP_FXOS8700_FXAS21002*
-    sensor_fxos_fxas;  // if sensor_fxos_fxas is a member of Orientation9DOF,
-                       // then when called in onRepeat it causes CPU panic
 
 // Orientation9DOF represents a 9-Degrees-of-Freedom sensor (magnetometer,
 // accelerometer, and gyroscope), such as an
@@ -48,7 +44,7 @@ Read9DOF::Read9DOF(Orientation9DOF* orientation_9dof,
       val_type{val_type},
       read_delay{read_delay} {
   load_configuration();
-  sensor_fxos_fxas->initFilter(this->read_delay);
+  orientation_9dof->sensor_fxos_fxas->initFilter(this->read_delay);
 }
 
 // Setup repeated readings from combination sensor.
@@ -72,38 +68,36 @@ void Read9DOF::enable() {
 //  for whichever parameter _is_ updated the fastest - this
 //  ensures that that parameter and all others are never stale.
 void Read9DOF::update() {
-  // if sensor_fxos_fxas is a member of Orientation9DOF, then when called in
-  // onRepeat it causes CPU panic
   switch (val_type) {
     case (compass_hdg):
       // sensor is read and filter called, only for compass_hdg
       // remaining parameters are obtained from most recent filter results
-      sensor_fxos_fxas->gatherOrientationDataOnce(false);
-      output = sensor_fxos_fxas->getHeadingRadians();
+      orientation_9dof->sensor_fxos_fxas->gatherOrientationDataOnce(false);
+      output = orientation_9dof->sensor_fxos_fxas->getHeadingRadians();
       break;
     case (roll):
-      output = sensor_fxos_fxas->getRollRadians();
+      output = orientation_9dof->sensor_fxos_fxas->getRollRadians();
       break;
     case (pitch):
-      output = sensor_fxos_fxas->getPitchRadians();
+      output = orientation_9dof->sensor_fxos_fxas->getPitchRadians();
       break;
     case (acceleration_x):
-      output = sensor_fxos_fxas->getAccelerationX();
+      output = orientation_9dof->sensor_fxos_fxas->getAccelerationX();
       break;
     case (acceleration_y):
-      output = sensor_fxos_fxas->getAccelerationY();
+      output = orientation_9dof->sensor_fxos_fxas->getAccelerationY();
       break;
     case (acceleration_z):
-      output = sensor_fxos_fxas->getAccelerationZ();
+      output = orientation_9dof->sensor_fxos_fxas->getAccelerationZ();
       break;
     case (rate_of_turn):
-      output = sensor_fxos_fxas->getRateOfTurn();
+      output = orientation_9dof->sensor_fxos_fxas->getRateOfTurn();
       break;
     case (rate_of_pitch):
-      output = sensor_fxos_fxas->getRateOfPitch();
+      output = orientation_9dof->sensor_fxos_fxas->getRateOfPitch();
       break;
     case (rate_of_roll):
-      output = sensor_fxos_fxas->getRateOfRoll();
+      output = orientation_9dof->sensor_fxos_fxas->getRateOfRoll();
       break;
     default:
       output = 0.0;

--- a/src/sensors/orientation_9dof_input.h
+++ b/src/sensors/orientation_9dof_input.h
@@ -26,8 +26,11 @@ class Orientation9DOF : public Sensor {
   Orientation9DOF(uint8_t pin_i2c_sda, uint8_t pin_i2c_scl,
                   String config_path = "");
   void stream_raw_values(void);  // used when calibrating
- private:
-  uint8_t addr;  // unused
+  // pointer to physical sensor
+  SensorNXP_FXOS8700_FXAS21002 *sensor_fxos_fxas;
+
+private:
+ uint8_t addr;  // unused
 };
 
 // Pass one of these in Read9DOF() constructor corresponding to type of value

--- a/src/sensors/sensor_nxp_fxos8700_fxas21002.cpp
+++ b/src/sensors/sensor_nxp_fxos8700_fxas21002.cpp
@@ -16,9 +16,9 @@
 #define N2K_INVALID_FLOAT (-1e-9) //NMEA2000 value for unavailable parameters
 
 //  Constructor creates an accelerometer/magnetometer object (fxos_)
-//  and a gyroscope object (fxas_)
+//  a gyroscope object (fxas_), and filter
 SensorNXP_FXOS8700_FXAS21002::SensorNXP_FXOS8700_FXAS21002()
-    : fxos_(0x8700A, 0x8700B), fxas_(0x0021002C) {}
+    : filter(), fxos_(0x8700A, 0x8700B), fxas_(0x0021002C) {}
 
 //  Connect to FXOS8700 & FXAS21002 sensor combination using I2C.
 //  To use default Arduino I2C pins, pass pin_i2c_sda and pin_i2c_scl = -1

--- a/src/sensors/sensor_nxp_fxos8700_fxas21002.h
+++ b/src/sensors/sensor_nxp_fxos8700_fxas21002.h
@@ -58,12 +58,9 @@ class SensorNXP_FXOS8700_FXAS21002 {
 
  private:
   // pick one of three following filters: slower == better quality output
-  // Adafruit_NXPSensorFusion filter; // slowest.  Note that this one needs to
-  // be declared outside of class, else heading returns 0.0 always. Unsure
-  // why. Currently declared in *.cpp file  The other two filters are fine when
-  // declared inside class. Adafruit_NXP_SensorFusion filter runs fine on ESP32.
+  Adafruit_NXPSensorFusion filter;  // slowest/largest. Runs fine on ESP32.
   // Adafruit_Madgwick filter;  // faster than NXP
-  Adafruit_Mahony filter;    // fastest/smallest
+  // Adafruit_Mahony filter;    // fastest/smallest
 
   Adafruit_FXOS8700 fxos_;    // the combined magnetometer + accelerometer
   Adafruit_FXAS21002C fxas_;  // the gyroscope


### PR DESCRIPTION
Issue #239 and @joelkoz (https://github.com/SignalK/SensESP/issues/239#issuecomment-724183941) suggested an additional improvement to the orientation code. The pointer, which was global, to the dynamically-allocated `sensor_fxos_fxas` has been moved into the class `Orientation9DOF`. 

During testing this change, I also discovered how to move the object `Adafruit_NXPSensorFusion filter` inside the class. That filter (the subject of PR #247) had been global as otherwise the filter didn't function. This filter is now defined in 'sensor_nxp_fx8700_fxas21002.h` together with the two other filters that had not had this limitation.

This PR edits `fx8700_heading_example.cpp` and the four orientation source files.