### PR TITLE
Ads1x15 fix and enhancement

### DIFF
--- a/examples/ads1x15_volt_meter.cpp
+++ b/examples/ads1x15_volt_meter.cpp
@@ -9,7 +9,6 @@
 #include "sensesp_app.h"
 #include "sensors/ads1x15.h"
 #include "signalk/signalk_output.h"
-#include "transforms/ads1x15_voltage.h"
 #include "transforms/linear.h"
 #include "transforms/voltage_multiplier.h"
 
@@ -21,52 +20,69 @@ ReactESP app([]() {
   sensesp_app = new SensESPApp();
 
   // Create an instance of a ADS1115 Analog-to-Digital Converter (ADC).
-  ADS1x15CHIP_t chip = ADS1115chip;
+  // You could use an ADS1015 (the 12-bit version of the chip) instead.
   adsGain_t gain = GAIN_TWOTHIRDS;
   ADS1115* ads1115 = new ADS1115(0x48, gain);
 
-  // Create an instance of ADS1115Value to read a specific channel of the ADC,
-  // the channel on the physical chip that the input is connected to.
+  // Create an instance of ADS1115Voltage to read a specific channel of the ADC,
+  // (the channel on the physical chip that the input is connected to), and
+  // convert it back into the voltage that was read by the ADC.
   uint8_t channel_12V = 0;
   uint read_delay_12V = 500;
 
-  auto* alt_12v_voltage = new ADS1115Value(ads1115, channel_12V, read_delay_12V,
-                                           "/12V_Alt/ADC read delay");
+  auto* alt_12v_voltage = new ADS1115Voltage(ads1115, channel_12V, read_delay_12V,
+                                             "/12V_Alt/ADC read delay");
 
-  // The output from the ADS1115 needs to be sent through some transforms to get
-  // it ready to display in Signal K:
-  // - ADS1x15Voltage() takes the output from the ADS1115 and converts it back
-  // into the voltage that was read by the chip.
+  // The output from ADS1115Voltage needs to be sent through some transforms to get
+  // it into Signal K:
   // - VoltageMultiplier() reverses the effect of the physical voltage divider
-  // that was used to step the source voltage
-  //   down to less than 5 volts, which is the maximum the ADC can read. The
-  //   output is the original voltage.
+  //   that was used to step the source voltage down to less than 5 volts, which is
+  //   the maximum the ADC can read. The output is the original voltage.
   // - SKOutputNumber() is a specialized transport to send a float value to the
-  // Signal K server.
+  //   Signal K server. 
+  // - NOTE: there are more versions of SKOutput(), each used to send the
+  //   appropriate type to Signal K: SKOutputInt, SKOutputBool, and SKOutputString.
   //
   // To find valid Signal K Paths that fits your need you look at this link:
   // https://signalk.org/specification/1.4.0/doc/vesselsBranch.html#vesselsregexpelectrical
 
-  alt_12v_voltage->connect_to(new ADS1x15Voltage(chip, gain))
-      ->connect_to(new VoltageMultiplier(
-          10000, 4730,
-          "/12V_Alt/VoltMultiplier"))  // Measured ohm values of R1 and R2 in the
-                                      // physical voltage divider
+  alt_12v_voltage->connect_to(new VoltageMultiplier(
+                                  10000, 4730,                // Measured ohm values of R1 and
+                                  "/12V_Alt/VoltMultiplier")) // R2 in the physical voltage divider
       ->connect_to(new SKOutputNumber("electrical.alternators.12V.voltage",
                                       "/12V_Alt/skPath"));
 
-  // Create a second instance of ADS1115Value to read from the same physical
-  // ADS1115, but from channel 1 instead of 0.
-  uint8_t channel_24V = 1;
-  uint read_delay_24V = 500;
+  
+  // Create an instance of ADS1115RawValue to read from the same physical ADS1115, but
+  // from channel 1 instead of 0. ADS1115RawValue does NOT convert the value into the 
+  // voltage that was read - instead, it outputs an int from 0 to 32,768. ADS1115RawValue
+  // is used when you don't care about the actual voltage, because you're measuring something
+  // like a distance, or the percentage fullness of a tank, which is what this example is.
+  uint8_t channel_tank_level = 1;
+  uint read_delay_tank_level = 500;
 
-  auto* alt_24v_voltage = new ADS1115Value(ads1115, channel_24V, read_delay_24V,
-                                           "/24V_Alt/ADC read delay");
+  auto* tank_level = new ADS1115RawValue(ads1115, channel_tank_level, read_delay_tank_level,
+                                         "/tank_level/read delay");
 
-  alt_24v_voltage->connect_to(new ADS1x15Voltage(chip, gain))
-      ->connect_to(new VoltageMultiplier(21800, 4690, "/24V_Alt/VoltMultiplier"))
-      ->connect_to(new SKOutputNumber("electrical.alternators.24V.voltage",
-                                      "/24V_Alt/skPath"));
+  // In this example, the ADS1115 is reading the output of a capacitive sensor in the form
+  // of a long strip, attached vertically to the outside of a plastic water tank. When the
+  // tank is empty, the ADS1115 reads a value of 800. When full, it reads 28,800.
+  // So the range is 28,000 (28,800 - 800).
+  // To convert the Raw Value output into a percentage, we need a multiplier and an offset:
+  // Range / 100% = 280, so the multiplier is 1 / 280 = 0.003571429
+  // The Raw Value at empty is 800: 800 x multiplier (0.003571429) = 2.8571432, so the offset needs
+  // to be -2.8571432 to make the output 0 (percent) when the tank is empty.
+  // The Raw Value at full is 28,800: 28,800 x multiplier (0.003571429) = 102.8571552.
+  // Add the offset (-2.8571432) and you get 100.000012 (percent).
+  // We use a Linear Transform to apply the multiplier and the offset, and then
+  // SKOutputNumber to send the output (the percentage of tank fullness) to Signal K.
+
+  float multiplier = 0.003571429;
+  float offset = -2.8571432;
+
+  tank_level->connect_to(new Linear(multiplier, offset, "/tank_level/linear"))
+      ->connect_to(new SKOutputNumber("tanks.freshWater.currentLevel",
+                                      "/tank_level/skPath"));
 
   sensesp_app->enable();
 });

--- a/examples/ads1x15_volt_meter.cpp
+++ b/examples/ads1x15_volt_meter.cpp
@@ -27,7 +27,7 @@ ReactESP app([]() {
   // Create an instance of ADS1115Voltage to read a specific channel of the ADC,
   // (the channel on the physical chip that the input is connected to), and
   // convert it back into the voltage that was read by the ADC.
-  uint8_t channel_12V = 0;
+  ADS1x15Channel_t channel_12V = channel_0;
   uint read_delay_12V = 500;
 
   auto* alt_12v_voltage = new ADS1115Voltage(ads1115, channel_12V, read_delay_12V,
@@ -58,7 +58,7 @@ ReactESP app([]() {
   // voltage that was read - instead, it outputs an int from 0 to 32,768. ADS1115RawValue
   // is used when you don't care about the actual voltage, because you're measuring something
   // like a distance, or the percentage fullness of a tank, which is what this example is.
-  uint8_t channel_tank_level = 1;
+  ADS1x15Channel_t channel_tank_level = channel_1;
   uint read_delay_tank_level = 500;
 
   auto* tank_level = new ADS1115RawValue(ads1115, channel_tank_level, read_delay_tank_level,

--- a/src/sensors/ads1x15.cpp
+++ b/src/sensors/ads1x15.cpp
@@ -4,10 +4,10 @@
 
 template <class T_Ada_1x15>
 ADS1x15<T_Ada_1x15>::ADS1x15(uint8_t addr, adsGain_t gain, String config_path)
-    : Sensor(config_path), gain{gain} {
-  ads = new T_Ada_1x15(addr);
-  ads->begin();
-  ads->setGain(gain);
+    : Sensor(config_path), gain_{gain} {
+  ads_ = new T_Ada_1x15(addr);
+  ads_->begin();
+  ads_->setGain(gain_);
 }
 
 // define all possible instances of an ADS1x15
@@ -19,26 +19,26 @@ template <class T_ads_1x15>
 ADS1x15RawValue<T_ads_1x15>::ADS1x15RawValue(T_ads_1x15* ads1x15, uint8_t channel,
                                        uint read_delay, String config_path)
     : NumericSensor(config_path),
-      ads1x15{ads1x15},
-      channel{channel},
-      read_delay{read_delay} {
+      ads1x15_{ads1x15},
+      channel_{channel},
+      read_delay_{read_delay} {
   load_configuration();
 }
 
 template <class T_ads_1x15>
 void ADS1x15RawValue<T_ads_1x15>::read_raw_value() {
-  switch (channel) {
+  switch (channel_) {
     case 0:
     case 1:
     case 2:
     case 3:
-      raw_value = ads1x15->ads->readADC_SingleEnded(channel);
+      raw_value_ = ads1x15_->ads_->readADC_SingleEnded(channel_);
       break;
     case 10:
-      raw_value = ads1x15->ads->readADC_Differential_0_1();
+      raw_value_ = ads1x15_->ads_->readADC_Differential_0_1();
       break;
     case 23:
-      raw_value = ads1x15->ads->readADC_Differential_2_3();
+      raw_value_ = ads1x15_->ads_->readADC_Differential_2_3();
       break;
     default:
       debugE("FATAL: invalid channel - must be 0, 1, 2, 3, 10, or 23");
@@ -47,15 +47,15 @@ void ADS1x15RawValue<T_ads_1x15>::read_raw_value() {
 
 template <class T_ads_1x15>
 void ADS1x15RawValue<T_ads_1x15>::enable() {
-  app.onRepeat(read_delay, [this]() {
+  app.onRepeat(read_delay_, [this]() {
     read_raw_value();
-    this->emit(raw_value);
+    this->emit(raw_value_);
   });
 }
 
 template <class T_ads_1x15>
 void ADS1x15RawValue<T_ads_1x15>::get_configuration(JsonObject& root) {
-  root["read_delay"] = read_delay;
+  root["read_delay"] = read_delay_;
   root["value"] = output;
 };
 
@@ -80,11 +80,11 @@ bool ADS1x15RawValue<T_ads_1x15>::set_configuration(const JsonObject& config) {
       return false;
     }
   }
-  read_delay = config["read_delay"];
+  read_delay_ = config["read_delay"];
   return true;
 }
 
-// define all possible instances of an ADS1x15value
+// define all possible instances of an ADS1x15RawValue
 template class ADS1x15RawValue<ADS1015>;
 template class ADS1x15RawValue<ADS1115>;
 
@@ -93,55 +93,55 @@ template class ADS1x15RawValue<ADS1115>;
 template <class T_ads_1x15, ADS1x15CHIP_t chip>
 ADS1x15Voltage<T_ads_1x15, chip>::ADS1x15Voltage(T_ads_1x15* ads1x15, uint8_t channel,
                                            uint read_delay, String config_path)
-    : ADS1x15RawValue<T_ads_1x15>(ads1x15, channel, read_delay, config_path), chip_type{chip} {
+    : ADS1x15RawValue<T_ads_1x15>(ads1x15, channel, read_delay, config_path), chip_{chip} {
   ADS1x15RawValue<T_ads_1x15>::load_configuration();
 }
 
 
 template <class T_ads_1x15, ADS1x15CHIP_t chip>
 void ADS1x15Voltage<T_ads_1x15, chip>::calculate_voltage(int input) {
-  if (chip_type == ADS1015chip) {
-    switch (ADS1x15RawValue<T_ads_1x15>::ads1x15->ads->gain) {
+  if (chip_ == ADS1015chip) {
+    switch (ADS1x15RawValue<T_ads_1x15>::ads1x15_->gain_) {
       case GAIN_TWOTHIRDS:
-        calculated_voltage = input * 0.003;
+        calculated_voltage_ = input * 0.003;
         break;
       case GAIN_ONE:
-        calculated_voltage = input * 0.002;
+        calculated_voltage_ = input * 0.002;
         break;
       case GAIN_TWO:
-        calculated_voltage = input * 0.001;
+        calculated_voltage_ = input * 0.001;
         break;
       case GAIN_FOUR:
-        calculated_voltage = input * 0.0005;
+        calculated_voltage_ = input * 0.0005;
         break;
       case GAIN_EIGHT:
-        calculated_voltage = input * 0.00025;
+        calculated_voltage_ = input * 0.00025;
         break;
       case GAIN_SIXTEEN:
-        calculated_voltage = input * 0.000125;
+        calculated_voltage_ = input * 0.000125;
         break;
       default:
         debugE("FATAL: invalid GAIN parameter.");
     }
-  } else if (chip_type == ADS1115chip) {
-    switch (ADS1x15RawValue<T_ads_1x15>::ads1x15->ads->gain) {
+  } else if (chip_ == ADS1115chip) {
+    switch (ADS1x15RawValue<T_ads_1x15>::ads1x15_->gain_) {
       case GAIN_TWOTHIRDS:
-        calculated_voltage = input * 0.0001875;
+        calculated_voltage_ = input * 0.0001875;
         break;
       case GAIN_ONE:
-        calculated_voltage = input * 0.000125;
+        calculated_voltage_ = input * 0.000125;
         break;
       case GAIN_TWO:
-        calculated_voltage = input * 0.0000625;
+        calculated_voltage_ = input * 0.0000625;
         break;
       case GAIN_FOUR:
-        calculated_voltage = input * 0.00003125;
+        calculated_voltage_ = input * 0.00003125;
         break;
       case GAIN_EIGHT:
-        calculated_voltage = input * 0.000015625;
+        calculated_voltage_ = input * 0.000015625;
         break;
       case GAIN_SIXTEEN:
-        calculated_voltage = input * 0.0000078125;
+        calculated_voltage_ = input * 0.0000078125;
         break;
       default:
         debugE("FATAL: invalid GAIN parameter.");
@@ -154,10 +154,13 @@ void ADS1x15Voltage<T_ads_1x15, chip>::calculate_voltage(int input) {
 
 template <class T_ads_1x15, ADS1x15CHIP_t chip>
 void ADS1x15Voltage<T_ads_1x15, chip>::enable() {
-  app.onRepeat(ADS1x15RawValue<T_ads_1x15>::read_delay, [this]() {
+  app.onRepeat(ADS1x15RawValue<T_ads_1x15>::read_delay_, [this]() {
     ADS1x15RawValue<T_ads_1x15>::read_raw_value();
-    calculate_voltage(ADS1x15RawValue<T_ads_1x15>::raw_value);
-    this->emit(calculated_voltage);
+    calculate_voltage(ADS1x15RawValue<T_ads_1x15>::raw_value_);
+    this->emit(calculated_voltage_);
   });
 }
 
+// define all possible instances of an ADS1x15Voltage
+template class ADS1x15Voltage<ADS1015, ADS1015chip>;
+template class ADS1x15Voltage<ADS1115, ADS1115chip>;

--- a/src/sensors/ads1x15.cpp
+++ b/src/sensors/ads1x15.cpp
@@ -16,7 +16,7 @@ template class ADS1x15<Adafruit_ADS1115>;
 
 
 template <class T_ads_1x15>
-ADS1x15RawValue<T_ads_1x15>::ADS1x15RawValue(T_ads_1x15* ads1x15, uint8_t channel,
+ADS1x15RawValue<T_ads_1x15>::ADS1x15RawValue(T_ads_1x15* ads1x15, ADS1x15Channel_t channel,
                                        uint read_delay, String config_path)
     : NumericSensor(config_path),
       ads1x15_{ads1x15},
@@ -28,20 +28,18 @@ ADS1x15RawValue<T_ads_1x15>::ADS1x15RawValue(T_ads_1x15* ads1x15, uint8_t channe
 template <class T_ads_1x15>
 void ADS1x15RawValue<T_ads_1x15>::read_raw_value() {
   switch (channel_) {
-    case 0:
-    case 1:
-    case 2:
-    case 3:
+    case channel_0:
+    case channel_1:
+    case channel_2:
+    case channel_3:
       raw_value_ = ads1x15_->ads_->readADC_SingleEnded(channel_);
       break;
-    case 10:
+    case channels_0_1:
       raw_value_ = ads1x15_->ads_->readADC_Differential_0_1();
       break;
-    case 23:
+    case channels_2_3:
       raw_value_ = ads1x15_->ads_->readADC_Differential_2_3();
       break;
-    default:
-      debugE("FATAL: invalid channel - must be 0, 1, 2, 3, 10, or 23");
   }
 }
 
@@ -91,7 +89,7 @@ template class ADS1x15RawValue<ADS1115>;
 
 
 template <class T_ads_1x15, ADS1x15CHIP_t chip>
-ADS1x15Voltage<T_ads_1x15, chip>::ADS1x15Voltage(T_ads_1x15* ads1x15, uint8_t channel,
+ADS1x15Voltage<T_ads_1x15, chip>::ADS1x15Voltage(T_ads_1x15* ads1x15, ADS1x15Channel_t channel,
                                            uint read_delay, String config_path)
     : ADS1x15RawValue<T_ads_1x15>(ads1x15, channel, read_delay, config_path), chip_{chip} {
   ADS1x15RawValue<T_ads_1x15>::load_configuration();

--- a/src/sensors/ads1x15.cpp
+++ b/src/sensors/ads1x15.cpp
@@ -4,7 +4,7 @@
 
 template <class T_Ada_1x15>
 ADS1x15<T_Ada_1x15>::ADS1x15(uint8_t addr, adsGain_t gain, String config_path)
-    : Sensor(config_path) {
+    : Sensor(config_path), gain{gain} {
   ads = new T_Ada_1x15(addr);
   ads->begin();
   ads->setGain(gain);
@@ -13,6 +13,7 @@ ADS1x15<T_Ada_1x15>::ADS1x15(uint8_t addr, adsGain_t gain, String config_path)
 // define all possible instances of an ADS1x15
 template class ADS1x15<Adafruit_ADS1015>;
 template class ADS1x15<Adafruit_ADS1115>;
+
 
 template <class T_ads_1x15>
 ADS1x15RawValue<T_ads_1x15>::ADS1x15RawValue(T_ads_1x15* ads1x15, uint8_t channel,
@@ -25,25 +26,30 @@ ADS1x15RawValue<T_ads_1x15>::ADS1x15RawValue(T_ads_1x15* ads1x15, uint8_t channe
 }
 
 template <class T_ads_1x15>
+void ADS1x15RawValue<T_ads_1x15>::read_raw_value() {
+  switch (channel) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+      raw_value = ads1x15->ads->readADC_SingleEnded(channel);
+      break;
+    case 10:
+      raw_value = ads1x15->ads->readADC_Differential_0_1();
+      break;
+    case 23:
+      raw_value = ads1x15->ads->readADC_Differential_2_3();
+      break;
+    default:
+      debugE("FATAL: invalid channel - must be 0, 1, 2, 3, 10, or 23");
+  }
+}
+
+template <class T_ads_1x15>
 void ADS1x15RawValue<T_ads_1x15>::enable() {
   app.onRepeat(read_delay, [this]() {
-    switch (channel) {
-      case 0:
-      case 1:
-      case 2:
-      case 3:
-        output = ads1x15->ads->readADC_SingleEnded(channel);
-        break;
-      case 10:
-        output = ads1x15->ads->readADC_Differential_0_1();
-        break;
-      case 23:
-        output = ads1x15->ads->readADC_Differential_2_3();
-        break;
-      default:
-        debugE("FATAL: invalid channel - must be 0, 1, 2, 3, 10, or 23");
-    }
-    notify();
+    read_raw_value();
+    this->emit(raw_value);
   });
 }
 
@@ -81,3 +87,77 @@ bool ADS1x15RawValue<T_ads_1x15>::set_configuration(const JsonObject& config) {
 // define all possible instances of an ADS1x15value
 template class ADS1x15RawValue<ADS1015>;
 template class ADS1x15RawValue<ADS1115>;
+
+
+
+template <class T_ads_1x15, ADS1x15CHIP_t chip>
+ADS1x15Voltage<T_ads_1x15, chip>::ADS1x15Voltage(T_ads_1x15* ads1x15, uint8_t channel,
+                                           uint read_delay, String config_path)
+    : ADS1x15RawValue<T_ads_1x15>(ads1x15, channel, read_delay, config_path), chip_type{chip} {
+  ADS1x15RawValue<T_ads_1x15>::load_configuration();
+}
+
+
+template <class T_ads_1x15, ADS1x15CHIP_t chip>
+void ADS1x15Voltage<T_ads_1x15, chip>::calculate_voltage(int input) {
+  if (chip_type == ADS1015chip) {
+    switch (ADS1x15RawValue<T_ads_1x15>::ads1x15->ads->gain) {
+      case GAIN_TWOTHIRDS:
+        calculated_voltage = input * 0.003;
+        break;
+      case GAIN_ONE:
+        calculated_voltage = input * 0.002;
+        break;
+      case GAIN_TWO:
+        calculated_voltage = input * 0.001;
+        break;
+      case GAIN_FOUR:
+        calculated_voltage = input * 0.0005;
+        break;
+      case GAIN_EIGHT:
+        calculated_voltage = input * 0.00025;
+        break;
+      case GAIN_SIXTEEN:
+        calculated_voltage = input * 0.000125;
+        break;
+      default:
+        debugE("FATAL: invalid GAIN parameter.");
+    }
+  } else if (chip_type == ADS1115chip) {
+    switch (ADS1x15RawValue<T_ads_1x15>::ads1x15->ads->gain) {
+      case GAIN_TWOTHIRDS:
+        calculated_voltage = input * 0.0001875;
+        break;
+      case GAIN_ONE:
+        calculated_voltage = input * 0.000125;
+        break;
+      case GAIN_TWO:
+        calculated_voltage = input * 0.0000625;
+        break;
+      case GAIN_FOUR:
+        calculated_voltage = input * 0.00003125;
+        break;
+      case GAIN_EIGHT:
+        calculated_voltage = input * 0.000015625;
+        break;
+      case GAIN_SIXTEEN:
+        calculated_voltage = input * 0.0000078125;
+        break;
+      default:
+        debugE("FATAL: invalid GAIN parameter.");
+    }
+  } else {
+    debugE("FATAL: chip parameter must be ADS1015chip or ADS1115chip.");
+  }
+}
+
+
+template <class T_ads_1x15, ADS1x15CHIP_t chip>
+void ADS1x15Voltage<T_ads_1x15, chip>::enable() {
+  app.onRepeat(ADS1x15RawValue<T_ads_1x15>::read_delay, [this]() {
+    ADS1x15RawValue<T_ads_1x15>::read_raw_value();
+    calculate_voltage(ADS1x15RawValue<T_ads_1x15>::raw_value);
+    this->emit(calculated_voltage);
+  });
+}
+

--- a/src/sensors/ads1x15.cpp
+++ b/src/sensors/ads1x15.cpp
@@ -15,7 +15,7 @@ template class ADS1x15<Adafruit_ADS1015>;
 template class ADS1x15<Adafruit_ADS1115>;
 
 template <class T_ads_1x15>
-ADS1x15Value<T_ads_1x15>::ADS1x15Value(T_ads_1x15* ads1x15, uint8_t channel,
+ADS1x15RawValue<T_ads_1x15>::ADS1x15RawValue(T_ads_1x15* ads1x15, uint8_t channel,
                                        uint read_delay, String config_path)
     : NumericSensor(config_path),
       ads1x15{ads1x15},
@@ -25,7 +25,7 @@ ADS1x15Value<T_ads_1x15>::ADS1x15Value(T_ads_1x15* ads1x15, uint8_t channel,
 }
 
 template <class T_ads_1x15>
-void ADS1x15Value<T_ads_1x15>::enable() {
+void ADS1x15RawValue<T_ads_1x15>::enable() {
   app.onRepeat(read_delay, [this]() {
     switch (channel) {
       case 0:
@@ -48,7 +48,7 @@ void ADS1x15Value<T_ads_1x15>::enable() {
 }
 
 template <class T_ads_1x15>
-void ADS1x15Value<T_ads_1x15>::get_configuration(JsonObject& root) {
+void ADS1x15RawValue<T_ads_1x15>::get_configuration(JsonObject& root) {
   root["read_delay"] = read_delay;
   root["value"] = output;
 };
@@ -62,12 +62,12 @@ static const char SCHEMA[] PROGMEM = R"###({
   })###";
 
 template <class T_ads_1x15>
-String ADS1x15Value<T_ads_1x15>::get_config_schema() {
+String ADS1x15RawValue<T_ads_1x15>::get_config_schema() {
   return FPSTR(SCHEMA);
 }
 
 template <class T_ads_1x15>
-bool ADS1x15Value<T_ads_1x15>::set_configuration(const JsonObject& config) {
+bool ADS1x15RawValue<T_ads_1x15>::set_configuration(const JsonObject& config) {
   String expected[] = {"read_delay"};
   for (auto str : expected) {
     if (!config.containsKey(str)) {
@@ -79,5 +79,5 @@ bool ADS1x15Value<T_ads_1x15>::set_configuration(const JsonObject& config) {
 }
 
 // define all possible instances of an ADS1x15value
-template class ADS1x15Value<ADS1015>;
-template class ADS1x15Value<ADS1115>;
+template class ADS1x15RawValue<ADS1015>;
+template class ADS1x15RawValue<ADS1115>;

--- a/src/sensors/ads1x15.h
+++ b/src/sensors/ads1x15.h
@@ -6,9 +6,23 @@
 
 #include "sensor.h"
 
-// ADS1x15 creates an instance of an ADS1015 or ADS1115 analog-to-digital
-// converter (ADC) that will be used by ADS1015channel and ADS1115channel. In
-// main.cpp, you will use one of the type defined below: ADS1015 or ADS115.
+
+/**
+ * @brief ADS1x15 represents an ADS1015 or ADS1115 Analog to Digital Converter.
+ * 
+ * In main.cpp, use one of these typedefs: ADS1015 or ADS1115
+ *
+ * @param addr The address through which the chip reports its readings. The default
+ *   is 0x48, but can be changed on most chips - see the datasheet.
+ * 
+ * @param gain One of the adsGain_t values that determines the precision of
+ *   the output. 
+ *   See https://github.com/adafruit/Adafruit_ADS1X15/blob/master/Adafruit_ADS1015.h
+ * 
+ * @param config_path Not used for this Sensor, so you can omit it when you
+ *   create an instance of this Class in main.cpp.
+ * 
+ * */
 template <class T_Ada_1x15>
 class ADS1x15 : public Sensor {
  public:
@@ -18,19 +32,33 @@ class ADS1x15 : public Sensor {
   T_Ada_1x15* ads;
 };
 
+// define all possible instances of the class
 typedef ADS1x15<Adafruit_ADS1015> ADS1015;
 typedef ADS1x15<Adafruit_ADS1115> ADS1115;
 
-// ADS1015Value is used to read the value of an ADS1x15 (either ADS1015 or
-// ADS1115). If you want to read a single channel, make your channel parameter
-// be 0, 1 2 or 3 and readADC_SingleEnded() will be used. If you want to read
-// the difference between two channels, your channel parameter should be:
-// - 10 will use readADC_Differential_0_1()
-// - 23 will use readADC_Differential_2_3()
+
+/**
+ * @brief ADS1x15RawValue is used to read the raw output of the ADS1x15.
+ *   If you want the voltage that was the input to the ADS1x15 (voltage is
+ *   what the ADS1x15 actually reads), use ADS1x15Voltage instead.
+ *
+ * @param ads1x15 A pointer to the ADS1x15 object.
+ * 
+ * @param channel The channel of the ADS1x15 that you want to read. For a
+ *   single channel, use 0, 1, 2, or 3, and readADC_SingleEnded() will be used. If
+ *   you want to read the difference between two channels, this parameter should be:
+ *   - 10 to use readADC_Differential_0_1()
+ *   - 23 to use readADC_Differential_2_3()
+ * 
+ * @param read_delay How often to read the value, in ms.
+ * 
+ * @param config_path The path to configuring read_delay in the Config UI.
+ * 
+ * */
 template <class T_ads_1x15>
-class ADS1x15Value : public NumericSensor {
+class ADS1x15RawValue : public NumericSensor {
  public:
-  ADS1x15Value(T_ads_1x15* ads1x15, uint8_t channel = 0, uint read_delay = 200,
+  ADS1x15RawValue(T_ads_1x15* ads1x15, uint8_t channel = 0, uint read_delay = 200,
                String config_path = "");
   void enable() override final;
 
@@ -43,14 +71,21 @@ class ADS1x15Value : public NumericSensor {
   virtual String get_config_schema() override;
 };
 
-typedef ADS1x15Value<ADS1015> ADS1015Value;
-typedef ADS1x15Value<ADS1115> ADS1115Value;
+// define all possible instances of the class
+typedef ADS1x15RawValue<ADS1015> ADS1015RawValue;
+typedef ADS1x15RawValue<ADS1115> ADS1115RawValue;
 
 // FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
-// [[deprecated("Use ADS1015Value instead.")]]
-typedef ADS1015Value ADS1015value;
+// [[deprecated("Use ADS1015RawValue instead.")]]
+typedef ADS1015RawValue ADS1015value; // The original name
 // FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
-// [[deprecated("Use ADS1115Value instead.")]]
-typedef ADS1115Value ADS1115value;
+// [[deprecated("Use ADS1015RawValue instead.")]]
+typedef ADS1015RawValue ADS1015Value; // The second name
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use ADS1115RawValue instead.")]]
+typedef ADS1115RawValue ADS1115value; // The original name
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use ADS1015RawValue instead.")]]
+typedef ADS1115RawValue ADS1115Value; // The second name
 
 #endif

--- a/src/sensors/ads1x15.h
+++ b/src/sensors/ads1x15.h
@@ -47,27 +47,31 @@ typedef ADS1x15<Adafruit_ADS1115> ADS1115;
  * @param ads1x15 A pointer to the ADS1x15 object.
  * 
  * @param channel The channel of the ADS1x15 that you want to read. For a
- *   single channel, use 0, 1, 2, or 3, and readADC_SingleEnded() will be used. If
- *   you want to read the difference between two channels, this parameter should be:
- *   - 10 to use readADC_Differential_0_1()
- *   - 23 to use readADC_Differential_2_3()
+ *   single channel, use channel_0, channel_1, channel_2, or channel_3, and 
+ *   readADC_SingleEnded() will be used. If you want to read the difference between
+ *   two channels, this parameter should be:
+ *   - channels_0_1 to use readADC_Differential_0_1()
+ *   - channels_2_3 to use readADC_Differential_2_3()
  * 
  * @param read_delay How often to read the value, in ms.
  * 
  * @param config_path The path to configuring read_delay in the Config UI.
  * 
  * */
+
+enum ADS1x15Channel_t { channel_0, channel_1, channel_2, channel_3, channels_0_1, channels_2_3 };
+
 template <class T_ads_1x15>
 class ADS1x15RawValue : public NumericSensor {
  public:
-  ADS1x15RawValue(T_ads_1x15* ads1x15, uint8_t channel = 0, uint read_delay = 200,
+  ADS1x15RawValue(T_ads_1x15* ads1x15, ADS1x15Channel_t channel = channel_0, uint read_delay = 200,
                String config_path = "");
   void enable() override;
 
  //protected:
   void read_raw_value();
   T_ads_1x15* ads1x15_;
-  uint8_t channel_;
+  ADS1x15Channel_t channel_;
   uint read_delay_;
   uint16_t raw_value_ = 0;
 
@@ -111,10 +115,11 @@ enum ADS1x15CHIP_t { ADS1015chip, ADS1115chip };
  * @param ads1x15 A pointer to the ADS1x15 object.
  * 
  * @param channel The channel of the ADS1x15 that you want to read. For a
- *   single channel, use 0, 1, 2, or 3, and readADC_SingleEnded() will be used. If
- *   you want to read the difference between two channels, this parameter should be:
- *   - 10 to use readADC_Differential_0_1()
- *   - 23 to use readADC_Differential_2_3()
+ *   single channel, use channel_0, channel_1, channel_2, or channel_3, and 
+ *   readADC_SingleEnded() will be used. If you want to read the difference between
+ *   two channels, this parameter should be:
+ *   - channels_0_1 to use readADC_Differential_0_1()
+ *   - channels_2_3 to use readADC_Differential_2_3()
  * 
  * @param read_delay How often to read the value, in ms.
  * 
@@ -124,7 +129,7 @@ enum ADS1x15CHIP_t { ADS1015chip, ADS1115chip };
 template <class T_ads_1x15, ADS1x15CHIP_t chip>
 class ADS1x15Voltage : public ADS1x15RawValue<T_ads_1x15> {
  public:
-  ADS1x15Voltage(T_ads_1x15* ads1x15, uint8_t channel = 0, uint read_delay = 200,
+  ADS1x15Voltage(T_ads_1x15* ads1x15, ADS1x15Channel_t channel = channel_0, uint read_delay = 200,
                String config_path = "");
   void enable() override final;
 

--- a/src/sensors/ads1x15.h
+++ b/src/sensors/ads1x15.h
@@ -29,8 +29,8 @@ class ADS1x15 : public Sensor {
   ADS1x15(uint8_t addr = 0x48, adsGain_t gain = GAIN_TWOTHIRDS,
           String config_path = "");
   void enable() override final {}
-  T_Ada_1x15* ads;
-  adsGain_t gain;
+  T_Ada_1x15* ads_;
+  adsGain_t gain_;
 };
 
 // define all possible instances of the class
@@ -64,12 +64,12 @@ class ADS1x15RawValue : public NumericSensor {
                String config_path = "");
   void enable() override;
 
- protected:
+ //protected:
   void read_raw_value();
-  T_ads_1x15* ads1x15;
-  uint8_t channel;
-  uint read_delay;
-  uint16_t raw_value = 0;
+  T_ads_1x15* ads1x15_;
+  uint8_t channel_;
+  uint read_delay_;
+  uint16_t raw_value_ = 0;
 
  private:
   virtual void get_configuration(JsonObject& doc) override;
@@ -130,8 +130,8 @@ class ADS1x15Voltage : public ADS1x15RawValue<T_ads_1x15> {
 
  private:
   void calculate_voltage(int input);
-  ADS1x15CHIP_t chip_type;
-  float calculated_voltage = 0.0;
+  ADS1x15CHIP_t chip_;
+  float calculated_voltage_ = 0.0;
 
 };
 

--- a/src/transforms/ads1x15_voltage.h
+++ b/src/transforms/ads1x15_voltage.h
@@ -5,36 +5,35 @@
 
 #include "transforms/transform.h"
 
-// FIXME: This shouldn't be a separate transform but integrated with ads1x15
-// sensors.
 
 // Pass one of these in the constructor to ADS1x15Voltage() to tell which of the
 // two chips you're working with.
 enum ADS1x15CHIP_t { ADS1015chip, ADS1115chip };
 
 /**
+ * @brief DEPRECATED: Use ADS1x15Voltage SENSOR instead of an ADS1x15Value
+ * Sensor connected to this ADS1x15Voltage Transform.
+ * 
  * A transform that takes the output from an ADS1015 or ADS1115
- analog-to-digital converter
- * (ADC) as input, and converts the value to the original voltage sensed by the
- ADC.
- * There are two parameters:
+ * analog-to-digital converter (ADC) as input, and converts the value to 
+ * the original voltage sensed by the ADC.
  *
- * - chip, which is either 0 (representing the ADS1015) or 1 (representing the
- ADS1115). Default is 1.
- * - gain, which is the value of the GAIN setting used by the firmware on the
- chip. It defaults to GAIN_TWOTHIRDS, which is also the default GAIN setting for
- both chips. Valid values are from the ADAfruit_ADS1015 library:
-
-        GAIN_TWOTHIRDS = +/-6.144V range
-        GAIN_ONE = +/-4.096V range
-        GAIN_TWO = +/-2.048V range
-        GAIN_FOUR = +/-1.024V range
-        GAIN_EIGHT = +/-0.512V range
-        GAIN_SIXTEEN = +/-0.256V range
+ * @param chip Either 0 (representing the ADS1015) or 1 (representing the
+ * ADS1115). Default is 1.
+ *
+ * @param gain The value of the GAIN setting used by the firmware on the
+ * chip. It defaults to GAIN_TWOTHIRDS, which is also the default GAIN setting for
+ * both chips. Valid values are from the ADAfruit_ADS1015 library:
+ *
+ *       GAIN_TWOTHIRDS = +/-6.144V range
+ *       GAIN_ONE = +/-4.096V range
+ *       GAIN_TWO = +/-2.048V range
+ *       GAIN_FOUR = +/-1.024V range
+ *       GAIN_EIGHT = +/-0.512V range
+ *       GAIN_SIXTEEN = +/-0.256V range
  *
  * It's up to you to set the proper chip and gain to match what you've set in
- ADS1015() or
- * ADS1115() - they are not automatically detected.
+ * ADS1015() or ADS1115() - they are not automatically detected.
  */
 class ADS1x15Voltage : public NumericTransform {
  public:


### PR DESCRIPTION
Addresses the items in Issue #242.

The new ADS1x15Voltage is identical to the class it inherits from, ADS1x15RawValue, except for one additional computation. It works as intended, but I'm not sure if the configuration methods will work the way I've done it (i.e., not defining the configuration methods in the new class). And I don't have an ADS1115 to test it with for another couple of weeks. So please give that aspect of it a good look.