### PR TITLE
Fix EspSoftwareSerial problem

### DIFF
--- a/examples/platformio.ini
+++ b/examples/platformio.ini
@@ -35,6 +35,7 @@ board_build.ldscript = eagle.flash.4m1m.ld
 build_flags =
    -Wall
    -Wno-reorder
+lib_ignore = EspSoftwareSerial   
 
 [env:d1_mini]
 extends = espressif8266_base

--- a/library.json
+++ b/library.json
@@ -111,8 +111,7 @@
       "name": "Adafruit AHRS"
     },
     {
-      "name": "EspSoftwareSerial",
-      "platforms": ["espressif32"]
+      "name": "EspSoftwareSerial"
     },
     {
       "name": "RemoteDebug",


### PR DESCRIPTION
Use `lib_ignore` for ESP8266 in `platformio.ini` to finally resolve the EspSoftwareSerial problem.