### PR TITLE
Fix deprecated build flag for configuring flash

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -58,8 +58,8 @@ lib_deps =
 [espressif8266_base]
 ;this section has config items common to all ESP8266 boards
 platform = espressif8266
+board_build.ldscript = eagle.flash.4m1m.ld
 build_flags =
-   -Wl,-Teagle.flash.4m1m.ld
    -Wall
    -Wno-reorder
 extra_scripts = extra_script.py


### PR DESCRIPTION
Addresses Issue #278 .

Fixed the same way as it was fixed in the example platformio.ini file: PR #228 .