### PR TITLE
Refactored DigitalOutput to pass through input values

### DIFF
--- a/src/sensors/digital_output.cpp
+++ b/src/sensors/digital_output.cpp
@@ -7,6 +7,7 @@ DigitalOutput::DigitalOutput(int pin) {
   pinMode(pin, OUTPUT);
 }
 
-void DigitalOutput::set_input(bool newValue, uint8_t inputChannel) {
-  digitalWrite(pin_number, newValue);
+void DigitalOutput::set_input(bool new_value, uint8_t inputChannel) {
+  digitalWrite(pin_number, new_value);
+  this->emit(new_value);
 }

--- a/src/sensors/digital_output.h
+++ b/src/sensors/digital_output.h
@@ -4,9 +4,18 @@
 #include <ArduinoJson.h>
 
 #include "system/observable.h"
-#include "system/valueconsumer.h"
+#include "transforms/transform.h"
 
-class DigitalOutput : public BooleanConsumer {
+/**
+ * DigitalOutput configures the specified GPIO pin
+ * as an output pin, then sets the status of that
+ * pin to HIGH whenever set_input() is called
+ * and new_value is true. The pin is set to LOW when
+ * new_value is false. After the output pin's state
+ * is set, the new_value is passed through unmodified
+ * as the value returned by BooleanTransform::get().
+ */
+class DigitalOutput : public BooleanTransform {
  public:
   DigitalOutput(int pin);
   void set_input(bool new_value, uint8_t input_channel = 0) override;


### PR DESCRIPTION
DigitalOutput was originally designed as a ValueConsumer<bool>.  This minor refactor changes it to a BooleanTransform that passes the input value along after setting the pin, allowing for its use in more complicated wiring designs.