### PR TITLE
DigitalInput fixes and updates

### DIFF
--- a/src/sensors/digital_input.cpp
+++ b/src/sensors/digital_input.cpp
@@ -102,7 +102,8 @@ DigitalInputChange::DigitalInputChange(uint8_t pin, int pin_mode,
     : DigitalInput(pin, pin_mode, interrupt_type, config_path),
       IntegerProducer(),
       read_delay_{read_delay},
-      triggered_{false} {
+      triggered_{false},
+      last_output_{0} {
     load_configuration();    
     }
 
@@ -112,12 +113,13 @@ void DigitalInputChange::enable() {
       output = digitalRead(pin_);
       triggered_ = true;
     });
-  // app.onTick was tried for this, but for some reason, it doesn't work.
-  // app.onRepeat() does work.
+  
+  
   app.onRepeat(read_delay_, [this](){
-      if (triggered_) {
+      if (triggered_ && output != last_output_) {
         noInterrupts();
         triggered_ = false;
+        last_output_ = output;
         interrupts();
         notify();
       }

--- a/src/sensors/digital_input.cpp
+++ b/src/sensors/digital_input.cpp
@@ -10,37 +10,36 @@ DigitalInput::DigitalInput(uint8_t pin, int pin_mode, int interrupt_type,
   pinMode(pin, pin_mode);
 }
 
-DigitalInputValue::DigitalInputValue(uint8_t pin, int pin_mode,
+DigitalInputState::DigitalInputState(uint8_t pin, int pin_mode,
                                      int interrupt_type, int read_delay,
                                      String config_path)
     : DigitalInput{pin, pin_mode, interrupt_type, config_path},
       IntegerProducer(),
-      read_delay{read_delay} {
+      read_delay{read_delay},
+      triggered{false} {
   load_configuration();      
 }
 
-void DigitalInputValue::enable() {
+void DigitalInputState::enable() {
   app.onRepeat(read_delay, [this]() {
     emit(digitalRead(pin));
   });
 }
 
-void DigitalInputValue::get_configuration(JsonObject& root) {
+void DigitalInputState::get_configuration(JsonObject& root) {
   root["read_delay"] = read_delay;
-  root["value"] = output;
 }
 
 static const char SCHEMA2[] PROGMEM = R"###({
     "type": "object",
     "properties": {
-        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" },
-        "value": { "title": "Last value", "type" : "number", "readOnly": true }
+        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" }
     }
   })###";
 
-String DigitalInputValue::get_config_schema() { return FPSTR(SCHEMA2); }
+String DigitalInputState::get_config_schema() { return FPSTR(SCHEMA2); }
 
-bool DigitalInputValue::set_configuration(const JsonObject& config) {
+bool DigitalInputState::set_configuration(const JsonObject& config) {
   String expected[] = {"read_delay"};
   for (auto str : expected) {
     if (!config.containsKey(str)) {
@@ -74,14 +73,12 @@ void DigitalInputCounter::enable() {
 
 void DigitalInputCounter::get_configuration(JsonObject& root) {
   root["read_delay"] = read_delay;
-  root["value"] = output;
 }
 
 static const char SCHEMA[] PROGMEM = R"###({
     "type": "object",
     "properties": {
-        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" },
-        "value": { "title": "Last value", "type" : "number", "readOnly": true }
+        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" }
     }
   })###";
 

--- a/src/sensors/digital_input.h
+++ b/src/sensors/digital_input.h
@@ -3,6 +3,18 @@
 
 #include "sensor.h"
 
+ /**
+ * @brief DigitalInput is the base class for reading a digital GPIO pin.
+ *
+ * @param pin The GPIO pin to which the device is connected
+ * 
+ * @param pin_mode Will be INPUT or INPUT_PULLUP
+ * 
+ * @param interrupt_type Will be RISING, FALLING, or CHANGE
+ * 
+ * @param config_path The path to configuring read_delay in the Config UI
+ * 
+ * */
 class DigitalInput : public Sensor {
  public:
   DigitalInput(uint8_t pin, int pin_mode, int interrupt_type,
@@ -13,24 +25,68 @@ class DigitalInput : public Sensor {
   int interrupt_type;
 };
 
-// DigitalInputValue is meant to report directly the state of
-// a slowly changing signal
-class DigitalInputValue : public DigitalInput, public IntegerProducer {
+
+ /**
+ * @brief DigitalInputState reports the state of a digital pin every read_delay ms.
+ * 
+ * Formerly called DigitalInputValue.
+ *
+ * It's useful for monitoring a device (such as a bilge pump) that should (or
+ * shouldn't) normally be on (or off). If you use the Signal K to InfluxDb Plugin
+ * and Grafana, you can easily see the frequency and duration of the device being
+ * on and off.
+ *
+ * @param pin The GPIO pin to which the device is connected.
+ * 
+ * @param pin_mode Will be INPUT or INPUT_PULLUP.
+ * 
+ * @param interrupt_type Will be RISING, FALLING, or CHANGE, but it doesn't matter
+ * which one you use, as this Class doesn't use an interrupt.
+ * 
+ * @param read_delay How often you want to read the pin, in ms.
+ * 
+ * @param config_path The path to configuring read_delay in the Config UI.
+ * 
+ * */
+class DigitalInputState : public DigitalInput, public IntegerProducer {
  public:
-  DigitalInputValue(uint8_t pin, int pin_mode, int interrupt_type,
+
+  DigitalInputState(uint8_t pin, int pin_mode, int interrupt_type,
                     int read_delay = 1000, String config_path = "");
 
   virtual void enable() override final;
 
  private:
-  bool triggered = false;
   int read_delay;
+  bool triggered;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;
 };
 
-// DigitalInputCounter tracks rapidly changing digital inputs
+// FIXME: Uncomment the following once the PIO Xtensa toolchain is updated
+// [[deprecated("Use DigitalInputState instead.")]]
+typedef DigitalInputState DigitalInputValue;
+
+
+ /**
+ * @brief DigitalInputCounter counts interrupts and reports the count every
+ * read_delay ms.
+ *
+ * A typical use case is to count the revolutions of something, such as an
+ * engine, to determine RPM. See /examples/rpm_counter.cpp
+ *
+ * @param pin The GPIO pin to which the device is connected
+ * 
+ * @param pin_mode Will be INPUT or INPUT_PULLUP
+ * 
+ * @param interrupt_type Will be RISING, FALLING, or CHANGE
+ * 
+ * @param read_delay How often you want to read the pin, in ms
+ * 
+ * @param config_path The path to configuring read_delay in the Config UI
+ * 
+ * */
 class DigitalInputCounter : public DigitalInput, public IntegerProducer {
  public:
   DigitalInputCounter(uint8_t pin, int pin_mode, int interrupt_type,

--- a/src/sensors/digital_input.h
+++ b/src/sensors/digital_input.h
@@ -21,8 +21,8 @@ class DigitalInput : public Sensor {
                String config_path = "");
 
  protected:
-  uint8_t pin;
-  int interrupt_type;
+  uint8_t pin_;
+  int interrupt_type_;
 };
 
 
@@ -57,8 +57,8 @@ class DigitalInputState : public DigitalInput, public IntegerProducer {
   virtual void enable() override final;
 
  private:
-  int read_delay;
-  bool triggered;
+  int read_delay_;
+  bool triggered_;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;
@@ -95,8 +95,8 @@ class DigitalInputCounter : public DigitalInput, public IntegerProducer {
   void enable() override final;
 
  private:
-  uint read_delay;
-  volatile uint counter = 0;
+  uint read_delay_;
+  volatile uint counter_ = 0;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensors/digital_input.h
+++ b/src/sensors/digital_input.h
@@ -102,4 +102,35 @@ class DigitalInputCounter : public DigitalInput, public IntegerProducer {
   virtual String get_config_schema() override;
 };
 
+
+ /**
+ * @brief DigitalInputChange is meant to report when a digital pin changes its state.
+ *
+ * It's intended for monitoring a button or other type of relatively slow changing switch.
+ * Because physical switches like buttons can be somewhat "noisy", you may want to connect
+ * the output of this Sensor to the Debounce Transform, and try different combinations of
+ * read_delay for this Sensor and ms_min_delay for Debounce to get the "cleanest" output
+ * from your button or other switch.
+ *
+ * @param pin The GPIO pin to which the device is connected
+ * 
+ * @param pin_mode Will be INPUT or INPUT_PULLUP
+ * 
+ * @param interrupt_type Will be RISING, FALLING, or CHANGE
+ * 
+ * */
+class DigitalInputChange : public DigitalInput, public IntegerProducer {
+ public:
+  DigitalInputChange(uint8_t pin, int pin_mode, int interrupt_type, uint read_delay = 50,
+                                         String config_path = "");
+  virtual void enable() override final;
+ 
+ private:
+  uint read_delay_;
+  bool triggered_;
+  virtual void get_configuration(JsonObject& doc) override;
+  virtual bool set_configuration(const JsonObject& config) override;
+  virtual String get_config_schema() override;
+};
+
 #endif

--- a/src/sensors/digital_input.h
+++ b/src/sensors/digital_input.h
@@ -128,6 +128,7 @@ class DigitalInputChange : public DigitalInput, public IntegerProducer {
  private:
   uint read_delay_;
   bool triggered_;
+  uint8_t last_output_;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;


### PR DESCRIPTION
Update comments to Doxygen style.
Change DigitalInputValue to DigitalInputState.
Properly initialize `triggered` variable.
Remove `value` from showing in the Config UI.
Add new class: DigitalInputChange.
Fix class member variable names.