### PR TITLE
Add a 50 ms timeout to the pulseIn(...) statement.

### DIFF
--- a/src/sensors/ultrasonic_distance.cpp
+++ b/src/sensors/ultrasonic_distance.cpp
@@ -22,7 +22,7 @@ void UltrasonicDistance::enable() {
       yield();
     }
     digitalWrite(trigger_pin, LOW);
-    this->emit(pulseIn(input_pin, HIGH));
+    this->emit(pulseIn(input_pin, HIGH, 50000));  // 50 ms timeout
   });
 }
 


### PR DESCRIPTION
The code will hang with a Security Token loop when the sensor is not connected if this delay is not present.