### PR TITLE
PressRepeater transform

### DIFF
--- a/src/transforms/press_repeater.cpp
+++ b/src/transforms/press_repeater.cpp
@@ -1,0 +1,86 @@
+#include "transforms/press_repeater.h"
+
+
+PressRepeater::PressRepeater(String config_path, int integer_false, int repeat_start_interval, int repeat_interval) : 
+    BooleanTransform(config_path),
+    integer_false{integer_false},
+    repeat_start_interval{repeat_start_interval},
+    repeat_interval{repeat_interval},
+    pushed{false},
+    repeating{false} {
+    load_configuration();
+}
+
+
+void PressRepeater::enable() {
+
+  app.onRepeat(10, [this]() {
+
+     if (pushed) {
+         // A press is currently in progress
+         if (repeating) {
+            if (last_value_sent > (unsigned long)repeat_interval) {
+                debugD("Repeating press report");
+                last_value_sent = 0;
+                this->emit(true);
+            }
+         }
+         else if (last_value_sent > (unsigned long)repeat_start_interval) {
+            debugD("Starting press report repeat");
+            repeating = true;
+            last_value_sent = 0;
+            this->emit(true);
+         }
+     }
+  });
+
+}
+
+
+void PressRepeater::set_input(int new_value, uint8_t input_channel) {
+   this->set_input(new_value != integer_false, input_channel);
+}
+
+
+void PressRepeater::set_input(bool new_value, uint8_t input_channel) {
+   if (new_value != pushed) {
+      pushed = new_value;
+
+      if (!pushed) {
+         repeating = false;
+      }
+
+      last_value_sent = 0;
+      this->emit(pushed);
+   }
+}
+
+
+void PressRepeater::get_configuration(JsonObject& root) {
+  root["repeat_start_interval"] = repeat_start_interval;
+  root["repeat_interval"] = repeat_interval;
+}
+
+
+static const char SCHEMA[] PROGMEM = R"###({
+    "type": "object",
+    "properties": {
+        "repeat_start_interval": { "title": "Start repeating after (ms)", "type": "integer" },
+        "repeat_interval": { "title": "Repeat report interval (ms)", "type": "integer" }
+    }
+})###";
+
+
+String PressRepeater::get_config_schema() { return FPSTR(SCHEMA); }
+
+bool PressRepeater::set_configuration(const JsonObject& config) {
+  String expected[] = {"repeat_start_interval", "repeat_interval"};
+  for (auto str : expected) {
+    if (!config.containsKey(str)) {
+      return false;
+    }
+  }
+  repeat_start_interval = config["repeat_start_interval"];
+  repeat_interval = config["repeat_interval"];
+  return true;
+}

--- a/src/transforms/press_repeater.cpp
+++ b/src/transforms/press_repeater.cpp
@@ -1,66 +1,57 @@
 #include "transforms/press_repeater.h"
 
-
-PressRepeater::PressRepeater(String config_path, int integer_false, int repeat_start_interval, int repeat_interval) : 
-    BooleanTransform(config_path),
-    integer_false{integer_false},
-    repeat_start_interval{repeat_start_interval},
-    repeat_interval{repeat_interval},
-    pushed{false},
-    repeating{false} {
-    load_configuration();
+PressRepeater::PressRepeater(String config_path, int integer_false,
+                             int repeat_start_interval, int repeat_interval)
+    : BooleanTransform(config_path),
+      integer_false{integer_false},
+      repeat_start_interval{repeat_start_interval},
+      repeat_interval{repeat_interval},
+      pushed{false},
+      repeating{false} {
+  load_configuration();
 }
-
 
 void PressRepeater::enable() {
-
   app.onRepeat(10, [this]() {
-
-     if (pushed) {
-         // A press is currently in progress
-         if (repeating) {
-            if (last_value_sent > (unsigned long)repeat_interval) {
-                debugD("Repeating press report");
-                last_value_sent = 0;
-                this->emit(true);
-            }
-         }
-         else if (last_value_sent > (unsigned long)repeat_start_interval) {
-            debugD("Starting press report repeat");
-            repeating = true;
-            last_value_sent = 0;
-            this->emit(true);
-         }
-     }
+    if (pushed) {
+      // A press is currently in progress
+      if (repeating) {
+        if (last_value_sent > (unsigned long)repeat_interval) {
+          debugD("Repeating press report");
+          last_value_sent = 0;
+          this->emit(true);
+        }
+      } else if (last_value_sent > (unsigned long)repeat_start_interval) {
+        debugD("Starting press report repeat");
+        repeating = true;
+        last_value_sent = 0;
+        this->emit(true);
+      }
+    }
   });
-
 }
-
 
 void PressRepeater::set_input(int new_value, uint8_t input_channel) {
-   this->set_input(new_value != integer_false, input_channel);
+  this->set_input(new_value != integer_false, input_channel);
 }
-
 
 void PressRepeater::set_input(bool new_value, uint8_t input_channel) {
-   if (new_value != pushed) {
-      pushed = new_value;
+  if (new_value != pushed) {
+    pushed = new_value;
 
-      if (!pushed) {
-         repeating = false;
-      }
+    if (!pushed) {
+      repeating = false;
+    }
 
-      last_value_sent = 0;
-      this->emit(pushed);
-   }
+    last_value_sent = 0;
+    this->emit(pushed);
+  }
 }
-
 
 void PressRepeater::get_configuration(JsonObject& root) {
   root["repeat_start_interval"] = repeat_start_interval;
   root["repeat_interval"] = repeat_interval;
 }
-
 
 static const char SCHEMA[] PROGMEM = R"###({
     "type": "object",
@@ -69,7 +60,6 @@ static const char SCHEMA[] PROGMEM = R"###({
         "repeat_interval": { "title": "Repeat report interval (ms)", "type": "integer" }
     }
 })###";
-
 
 String PressRepeater::get_config_schema() { return FPSTR(SCHEMA); }
 

--- a/src/transforms/press_repeater.h
+++ b/src/transforms/press_repeater.h
@@ -1,0 +1,50 @@
+#ifndef _press_repeater_H_
+#define _press_repeater_H_
+
+#include <elapsedMillis.h>
+
+#include "sensors/digital_input.h"
+#include "transforms/transform.h"
+#include "system/valueconsumer.h"
+
+/**
+ * PressRepeater is a transform that takes boolean inputs and adds
+ * button behaviors familiar to many device end users.
+ * It emits a value only when the state of the input changes
+ * (i.e. when the input changes from TRUE to FALSE, and vice versa).
+ * In addition, if the input remains TRUE longer than repeat_start_interval 
+ * milliseconds, it will emit TRUE once again, and then again every 
+ * repeat_interval milliseconds until the input returns to FALSE.
+ * <p>An example use case would be a DigitalInput connected to a button
+ * that represents the "Volume Up" or "Volume Down" of a sound system.
+ * <p>As a convenience for wiring up to DigitalInputValue and other
+ * producers that emit integers, PressRepeater can also consume
+ * integer values.  As long as the integer value coming in does not 
+ * match integer_false PressRepeater will act as if TRUE was passed to it.
+ */
+class PressRepeater : public BooleanTransform,
+                      public IntegerConsumer {
+
+    public:
+        PressRepeater(String config_path = "", int integer_false = 0, int repeat_start_interval = 1500, int repeat_interval = 250);
+
+        virtual void enable() override;
+
+        virtual void set_input(bool new_value, uint8_t input_channel = 0) override;
+        virtual void set_input(int new_value, uint8_t input_channel = 0) override;
+
+        virtual void get_configuration(JsonObject& doc) override;
+        virtual bool set_configuration(const JsonObject& config) override;
+        virtual String get_config_schema() override;
+    protected:
+       int integer_false;
+       int repeat_start_interval;
+       int repeat_interval;
+       elapsedMillis last_value_sent;
+       bool pushed;
+       bool repeating;
+
+};
+
+
+#endif

--- a/src/transforms/press_repeater.h
+++ b/src/transforms/press_repeater.h
@@ -4,47 +4,45 @@
 #include <elapsedMillis.h>
 
 #include "sensors/digital_input.h"
-#include "transforms/transform.h"
 #include "system/valueconsumer.h"
+#include "transforms/transform.h"
 
 /**
  * PressRepeater is a transform that takes boolean inputs and adds
  * button behaviors familiar to many device end users.
  * It emits a value only when the state of the input changes
  * (i.e. when the input changes from TRUE to FALSE, and vice versa).
- * In addition, if the input remains TRUE longer than repeat_start_interval 
- * milliseconds, it will emit TRUE once again, and then again every 
+ * In addition, if the input remains TRUE longer than repeat_start_interval
+ * milliseconds, it will emit TRUE once again, and then again every
  * repeat_interval milliseconds until the input returns to FALSE.
  * <p>An example use case would be a DigitalInput connected to a button
  * that represents the "Volume Up" or "Volume Down" of a sound system.
  * <p>As a convenience for wiring up to DigitalInputValue and other
  * producers that emit integers, PressRepeater can also consume
- * integer values.  As long as the integer value coming in does not 
+ * integer values.  As long as the integer value coming in does not
  * match integer_false PressRepeater will act as if TRUE was passed to it.
  */
-class PressRepeater : public BooleanTransform,
-                      public IntegerConsumer {
+class PressRepeater : public BooleanTransform, public IntegerConsumer {
+ public:
+  PressRepeater(String config_path = "", int integer_false = 0,
+                int repeat_start_interval = 1500, int repeat_interval = 250);
 
-    public:
-        PressRepeater(String config_path = "", int integer_false = 0, int repeat_start_interval = 1500, int repeat_interval = 250);
+  virtual void enable() override;
 
-        virtual void enable() override;
+  virtual void set_input(bool new_value, uint8_t input_channel = 0) override;
+  virtual void set_input(int new_value, uint8_t input_channel = 0) override;
 
-        virtual void set_input(bool new_value, uint8_t input_channel = 0) override;
-        virtual void set_input(int new_value, uint8_t input_channel = 0) override;
+  virtual void get_configuration(JsonObject& doc) override;
+  virtual bool set_configuration(const JsonObject& config) override;
+  virtual String get_config_schema() override;
 
-        virtual void get_configuration(JsonObject& doc) override;
-        virtual bool set_configuration(const JsonObject& config) override;
-        virtual String get_config_schema() override;
-    protected:
-       int integer_false;
-       int repeat_start_interval;
-       int repeat_interval;
-       elapsedMillis last_value_sent;
-       bool pushed;
-       bool repeating;
-
+ protected:
+  int integer_false;
+  int repeat_start_interval;
+  int repeat_interval;
+  elapsedMillis last_value_sent;
+  bool pushed;
+  bool repeating;
 };
-
 
 #endif


### PR DESCRIPTION
This is the main functionality of the old Button class, refactored to drop the digital input functionality and wrap the behavior in a BooleanTransform.

I opted to name this PressRepeater because upon further reflection, the suggested DigitalInputRepeater was too specific. While wiring this up to a digital input is by far the most common use case, I could see the need to use a different input, such as the boolean value coming in from a PUT request listener. That name may have made sense if we kept the "digital input" functionality in it, but as of now, this is a simple, generic transform.