### PR TITLE
Fix EspSoftwareSerial compile error

### DIFF
--- a/library.json
+++ b/library.json
@@ -68,6 +68,10 @@
       "version": "https://github.com/sivar2311/ESPTrueRandom"
     },
     {
+      "name": "elapsedMillis",
+      "version": "https://github.com/pfeerick/elapsedMillis"
+    },  
+    {
       "name": "Wire"
     },
     {
@@ -105,9 +109,6 @@
     },
     {
       "name": "Adafruit AHRS"
-    },
-    {
-      "name": "EspSoftwareSerial"
     },
     {
       "name": "RemoteDebug",

--- a/library.json
+++ b/library.json
@@ -111,6 +111,10 @@
       "name": "Adafruit AHRS"
     },
     {
+      "name": "EspSoftwareSerial",
+      "platforms": ["espressif32"]
+    },
+    {
       "name": "RemoteDebug",
       "version": "https://github.com/JoaoLopesF/RemoteDebug.git#0b5a9c1a49fd2ade0e3cadc3a3707781e819359a" }
   ],

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,8 @@ default_envs =
 framework = arduino
 lib_ldf_mode = deep
 monitor_speed = 115200
+
+[common_env_data]
 lib_deps =
    ReactESP
    ESP8266WebServer
@@ -39,6 +41,7 @@ lib_deps =
    OneWire
    DallasTemperature
    https://github.com/sivar2311/ESPTrueRandom
+   https://github.com/pfeerick/elapsedMillis
    Wire
    Adafruit ADS1X15
    Adafruit AHRS
@@ -50,7 +53,6 @@ lib_deps =
    Adafruit SHT31 Library
    Adafruit INA219
    Adafruit MAX31856 Library
-   EspSoftwareSerial
    https://github.com/JoaoLopesF/RemoteDebug.git#0b5a9c1a49fd2ade0e3cadc3a3707781e819359a
 
 [espressif8266_base]
@@ -61,6 +63,8 @@ build_flags =
    -Wall
    -Wno-reorder
 extra_scripts = extra_script.py
+lib_deps=
+   ${common_env_data.lib_deps}
 
 [env:d1_mini]
 extends = espressif8266_base
@@ -78,6 +82,9 @@ platform = espressif32
 build_unflags = -Werror=reorder
 board_build.partitions = min_spiffs.csv
 monitor_filters = esp32_exception_decoder
+lib_deps=
+    ${common_env_data.lib_deps}
+    EspSoftwareSerial
 
 [env:esp32dev]
 extends = espressif32_base


### PR DESCRIPTION
EspSoftwareSerial should only be explicitly included when compiling for ESP32