### PR TITLE
ClickType Transform

### DIFF
--- a/src/transforms/click_type.cpp
+++ b/src/transforms/click_type.cpp
@@ -1,148 +1,148 @@
 #include "transforms/click_type.h"
+
 #include "ReactESP.h"
 
-ClickType::ClickType(String config_path, long long_click_delay, long double_click_interval, long ultra_long_click_delay) :
-   Transform<bool, ClickTypes>(config_path),
-    click_count{0},
-    long_click_delay{long_click_delay},
-    ultra_long_click_delay{ultra_long_click_delay},
-    double_click_interval{double_click_interval},
-    delayed_click_report{NULL} {
-   load_configuration();
+ClickType::ClickType(String config_path, long long_click_delay,
+                     long double_click_interval, long ultra_long_click_delay)
+    : Transform<bool, ClickTypes>(config_path),
+      click_count{0},
+      long_click_delay{long_click_delay},
+      ultra_long_click_delay{ultra_long_click_delay},
+      double_click_interval{double_click_interval},
+      delayed_click_report{NULL} {
+  load_configuration();
 }
 
-
-
 void ClickType::set_input(bool input, uint8_t inputChannel) {
-
   if (input) {
     on_button_press();
-  }
-  else {
+  } else {
     on_button_release();
   }
 }
 
 bool ClickType::is_click(ClickTypes value) {
-   return (value != ClickTypes::ButtonPress && value != ClickTypes::ButtonRelease);
+  return (value != ClickTypes::ButtonPress &&
+          value != ClickTypes::ButtonRelease);
 }
-
 
 void ClickType::on_button_press() {
+  debugD(
+      "ClickType received PRESS on click count %d (millis: %ld, last release: "
+      "%ld ms ago)",
+      click_count, millis(), (long)release_duration);
 
-    debugD("ClickType received PRESS on click count %d (millis: %ld, last release: %ld ms ago)", click_count, millis(), (long)release_duration);
+  if (click_count == 0) {
+    // This is a new, isolated "click" that we have not yet processed.
+    click_count++;
+    press_duration = 0;
+  } else {
+    // One or more presses is already in progress...
 
-    if (click_count == 0) {
-      // This is a new, isolated "click" that we have not yet processed.
+    if (press_duration > ultra_long_click_delay) {
+      // The button down is the second one reported in a row without a button
+      // release and the press is now long enough to qualify as an "ultra long
+      // click"
+      on_ultra_long_click();
+    } else if (release_duration <= double_click_interval) {
+      // This is the start of a second click to come in prior to the expiration
+      // of the double_click_interval.  Remove any "SingleClick" report that may
+      // have been queued up....
+      if (delayed_click_report != NULL) {
+        delayed_click_report->remove();
+        delayed_click_report = NULL;
+        debugD(
+            "ClickType press is double click. Removed queued SingleClick "
+            "report");
+      }
       click_count++;
-      press_duration = 0;
     }
-    else {
-      // One or more presses is already in progress...
+  }
 
-      if (press_duration > ultra_long_click_delay) {
-          // The button down is the second one reported in a row without a button release
-          // and the press is now long enough to qualify as an "ultra long click"
-          on_ultra_long_click();
-      }
-      else if (release_duration <= double_click_interval) {
-        // This is the start of a second click to come in prior to the expiration of
-        // the double_click_interval.  Remove any "SingleClick" report that may
-        // have been queued up....
-        if (delayed_click_report != NULL) {
-            delayed_click_report->remove();
-            delayed_click_report = NULL;
-            debugD("ClickType press is double click. Removed queued SingleClick report");
-        }
-        click_count++;
-      }
-
-    }
-
-    this->emit(ClickTypes::ButtonPress);
-
+  this->emit(ClickTypes::ButtonPress);
 }
-
 
 void ClickType::on_button_release() {
+  debugD(
+      "ClickType received UNPRESS for click count %d (millis: %ld, press "
+      "duration: %ld ms)",
+      click_count, millis(), (long)press_duration);
 
-     debugD("ClickType received UNPRESS for click count %d (millis: %ld, press duration: %ld ms)", click_count, millis(), (long)press_duration);
-
-     if (click_count > 0) {
-        // This is the "release" of a click we are tracking...
-        if (press_duration >= this->ultra_long_click_delay) {
-            on_ultra_long_click();
+  if (click_count > 0) {
+    // This is the "release" of a click we are tracking...
+    if (press_duration >= this->ultra_long_click_delay) {
+      on_ultra_long_click();
+      this->on_click_completed();
+    } else if (press_duration >= this->long_click_delay) {
+      debugD(
+          "ClickType detected LongSingleClick (millis: %ld, press duration %ld "
+          "ms)",
+          millis(), (long)press_duration);
+      this->emitDelayed(ClickTypes::LongSingleClick);
+      this->on_click_completed();
+    } else if (this->click_count > 1) {
+      // We have just ended a double click.  Sent it immediately...
+      debugD(
+          "ClickType detected DoubleClick (millis: %ld, press duration %ld ms)",
+          millis(), (long)press_duration);
+      this->emitDelayed(ClickTypes::DoubleClick);
+      this->on_click_completed();
+    } else {
+      // This is the end of a potential single click.  Queue up the send of a
+      // SingleClick report, but delay it in case another click comes in prior
+      // to the double_click_interval, which would turn this click into a
+      // DoubleClick
+      unsigned long time_of_event = millis();
+      long pd = (long)press_duration;
+      delayed_click_report =
+          app.onDelay(double_click_interval + 20, [this, pd, time_of_event]() {
+            debugD(
+                "ClickType detected SingleClick (millis: %ld, queue time: %ld, "
+                "press duration %ld ms)",
+                millis(), time_of_event, pd);
+            this->emit(ClickTypes::SingleClick);
             this->on_click_completed();
-        }
-        else if (press_duration >= this->long_click_delay) {
-            debugD("ClickType detected LongSingleClick (millis: %ld, press duration %ld ms)", millis(), (long)press_duration);
-            this->emitDelayed(ClickTypes::LongSingleClick);
-            this->on_click_completed();
-        }
-        else if (this->click_count > 1) {
-          // We have just ended a double click.  Sent it immediately...
-          debugD("ClickType detected DoubleClick (millis: %ld, press duration %ld ms)", millis(), (long)press_duration);
-          this->emitDelayed(ClickTypes::DoubleClick);
-          this->on_click_completed();
-        }
-        else {
-          // This is the end of a potential single click.  Queue up the send of a SingleClick report,
-          // but delay it in case another click comes in prior to the double_click_interval, which would
-          // turn this click into a DoubleClick
-          unsigned long time_of_event = millis();
-          long pd = (long)press_duration;
-          delayed_click_report = app.onDelay(double_click_interval+20, [this, pd, time_of_event]() {
-              debugD("ClickType detected SingleClick (millis: %ld, queue time: %ld, press duration %ld ms)", millis(), time_of_event, pd);
-              this->emit(ClickTypes::SingleClick);
-              this->on_click_completed();
           });
-        }
+    }
 
-        release_duration = 0;
-        this->emit(ClickTypes::ButtonRelease);
+    release_duration = 0;
+    this->emit(ClickTypes::ButtonRelease);
 
-     }
-     else {
-       // A press release with no initial press should happen only when
-       // an UltraLongClick has already been sent, or the producer
-       // is feeding us weird values...
-       release_duration = 0;
-       debugW("ClickType detected UNPRESS with no pending PRESS (millis=%ld)", millis());
-     }
-  
+  } else {
+    // A press release with no initial press should happen only when
+    // an UltraLongClick has already been sent, or the producer
+    // is feeding us weird values...
+    release_duration = 0;
+    debugW("ClickType detected UNPRESS with no pending PRESS (millis=%ld)",
+           millis());
+  }
 }
-
-
 
 void ClickType::emitDelayed(ClickTypes value) {
-   app.onDelay(5, [this, value]() {
-     this->emit(value);
-   });
+  app.onDelay(5, [this, value]() { this->emit(value); });
 }
-
 
 void ClickType::on_click_completed() {
-    this->click_count = 0;
-    delayed_click_report = NULL;
-    press_duration = 0;
-    release_duration = 0;
+  this->click_count = 0;
+  delayed_click_report = NULL;
+  press_duration = 0;
+  release_duration = 0;
 }
-
 
 void ClickType::on_ultra_long_click() {
-    debugD("ClickType detected UltraLongSingleClick (millis: %ld, press duration %ld ms)", millis(), (long)press_duration);
-    this->emitDelayed(ClickTypes::UltraLongSingleClick);
-    on_click_completed();
+  debugD(
+      "ClickType detected UltraLongSingleClick (millis: %ld, press duration "
+      "%ld ms)",
+      millis(), (long)press_duration);
+  this->emitDelayed(ClickTypes::UltraLongSingleClick);
+  on_click_completed();
 }
-
 
 void ClickType::get_configuration(JsonObject& root) {
   root["long_click_delay"] = long_click_delay;
   root["ultra_long_click_delay"] = ultra_long_click_delay;
   root["double_click_interval"] = double_click_interval;
 }
-
-
 
 static const char SCHEMA[] PROGMEM = R"({
     "type": "object",
@@ -153,11 +153,11 @@ static const char SCHEMA[] PROGMEM = R"({
     }
   })";
 
-
 String ClickType::get_config_schema() { return FPSTR(SCHEMA); }
 
 bool ClickType::set_configuration(const JsonObject& config) {
-  String expected[] = {"long_click_delay", "ultra_long_click_delay", "double_click_interval"};
+  String expected[] = {"long_click_delay", "ultra_long_click_delay",
+                       "double_click_interval"};
   for (auto str : expected) {
     if (!config.containsKey(str)) {
       return false;

--- a/src/transforms/click_type.cpp
+++ b/src/transforms/click_type.cpp
@@ -1,0 +1,167 @@
+#include "transforms/click_type.h"
+#include "ReactESP.h"
+
+ClickType::ClickType(String config_path, long long_click_delay, long double_click_interval, long ultra_long_click_delay) :
+   Transform<bool, ClickTypes>(config_path),
+    click_count{0},
+    long_click_delay{long_click_delay},
+    ultra_long_click_delay{ultra_long_click_delay},
+    double_click_interval{double_click_interval},
+    delayed_click_report{NULL} {
+   load_configuration();
+}
+
+
+
+void ClickType::set_input(bool input, uint8_t inputChannel) {
+
+  if (input) {
+    on_button_press();
+  }
+  else {
+    on_button_release();
+  }
+}
+
+bool ClickType::is_click(ClickTypes value) {
+   return (value != ClickTypes::ButtonPress && value != ClickTypes::ButtonRelease);
+}
+
+
+void ClickType::on_button_press() {
+
+    debugD("ClickType received PRESS (millis: %ld, last press interval: %ld)", millis(), (long)press_released);
+
+    if (click_count == 0) {
+      // This is a new, isolated "click" that we have not yet processed.
+      click_count++;
+      press_started = 0;
+    }
+    else {
+      // One or more presses is already in progress...
+
+      if (press_started > ultra_long_click_delay) {
+          // The button down is the second one reported in a row without a button release
+          // and the press is now long enough to qualify as an "ultra long click"
+          on_ultra_long_click("PRESS");
+      }
+      else if (press_released <= double_click_interval) {
+        // This is the start of a second click to come in prior to the expiration of
+        // the double_click_interval.  Remove any "SingleClick" report that may
+        // have been queued up....
+        if (delayed_click_report != NULL) {
+            delayed_click_report->remove();
+            delayed_click_report = NULL;
+            debugD("ClickType received PRESS: double click detected. Removed queued SingleClick");
+        }
+      }
+
+    }
+
+    this->emit(ClickTypes::ButtonPress);
+
+}
+
+
+void ClickType::on_button_release() {
+
+     if (click_count > 0) {
+        // This is the "release" of a click we are tracking...
+        if (press_started >= this->ultra_long_click_delay) {
+            on_ultra_long_click("UNPRESSED");
+            this->on_click_completed();
+        }
+        else if (press_started >= this->long_click_delay) {
+            debugD("ClickType UNPRESSED with LongSingleClick (millis: %ld, press interval %ld)", millis(), (long)press_started);
+            this->emitDelayed(ClickTypes::LongSingleClick);
+            this->on_click_completed();
+        }
+        else if (this->click_count > 1) {
+          // We have just ended a double click.  Sent it immediately...
+          debugD("ClickType UNPRESSED with DoubleClick (millis: %ld, press interval %ld)", millis(), (long)press_started);
+          this->emitDelayed(ClickTypes::DoubleClick);
+          this->on_click_completed();
+        }
+        else {
+          // This is the end of a potential single click.  Queue up the send of a SingleClick report,
+          // but delay it in case another click comes in prior to the double_click_interval, which would
+          // turn this click into a DoubleClick
+          unsigned long time_of_event = millis();
+          long press_interval = (long)press_started;
+          delayed_click_report = app.onDelay(double_click_interval+20, [this, press_interval, time_of_event]() {
+              debugD("ClickType UNPRESSED with SingleClick (millis: %ld, queue time: %ld, press interval %ld)", millis(), time_of_event, press_interval);
+              this->emit(ClickTypes::SingleClick);
+              this->on_click_completed();
+          });
+        }
+
+        press_released = 0;
+        this->emit(ClickTypes::ButtonRelease);
+
+     }
+     else {
+       // A press release with no initial press should happen only when
+       // an UltraLongClick has already been sent, or the producer
+       // is feeding us weird values...
+       press_released = 0;
+       debugW("ClickType detected UNPRESS with no pending PRESS (millis=%ld)", millis());
+     }
+  
+}
+
+
+
+void ClickType::emitDelayed(ClickTypes value) {
+   app.onDelay(5, [this, value]() {
+     this->emit(value);
+   });
+}
+
+
+void ClickType::on_click_completed() {
+    this->click_count = 0;
+    delayed_click_report = NULL;
+    press_started = 0;
+    press_released = 0;
+}
+
+
+void ClickType::on_ultra_long_click(const char* keyType) {
+    debugD("ClickType %s with UltraLongSingleClick (millis: %ld, press interval %ld)", keyType, millis(), millis() - press_started);
+    this->emitDelayed(ClickTypes::UltraLongSingleClick);
+    on_click_completed();
+}
+
+
+void ClickType::get_configuration(JsonObject& root) {
+  root["long_click_delay"] = long_click_delay;
+  root["ultra_long_click_delay"] = ultra_long_click_delay;
+  root["double_click_interval"] = double_click_interval;
+}
+
+
+
+static const char SCHEMA[] PROGMEM = R"({
+    "type": "object",
+    "properties": {
+        "long_click_delay": { "title": "Long click milliseconds", "type": "integer" },
+        "ultra_long_click_delay": { "title": "Ultra long click milliseconds", "type": "integer" },
+        "double_click_interval": { "title": "Max millisecond interval between double clicks", "type" : "integer" }
+    }
+  })";
+
+
+String ClickType::get_config_schema() { return FPSTR(SCHEMA); }
+
+bool ClickType::set_configuration(const JsonObject& config) {
+  String expected[] = {"long_click_delay", "ultra_long_click_delay", "double_click_interval"};
+  for (auto str : expected) {
+    if (!config.containsKey(str)) {
+      return false;
+    }
+  }
+  long_click_delay = config["long_click_delay"];
+  ultra_long_click_delay = config["ultra_long_click_delay"];
+  double_click_interval = config["double_click_interval"];
+  return true;
+}

--- a/src/transforms/click_type.h
+++ b/src/transforms/click_type.h
@@ -66,21 +66,21 @@ class ClickType : public Transform<bool, ClickTypes> {
       /// a normal SingleClick and a LongSingleClick
       long long_click_delay;
 
-      /// How many milliseconds a button is pressed to distinguish between
+      /// How many milliseoncs a button is pressed to distinguish between
       /// a normal SingleClick and an UltraLongSingleClick
       long ultra_long_click_delay;
 
-      /// The maximum number of milliseconds that can pass for two
-      /// clicks in a row to be combined into a single DoubleClick
+      /// The maximum number of milliseconds that can pass before two
+      /// clicks in a row are combined into a single DoubleClick
       long double_click_interval;
 
 
-      /// Timer to time length of button presses
-      elapsedMillis press_started;
+      /// Timmer to time button presses
+      elapsedMillis press_duration;
 
 
       /// Timer to time interval between button releases
-      elapsedMillis press_released;
+      elapsedMillis release_duration;
 
 
       /// Holds a delayed "SingleClick" report that we can pull back
@@ -100,14 +100,14 @@ class ClickType : public Transform<bool, ClickTypes> {
 
       /// Processes an ultra long click. Unlike the other click types,
       /// ultra long clicks are executed as soon as they pass the
-      /// "ultra long" delay
-      void on_ultra_long_click(const char* keyType);
+      /// "ultra long"
+      void on_ultra_long_click();
 
 
 
       /**
-       * Resets click tracking variables after a press has been released and
-       * successfully translated into a click event
+       * Resets click tracking variables after a press has been released so the
+       * next button press can be processed.
        */
       void on_click_completed();
 
@@ -115,8 +115,8 @@ class ClickType : public Transform<bool, ClickTypes> {
       /**
        * Emits the specified value after a 5 millisecond delay. This allows
        * translated click types like SingleClick and DoubleClick to be
-       * sent, but delays its processing so the "ButtonPress" and
-       * "ButtonRelease" click typesbvcan propagate through the system.
+       * sent but delays its processing so the ClickTypes::ButtonReleased
+       * can propogate through the system.
        */
       void emitDelayed(ClickTypes value);
 };

--- a/src/transforms/click_type.h
+++ b/src/transforms/click_type.h
@@ -1,0 +1,124 @@
+#ifndef _click_types_H_
+#define _click_types_H_
+
+#include <elapsedMillis.h>
+
+#include "transforms/transform.h"
+
+
+/**
+ * ClickTypes defines the types of clicks and button presses a ClickType transform can detect
+ */
+enum class ClickTypes { ButtonPress, ButtonRelease, SingleClick, LongSingleClick, UltraLongSingleClick, DoubleClick };
+
+
+/**
+ * ClickType adds a time element to button presses. It measures the time between
+ * a button press and its release and will emit its value as an encoded version
+ * of the button press. 
+ */
+class ClickType : public Transform<bool, ClickTypes> {
+
+    public:
+
+      /**
+       * The constructor
+       * @param config_path The configuration path to use if you want the end user to be
+       * able to change these values with the configuration UI. Leave as blank to 
+       * disable this feature.
+       * @param long_click_delay The number of milliseconds that an incoming button
+       *  press must be held to differentiate between a SingleClick and a LongSingleClick.
+       *  This value should be less than ultra_long_click_delay
+       * @param double_click_interval The maximum number of milliseconds that can pass
+       *  before two consecutive button presses are sent as two SingleClick events, or
+       *  a single DoubleClick event.  If the interval is less than or equal to 
+       *  double_click_interval milliseconds, a single DoubleClick event is emitted.
+       * @param ultra_long_click_delay The number of milliseconds that an incoming button
+       *  press must be held to register a single UltraLongSingleClick. Once a button
+       *  has been held for ultra_long_click_delay milliseoncs, an UltraLongSingleClick
+       *  is immediately emitted. This value should be longer than long_click_delay
+       * 
+       */
+      ClickType(String config_path = "", long long_click_delay = 1300, long double_click_interval = 400, long ultra_long_click_delay = 5000);
+
+      /**
+       * Returns TRUE if the specified value is one of the higher level click interpretations
+       * like SingleClick or UltraLongDoubleClick. It returns FALSE if the value is
+       * ButtonPress or ButtonRelease
+       */
+      static bool is_click(ClickTypes value);
+
+      virtual void set_input(bool input, uint8_t input_channel = 0) override;
+      virtual void get_configuration(JsonObject& doc) override;
+      virtual bool set_configuration(const JsonObject& config) override;
+      virtual String get_config_schema() override;
+
+    protected:
+      /// A counter to specify how many clicks are currently being
+      /// processed. Used to distinguish between single and double
+      /// clicks.
+      int click_count;
+
+
+      // User Configuration variables...
+
+      /// How many milliseconds a button is pressed to distinguish between
+      /// a normal SingleClick and a LongSingleClick
+      long long_click_delay;
+
+      /// How many milliseoncs a button is pressed to distinguish between
+      /// a normal SingleClick and an UltraLongSingleClick
+      long ultra_long_click_delay;
+
+      /// The maximum number of milliseconds that can pass before two
+      /// clicks in a row are combined into a single DoubleClick
+      long double_click_interval;
+
+
+      /// Timmer to time button presses
+      elapsedMillis press_started;
+
+
+      /// Timer to time interval between button releases
+      elapsedMillis press_released;
+
+
+      /// Holds a delayed "SingleClick" report that we can pull back
+      /// if the second click of a double click comes through. This
+      /// value will be NULL if no click report is currently
+      /// queued up.
+      DelayReaction* delayed_click_report;
+
+
+      /// Processes incoming values that represent a "ButonPress" event
+      void on_button_press();
+
+
+      /// Processes incoming value that represent a "ButtonRelease" event
+      void on_button_release();
+
+
+      /// Processes an ultra long click. Unlike the other click types,
+      /// ultra long clicks are executed as soon as they pass the
+      /// "ultra long"
+      void on_ultra_long_click(const char* keyType);
+
+
+
+      /**
+       * Resets click tracking variables after a press has been released so the
+       * next button press can be processed.
+       */
+      void on_click_completed();
+
+
+      /**
+       * Emits the specified value after a 5 millisecond delay. This allows
+       * translated click types like SingleClick and DoubleClick to be
+       * sent but delays its processing so the ClickTyes::ButtonReleased
+       * can propogate through the system.
+       */
+      void emitDelayed(ClickTypes value);
+};
+
+#endif

--- a/src/transforms/click_type.h
+++ b/src/transforms/click_type.h
@@ -66,16 +66,16 @@ class ClickType : public Transform<bool, ClickTypes> {
       /// a normal SingleClick and a LongSingleClick
       long long_click_delay;
 
-      /// How many milliseoncs a button is pressed to distinguish between
+      /// How many milliseconds a button is pressed to distinguish between
       /// a normal SingleClick and an UltraLongSingleClick
       long ultra_long_click_delay;
 
-      /// The maximum number of milliseconds that can pass before two
-      /// clicks in a row are combined into a single DoubleClick
+      /// The maximum number of milliseconds that can pass for two
+      /// clicks in a row to be combined into a single DoubleClick
       long double_click_interval;
 
 
-      /// Timmer to time button presses
+      /// Timer to time length of button presses
       elapsedMillis press_started;
 
 
@@ -100,14 +100,14 @@ class ClickType : public Transform<bool, ClickTypes> {
 
       /// Processes an ultra long click. Unlike the other click types,
       /// ultra long clicks are executed as soon as they pass the
-      /// "ultra long"
+      /// "ultra long" delay
       void on_ultra_long_click(const char* keyType);
 
 
 
       /**
-       * Resets click tracking variables after a press has been released so the
-       * next button press can be processed.
+       * Resets click tracking variables after a press has been released and
+       * successfully translated into a click event
        */
       void on_click_completed();
 
@@ -115,8 +115,8 @@ class ClickType : public Transform<bool, ClickTypes> {
       /**
        * Emits the specified value after a 5 millisecond delay. This allows
        * translated click types like SingleClick and DoubleClick to be
-       * sent but delays its processing so the ClickTyes::ButtonReleased
-       * can propogate through the system.
+       * sent, but delays its processing so the "ButtonPress" and
+       * "ButtonRelease" click typesbvcan propagate through the system.
        */
       void emitDelayed(ClickTypes value);
 };

--- a/src/transforms/click_type.h
+++ b/src/transforms/click_type.h
@@ -5,120 +5,118 @@
 
 #include "transforms/transform.h"
 
-
 /**
- * ClickTypes defines the types of clicks and button presses a ClickType transform can detect
+ * ClickTypes defines the types of clicks and button presses a ClickType
+ * transform can detect
  */
-enum class ClickTypes { ButtonPress, ButtonRelease, SingleClick, LongSingleClick, UltraLongSingleClick, DoubleClick };
-
+enum class ClickTypes {
+  ButtonPress,
+  ButtonRelease,
+  SingleClick,
+  LongSingleClick,
+  UltraLongSingleClick,
+  DoubleClick
+};
 
 /**
  * ClickType adds a time element to button presses. It measures the time between
  * a button press and its release and will emit its value as an encoded version
- * of the button press. 
+ * of the button press.
  */
 class ClickType : public Transform<bool, ClickTypes> {
+ public:
+  /**
+   * The constructor
+   * @param config_path The configuration path to use if you want the end user
+   * to be able to change these values with the configuration UI. Leave as blank
+   * to disable this feature.
+   * @param long_click_delay The number of milliseconds that an incoming button
+   *  press must be held to differentiate between a SingleClick and a
+   * LongSingleClick. This value should be less than ultra_long_click_delay
+   * @param double_click_interval The maximum number of milliseconds that can
+   * pass before two consecutive button presses are sent as two SingleClick
+   * events, or a single DoubleClick event.  If the interval is less than or
+   * equal to double_click_interval milliseconds, a single DoubleClick event is
+   * emitted.
+   * @param ultra_long_click_delay The number of milliseconds that an incoming
+   * button press must be held to register a single UltraLongSingleClick. Once a
+   * button has been held for ultra_long_click_delay milliseoncs, an
+   * UltraLongSingleClick is immediately emitted. This value should be longer
+   * than long_click_delay
+   *
+   */
+  ClickType(String config_path = "", long long_click_delay = 1300,
+            long double_click_interval = 400,
+            long ultra_long_click_delay = 5000);
 
-    public:
+  /**
+   * Returns TRUE if the specified value is one of the higher level click
+   * interpretations like SingleClick or UltraLongDoubleClick. It returns FALSE
+   * if the value is ButtonPress or ButtonRelease
+   */
+  static bool is_click(ClickTypes value);
 
-      /**
-       * The constructor
-       * @param config_path The configuration path to use if you want the end user to be
-       * able to change these values with the configuration UI. Leave as blank to 
-       * disable this feature.
-       * @param long_click_delay The number of milliseconds that an incoming button
-       *  press must be held to differentiate between a SingleClick and a LongSingleClick.
-       *  This value should be less than ultra_long_click_delay
-       * @param double_click_interval The maximum number of milliseconds that can pass
-       *  before two consecutive button presses are sent as two SingleClick events, or
-       *  a single DoubleClick event.  If the interval is less than or equal to 
-       *  double_click_interval milliseconds, a single DoubleClick event is emitted.
-       * @param ultra_long_click_delay The number of milliseconds that an incoming button
-       *  press must be held to register a single UltraLongSingleClick. Once a button
-       *  has been held for ultra_long_click_delay milliseoncs, an UltraLongSingleClick
-       *  is immediately emitted. This value should be longer than long_click_delay
-       * 
-       */
-      ClickType(String config_path = "", long long_click_delay = 1300, long double_click_interval = 400, long ultra_long_click_delay = 5000);
+  virtual void set_input(bool input, uint8_t input_channel = 0) override;
+  virtual void get_configuration(JsonObject& doc) override;
+  virtual bool set_configuration(const JsonObject& config) override;
+  virtual String get_config_schema() override;
 
-      /**
-       * Returns TRUE if the specified value is one of the higher level click interpretations
-       * like SingleClick or UltraLongDoubleClick. It returns FALSE if the value is
-       * ButtonPress or ButtonRelease
-       */
-      static bool is_click(ClickTypes value);
+ protected:
+  /// A counter to specify how many clicks are currently being
+  /// processed. Used to distinguish between single and double
+  /// clicks.
+  int click_count;
 
-      virtual void set_input(bool input, uint8_t input_channel = 0) override;
-      virtual void get_configuration(JsonObject& doc) override;
-      virtual bool set_configuration(const JsonObject& config) override;
-      virtual String get_config_schema() override;
+  // User Configuration variables...
 
-    protected:
-      /// A counter to specify how many clicks are currently being
-      /// processed. Used to distinguish between single and double
-      /// clicks.
-      int click_count;
+  /// How many milliseconds a button is pressed to distinguish between
+  /// a normal SingleClick and a LongSingleClick
+  long long_click_delay;
 
+  /// How many milliseoncs a button is pressed to distinguish between
+  /// a normal SingleClick and an UltraLongSingleClick
+  long ultra_long_click_delay;
 
-      // User Configuration variables...
+  /// The maximum number of milliseconds that can pass before two
+  /// clicks in a row are combined into a single DoubleClick
+  long double_click_interval;
 
-      /// How many milliseconds a button is pressed to distinguish between
-      /// a normal SingleClick and a LongSingleClick
-      long long_click_delay;
+  /// Timmer to time button presses
+  elapsedMillis press_duration;
 
-      /// How many milliseoncs a button is pressed to distinguish between
-      /// a normal SingleClick and an UltraLongSingleClick
-      long ultra_long_click_delay;
+  /// Timer to time interval between button releases
+  elapsedMillis release_duration;
 
-      /// The maximum number of milliseconds that can pass before two
-      /// clicks in a row are combined into a single DoubleClick
-      long double_click_interval;
+  /// Holds a delayed "SingleClick" report that we can pull back
+  /// if the second click of a double click comes through. This
+  /// value will be NULL if no click report is currently
+  /// queued up.
+  DelayReaction* delayed_click_report;
 
+  /// Processes incoming values that represent a "ButonPress" event
+  void on_button_press();
 
-      /// Timmer to time button presses
-      elapsedMillis press_duration;
+  /// Processes incoming value that represent a "ButtonRelease" event
+  void on_button_release();
 
+  /// Processes an ultra long click. Unlike the other click types,
+  /// ultra long clicks are executed as soon as they pass the
+  /// "ultra long"
+  void on_ultra_long_click();
 
-      /// Timer to time interval between button releases
-      elapsedMillis release_duration;
+  /**
+   * Resets click tracking variables after a press has been released so the
+   * next button press can be processed.
+   */
+  void on_click_completed();
 
-
-      /// Holds a delayed "SingleClick" report that we can pull back
-      /// if the second click of a double click comes through. This
-      /// value will be NULL if no click report is currently
-      /// queued up.
-      DelayReaction* delayed_click_report;
-
-
-      /// Processes incoming values that represent a "ButonPress" event
-      void on_button_press();
-
-
-      /// Processes incoming value that represent a "ButtonRelease" event
-      void on_button_release();
-
-
-      /// Processes an ultra long click. Unlike the other click types,
-      /// ultra long clicks are executed as soon as they pass the
-      /// "ultra long"
-      void on_ultra_long_click();
-
-
-
-      /**
-       * Resets click tracking variables after a press has been released so the
-       * next button press can be processed.
-       */
-      void on_click_completed();
-
-
-      /**
-       * Emits the specified value after a 5 millisecond delay. This allows
-       * translated click types like SingleClick and DoubleClick to be
-       * sent but delays its processing so the ClickTypes::ButtonReleased
-       * can propogate through the system.
-       */
-      void emitDelayed(ClickTypes value);
+  /**
+   * Emits the specified value after a 5 millisecond delay. This allows
+   * translated click types like SingleClick and DoubleClick to be
+   * sent but delays its processing so the ClickTypes::ButtonReleased
+   * can propogate through the system.
+   */
+  void emitDelayed(ClickTypes value);
 };
 
 #endif


### PR DESCRIPTION
This is a refactor of the ClickType class. 

Changes based on our discussions:

1. ButtonPress and ButtonRelease ClickTypes have been added and are reported appropriately

2. The big convoluted IF statement from `set_input()` has been broken up into smaller functional methods for clarity

3. All protected state member variables have been documented for Doxygen.  Many have been renamed to clarify their use

4. elapsedMillis class library was used for timing routines.  Two member values that saved the current millis() value has been refactored to be elapsedMillis types

I did not use a state machine because really there are only two states: "idle" (`click_count == 0`) and "click in progress" (`click_count >= 1`).  The old code did use some implied values on the timer values to determine state, so I refactored the code to use these more explicit state values in the IF statements.

The Button class from the other PR has been dropped and I'll put similar but refactored functionality in a new PR