### PR TITLE
Change debounce logic

### DIFF
--- a/src/transforms/debounce.cpp
+++ b/src/transforms/debounce.cpp
@@ -13,9 +13,9 @@ DebounceTemplate<T>::DebounceTemplate(int ms_min_delay, String config_path)
 template<class T>
 void DebounceTemplate<T>::set_input(T newValue, uint8_t inputChannel) {
   if (interrupt_timer_ > ms_min_delay_) {
-    interrupt_timer_ = 0;
     this->emit(newValue);
   }
+  interrupt_timer_ = 0;
 }
 
 template<class T>

--- a/src/transforms/debounce.cpp
+++ b/src/transforms/debounce.cpp
@@ -1,14 +1,48 @@
 #include "debounce.h"
 
-Debounce::Debounce(int ms_min_delay, String config_path)
-    : BooleanTransform(config_path), ms_min_delay{ms_min_delay} {
-  last_time = millis();
+template<class T>
+Debounce<T>::Debounce(int ms_min_delay, String config_path)
+    : SymmetricTransform<T>(config_path), ms_min_delay{ms_min_delay} {
+      interrupt_timer = 0;
 }
 
-void Debounce::set_input(bool newValue, uint8_t inputChannel) {
-  int elapsed = millis() - last_time;
-  if (newValue != output || elapsed > ms_min_delay) {
-    last_time = millis();
+template<class T>
+void Debounce<T>::set_input(T newValue, uint8_t inputChannel) {
+  if (interrupt_timer > ms_min_delay) {
+    interrupt_timer = 0;
     this->emit(newValue);
   }
 }
+
+template<class T>
+void Debounce<T>::get_configuration(JsonObject& root) {
+  root["min_delay"] = ms_min_delay;
+}
+
+static const char SCHEMA[] PROGMEM = R"###({
+    "type": "object",
+    "properties": {
+        "min_delay": { "title": "Minimum delay", "type": "number", "description": "The minimum time in ms between inputs for output to happen" }
+    }
+  })###";
+
+template<class T>
+String Debounce<T>::get_config_schema() { return FPSTR(SCHEMA); }
+
+template<class T>
+bool Debounce<T>::set_configuration(const JsonObject& config) {
+  String expected[] = {"min_delay"};
+  for (auto str : expected) {
+    if (!config.containsKey(str)) {
+      return false;
+    }
+  }
+  ms_min_delay = config["min_delay"];
+  return true;
+}
+
+// define all possible instances of a Debounce
+template class Debounce<bool>;
+template class Debounce<int>;
+template class Debounce<float>;
+template class Debounce<String>;

--- a/src/transforms/debounce.cpp
+++ b/src/transforms/debounce.cpp
@@ -1,5 +1,9 @@
 #include "debounce.h"
 
+// Developers: this isn't an ideal implementation of a templated Transform.
+// See the limitations and suggestion solution in SensESP Issue #287.
+// https://github.com/SignalK/SensESP/issues/287
+
 template<class T>
 DebounceTemplate<T>::DebounceTemplate(int ms_min_delay, String config_path)
     : SymmetricTransform<T>(config_path), ms_min_delay_{ms_min_delay} {

--- a/src/transforms/debounce.cpp
+++ b/src/transforms/debounce.cpp
@@ -1,13 +1,13 @@
 #include "debounce.h"
 
 template<class T>
-Debounce<T>::Debounce(int ms_min_delay, String config_path)
+DebounceTemplate<T>::DebounceTemplate(int ms_min_delay, String config_path)
     : SymmetricTransform<T>(config_path), ms_min_delay_{ms_min_delay} {
       interrupt_timer_ = 0;
 }
 
 template<class T>
-void Debounce<T>::set_input(T newValue, uint8_t inputChannel) {
+void DebounceTemplate<T>::set_input(T newValue, uint8_t inputChannel) {
   if (interrupt_timer_ > ms_min_delay_) {
     interrupt_timer_ = 0;
     this->emit(newValue);
@@ -15,7 +15,7 @@ void Debounce<T>::set_input(T newValue, uint8_t inputChannel) {
 }
 
 template<class T>
-void Debounce<T>::get_configuration(JsonObject& root) {
+void DebounceTemplate<T>::get_configuration(JsonObject& root) {
   root["min_delay"] = ms_min_delay_;
 }
 
@@ -27,10 +27,10 @@ static const char SCHEMA[] PROGMEM = R"###({
   })###";
 
 template<class T>
-String Debounce<T>::get_config_schema() { return FPSTR(SCHEMA); }
+String DebounceTemplate<T>::get_config_schema() { return FPSTR(SCHEMA); }
 
 template<class T>
-bool Debounce<T>::set_configuration(const JsonObject& config) {
+bool DebounceTemplate<T>::set_configuration(const JsonObject& config) {
   String expected[] = {"min_delay"};
   for (auto str : expected) {
     if (!config.containsKey(str)) {
@@ -42,7 +42,7 @@ bool Debounce<T>::set_configuration(const JsonObject& config) {
 }
 
 // define all possible instances of a Debounce
-template class Debounce<bool>;
-template class Debounce<int>;
-template class Debounce<float>;
-template class Debounce<String>;
+template class DebounceTemplate<bool>;
+template class DebounceTemplate<int>;
+template class DebounceTemplate<float>;
+template class DebounceTemplate<String>;

--- a/src/transforms/debounce.cpp
+++ b/src/transforms/debounce.cpp
@@ -11,14 +11,14 @@ DebounceTemplate<T>::DebounceTemplate(int ms_min_delay, String config_path)
       value_sent_{false},
       stable_input_{false},
       reaction_{NULL} {
-  load_configuration();
+  this->load_configuration();
 }
 
 template <class T>
-void DebounceTemplate<T>::set_input(T newValue, uint8_t inputChannel) {
+void DebounceTemplate<T>::set_input(T input, uint8_t inputChannel) {
   if (reaction_ != NULL) {
     reaction_->remove();
-    reaction = NULL;
+    reaction_ = NULL;
   }
   // Input has changed since the last emit, or this is the first
   // input since the program started to run.
@@ -63,4 +63,4 @@ bool DebounceTemplate<T>::set_configuration(const JsonObject& config) {
 template class DebounceTemplate<bool>;
 template class DebounceTemplate<int>;
 template class DebounceTemplate<float>;
-template class DebounceTemplate<String>;
+//template class DebounceTemplate<String>;

--- a/src/transforms/debounce.cpp
+++ b/src/transforms/debounce.cpp
@@ -2,21 +2,21 @@
 
 template<class T>
 Debounce<T>::Debounce(int ms_min_delay, String config_path)
-    : SymmetricTransform<T>(config_path), ms_min_delay{ms_min_delay} {
-      interrupt_timer = 0;
+    : SymmetricTransform<T>(config_path), ms_min_delay_{ms_min_delay} {
+      interrupt_timer_ = 0;
 }
 
 template<class T>
 void Debounce<T>::set_input(T newValue, uint8_t inputChannel) {
-  if (interrupt_timer > ms_min_delay) {
-    interrupt_timer = 0;
+  if (interrupt_timer_ > ms_min_delay_) {
+    interrupt_timer_ = 0;
     this->emit(newValue);
   }
 }
 
 template<class T>
 void Debounce<T>::get_configuration(JsonObject& root) {
-  root["min_delay"] = ms_min_delay;
+  root["min_delay"] = ms_min_delay_;
 }
 
 static const char SCHEMA[] PROGMEM = R"###({
@@ -37,7 +37,7 @@ bool Debounce<T>::set_configuration(const JsonObject& config) {
       return false;
     }
   }
-  ms_min_delay = config["min_delay"];
+  ms_min_delay_ = config["min_delay"];
   return true;
 }
 

--- a/src/transforms/debounce.h
+++ b/src/transforms/debounce.h
@@ -23,8 +23,8 @@ class Debounce : public SymmetricTransform<T> {
   virtual void set_input(T new_value, uint8_t input_channel = 0) override;
 
  private:
-  elapsedMillis interrupt_timer;
-  int ms_min_delay;
+  elapsedMillis interrupt_timer_;
+  int ms_min_delay_;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/transforms/debounce.h
+++ b/src/transforms/debounce.h
@@ -37,8 +37,10 @@ class DebounceTemplate : public SymmetricTransform<T> {
   virtual void set_input(T new_value, uint8_t input_channel = 0) override;
 
  private:
-  elapsedMillis interrupt_timer_;
   int ms_min_delay_;
+  bool value_sent_;
+  bool stable_input_;
+  DelayReaction* reaction_;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/transforms/debounce.h
+++ b/src/transforms/debounce.h
@@ -5,7 +5,7 @@
 #include <elapsedMillis.h>
 
 /**
- * @brief Debounce is a passthrough transform that will output a value only when
+ * @brief DebounceTemplate is a passthrough transform that will output a value only when
  * there is ms_min_delay milliseconds between inputs.
  *
  * @tparam T The type of value being passed through Debounce.
@@ -16,9 +16,9 @@
  * @param config_path The path for configuring ms_min_delay with the Config UI.
  */
 template<class T>
-class Debounce : public SymmetricTransform<T> {
+class DebounceTemplate : public SymmetricTransform<T> {
  public:
-  Debounce(int ms_min_delay = 200, String config_path = "");
+  DebounceTemplate(int ms_min_delay = 200, String config_path = "");
 
   virtual void set_input(T new_value, uint8_t input_channel = 0) override;
 
@@ -30,9 +30,10 @@ class Debounce : public SymmetricTransform<T> {
   virtual String get_config_schema() override;
 };
 
-typedef Debounce<bool> DebounceBool;
-typedef Debounce<int> DebounceInt;
-typedef Debounce<float> DebounceFloat;
-typedef Debounce<String> DebounceString;
+typedef DebounceTemplate<bool> DebounceBool;
+typedef DebounceTemplate<bool> Debounce; // for backward-compatibility with original class
+typedef DebounceTemplate<int> DebounceInt;
+typedef DebounceTemplate<float> DebounceFloat;
+typedef DebounceTemplate<String> DebounceString;
 
 #endif

--- a/src/transforms/debounce.h
+++ b/src/transforms/debounce.h
@@ -9,20 +9,30 @@
 // https://github.com/SignalK/SensESP/issues/287
 
 /**
- * @brief DebounceTemplate is a passthrough transform that will output a value only when
- * there is ms_min_delay milliseconds between inputs.
+ * @brief DebounceTemplate implements debounce code for a button or switch
+ * 
+ * It's a passthrough transform that will output a value immediately on the
+ * initial input, and then only when the time between inputs is greater than
+ * ms_min_delay milliseconds. If you're monitoring the button press and the button
+ * release, you need to make sure that the time between the stabilization of the
+ * the button press and the beginning of the button release is longer than ms_min_delay.
  *
  * @tparam T The type of value being passed through Debounce.
  *
  * @param ms_min_delay The minimum amount of time that must have passed since
- * the previous input in order for the output to occur.
+ * the previous input in order for the output to occur. This needs to be larger than the
+ * number of milliseconds between the successive bounces in a bouncy signal. For example,
+ * if your button bounces up and down every 5 milliseconds between the time you start the
+ * button press and the time all the bouncing stops, then ms_min_delay needs to be larger
+ * than 5. To be safe, make it at least twice the length of the longest bouncer interval
+ * you know your button might generate. The default value for this class is 20 ms.
  *
  * @param config_path The path for configuring ms_min_delay with the Config UI.
  */
 template<class T>
 class DebounceTemplate : public SymmetricTransform<T> {
  public:
-  DebounceTemplate(int ms_min_delay = 200, String config_path = "");
+  DebounceTemplate(int ms_min_delay = 20, String config_path = "");
 
   virtual void set_input(T new_value, uint8_t input_channel = 0) override;
 

--- a/src/transforms/debounce.h
+++ b/src/transforms/debounce.h
@@ -4,6 +4,10 @@
 #include "transforms/transform.h"
 #include <elapsedMillis.h>
 
+// Developers: this isn't an ideal implementation of a templated Transform.
+// See the limitations and suggestion solution in SensESP Issue #287.
+// https://github.com/SignalK/SensESP/issues/287
+
 /**
  * @brief DebounceTemplate is a passthrough transform that will output a value only when
  * there is ms_min_delay milliseconds between inputs.

--- a/src/transforms/debounce.h
+++ b/src/transforms/debounce.h
@@ -2,7 +2,6 @@
 #define debounce_H
 
 #include "transforms/transform.h"
-#include <elapsedMillis.h>
 
 // Developers: this isn't an ideal implementation of a templated Transform.
 // See the limitations and suggestion solution in SensESP Issue #287.
@@ -11,28 +10,27 @@
 /**
  * @brief DebounceTemplate implements debounce code for a button or switch
  * 
- * It's a passthrough transform that will output a value immediately on the
- * initial input, and then only when the time between inputs is greater than
- * ms_min_delay milliseconds. If you're monitoring the button press and the button
- * release, you need to make sure that the time between the stabilization of the
- * the button press and the beginning of the button release is longer than ms_min_delay.
+ * It's a passthrough transform that will output a value only if it's different
+ * from the previous output, and only if it's been ms_min_delay ms since the input
+ * was received, with no other input received since then.
  *
  * @tparam T The type of value being passed through Debounce.
  *
  * @param ms_min_delay The minimum amount of time that must have passed since
- * the previous input in order for the output to occur. This needs to be larger than the
- * number of milliseconds between the successive bounces in a bouncy signal. For example,
- * if your button bounces up and down every 5 milliseconds between the time you start the
- * button press and the time all the bouncing stops, then ms_min_delay needs to be larger
- * than 5. To be safe, make it at least twice the length of the longest bouncer interval
- * you know your button might generate. The default value for this class is 20 ms.
+ * the input was received by this Transform in order for the output to occur. If
+ * you are using this to debounce the output from DigitalInputChange, ms_min_delay
+ * should be set at least a little bit longer than DigitalInputChange::read_delay.
+ * 
+ * DigitalInputChange::read_delay is 10 ms by default, and Debounce::ms_min_delay
+ * is 15 ms by default. If that doesn't adequately debounce your button or switch,
+ * adjust both of those values until it does.
  *
  * @param config_path The path for configuring ms_min_delay with the Config UI.
  */
 template<class T>
 class DebounceTemplate : public SymmetricTransform<T> {
  public:
-  DebounceTemplate(int ms_min_delay = 20, String config_path = "");
+  DebounceTemplate(int ms_min_delay = 15, String config_path = "");
 
   virtual void set_input(T new_value, uint8_t input_channel = 0) override;
 
@@ -50,6 +48,6 @@ typedef DebounceTemplate<bool> DebounceBool;
 typedef DebounceTemplate<bool> Debounce; // for backward-compatibility with original class
 typedef DebounceTemplate<int> DebounceInt;
 typedef DebounceTemplate<float> DebounceFloat;
-typedef DebounceTemplate<String> DebounceString;
+//typedef DebounceTemplate<String> DebounceString;
 
 #endif

--- a/src/transforms/debounce.h
+++ b/src/transforms/debounce.h
@@ -2,21 +2,37 @@
 #define debounce_H
 
 #include "transforms/transform.h"
+#include <elapsedMillis.h>
 
 /**
- * Debounce is a boolean passthrough transform that will only
- * accept value changes that are sufficiently spaced apart to
- * be passed on to the next consumer.
+ * @brief Debounce is a passthrough transform that will output a value only when
+ * there is ms_min_delay milliseconds between inputs.
+ *
+ * @tparam T The type of value being passed through Debounce.
+ *
+ * @param ms_min_delay The minimum amount of time that must have passed since
+ * the previous input in order for the output to occur.
+ *
+ * @param config_path The path for configuring ms_min_delay with the Config UI.
  */
-class Debounce : public BooleanTransform {
+template<class T>
+class Debounce : public SymmetricTransform<T> {
  public:
   Debounce(int ms_min_delay = 200, String config_path = "");
 
-  virtual void set_input(bool new_value, uint8_t input_channel = 0) override;
+  virtual void set_input(T new_value, uint8_t input_channel = 0) override;
 
- protected:
-  unsigned long last_time;
+ private:
+  elapsedMillis interrupt_timer;
   int ms_min_delay;
+  virtual void get_configuration(JsonObject& doc) override;
+  virtual bool set_configuration(const JsonObject& config) override;
+  virtual String get_config_schema() override;
 };
+
+typedef Debounce<bool> DebounceBool;
+typedef Debounce<int> DebounceInt;
+typedef Debounce<float> DebounceFloat;
+typedef Debounce<String> DebounceString;
 
 #endif


### PR DESCRIPTION
The logic for the Debounce Transform wasn't really doing a debounce. Now it is.
Also made it a Template class to handle all types of input.
Also made the debounce delay configurable.
Also updated the comments to Doxygen style.
(Oops - I guess this should have been four different commits. Sorry!)