### PR TITLE
Split frequency from Wire.begin() for ESP8266 compatibility

### DIFF
--- a/src/sensors/sensor_nxp_fxos8700_fxas21002.cpp
+++ b/src/sensors/sensor_nxp_fxos8700_fxas21002.cpp
@@ -42,9 +42,10 @@ bool SensorNXP_FXOS8700_FXAS21002::connect(int pin_i2c_sda,
     }
   }//end of loading calibration
 
-  Wire.begin(pin_i2c_sda, pin_i2c_scl, 400000 );
+  Wire.begin(pin_i2c_sda, pin_i2c_scl);
+  Wire.setClock(400000);  // separate from begin() for ESP82666 compatibility
   if (!startSensors()) {
-      debugE("Failed to find sensors");
+    debugE("Failed to find sensors");
     return false;
   }
 


### PR DESCRIPTION
Issue #256 noted that the `begin()` method of the Wire library differs between the ESP8266 and ESP32 versions. This PR removes the frequency from the begin() call, and instead makes a separate call to `setClock()`  The code is now compatible with both versions of the Wire library and fixes #256.

I've verified that it compiles without warnings for the d1_mini and ESP32-Wrover, and runs on the Wrover. I don't have a board to test the d1_mini executable (but have one ordered).