### PR TITLE
Transform to repeat the reporting of a value at regular intvervals

### DIFF
--- a/src/transforms/repeat_report.cpp
+++ b/src/transforms/repeat_report.cpp
@@ -1,0 +1,56 @@
+#include "transforms/repeat_report.h"
+
+template <typename T>
+void RepeatReport<T>::set_input(T input, uint8_t inputChannel) {
+      last_update_interval = 0;
+      this->emit(input);
+}
+
+
+template <typename T>
+void RepeatReport<T>::enable() {
+      SymmetricTransform<T>::enable();
+      app.onRepeat(10, [this]() {
+         if (last_update_interval > max_silence_interval) {
+           this->last_update_interval = 0;
+           this->notify();
+         }
+      });
+}
+
+
+template <typename T>
+void RepeatReport<T>::get_configuration(JsonObject& root) {
+  root["max_silence_interval"] = max_silence_interval;
+  root["value"] = this->output;
+}
+
+static const char SCHEMA[] PROGMEM = R"###({
+    "type": "object",
+    "properties": {
+        "max_silence_interval": { "title": "Max ms interval until value repeated", "type": "number" },
+        "value": { "title": "Last value", "type" : "number", "readOnly": true }
+    }
+  })###";
+
+template <typename T>
+String RepeatReport<T>::get_config_schema() { return FPSTR(SCHEMA); }
+
+template <typename T>
+bool RepeatReport<T>::set_configuration(const JsonObject& config) {
+  String expected[] = {"max_silence_interval"};
+  for (auto str : expected) {
+    if (!config.containsKey(str)) {
+      return false;
+    }
+  }
+  this->max_silence_interval = config["max_silence_interval"];
+  return true;
+}
+
+
+// Force compiler to make versions for the common data types...
+template class RepeatReport<float>;
+template class RepeatReport<int>;
+template class RepeatReport<bool>;
+template class RepeatReport<String>;

--- a/src/transforms/repeat_report.h
+++ b/src/transforms/repeat_report.h
@@ -1,0 +1,35 @@
+#ifndef _repeat_report_H_
+#define _repeat_report_H_
+
+#include <elapsedMillis.h>
+
+#include "transforms/transform.h"
+
+/**
+ * RepeatReport ensures that values that do not change frequently are still reported at
+ * at a specified maximum silence interval. If the value has not changed in max_silence_interval 
+ * milliseconds, the current value is emmitted again, 
+ */
+template <typename T>
+class RepeatReport : public SymmetricTransform<T> {
+ public:
+  RepeatReport(long max_silence_interval = 15000, String config_path = "") :
+     SymmetricTransform<T>(config_path),
+     max_silence_interval{max_silence_interval} {
+     this->load_configuration();
+  }
+
+  // The followig methods moved to CPP file to avoid excessive inline code generation...
+  virtual void set_input(T input, uint8_t inputChannel = 0) override;
+  virtual void enable() override;
+  virtual void get_configuration(JsonObject& doc) override;
+  virtual bool set_configuration(const JsonObject& config) override;
+  virtual String get_config_schema() override;
+
+ private:
+  long max_silence_interval;
+  elapsedMillis last_update_interval;
+
+}; 
+
+#endif


### PR DESCRIPTION
RepeatReport() is a transform for values that do not change frequently, but to still ensure they can be reported to another consumer (like the SK server) at frequent intervals.