### PR TITLE
Fixed a bug in Integrator Transform; gave it a reset() method

### DIFF
--- a/src/transforms/integrator.cpp
+++ b/src/transforms/integrator.cpp
@@ -21,6 +21,8 @@ void Integrator::set_input(float input, uint8_t inputChannel) {
   this->emit(value);
 }
 
+void Integrator::reset() {value = 0;}
+
 void Integrator::get_configuration(JsonObject& root) {
   root["k"] = k;
   root["value"] = value;

--- a/src/transforms/integrator.cpp
+++ b/src/transforms/integrator.cpp
@@ -17,7 +17,7 @@ void Integrator::enable() {
 }
 
 void Integrator::set_input(float input, uint8_t inputChannel) {
-  value += input;
+  value += input * k;
   this->emit(value);
 }
 

--- a/src/transforms/integrator.h
+++ b/src/transforms/integrator.h
@@ -12,6 +12,7 @@ class Integrator : public NumericTransform {
   virtual void get_configuration(JsonObject& doc) override final;
   virtual bool set_configuration(const JsonObject& config) override final;
   virtual String get_config_schema() override;
+  void reset();
 
  private:
   float value = 0;


### PR DESCRIPTION
Fixed a bug in the Integrator Transform - it didn't use the multiplier (`k`) in the calculation of `value`.

Added a public method to reset `value` to 0. Will be used in conjuction with a new LambdaConsumer to reset the value when the user does something (pushes a button, for example).