### PR TITLE
Remove EspSoftwareSerial dependency

### DIFF
--- a/examples/gps_compass.cpp
+++ b/examples/gps_compass.cpp
@@ -1,6 +1,9 @@
 #include <Arduino.h>
 
-#include "SoftwareSerial.h"
+#ifdef ESP8266
+#include <SoftwareSerial.h>
+#endif
+
 #include "sensesp_app.h"
 #include "wiring_helpers.h"
 
@@ -11,18 +14,20 @@ ReactESP app([]() {
   SetupSerialDebug(115200);
 #endif
 
-  // Software serial port is used for receiving NMEA data
+  // Software serial port is used for receiving NMEA data on ESP8266
   // ESP8266 pins are specified as DX
   // ESP32 pins are specified as just the X in GPIOX
 #ifdef ESP8266
   uint8_t pin = D7;
+  SoftwareSerial* serial = new SoftwareSerial(pin, -1);
+  serial->begin(38400, SWSERIAL_8N1);
 #elif defined(ESP32)
   uint8_t pin = 4;
+  HardwareSerial* serial = &Serial1;
+  serial->begin(38400, SERIAL_8N1, pin, -1);
 #endif
-  SoftwareSerial* sw_serial = new SoftwareSerial(pin, -1);
-  sw_serial->begin(38400, SWSERIAL_8N1);
 
-  setup_gps(sw_serial);
+  setup_gps(serial);
 
   sensesp_app->enable();
 });

--- a/library.json
+++ b/library.json
@@ -111,12 +111,9 @@
       "name": "Adafruit AHRS"
     },
     {
-      "name": "EspSoftwareSerial",
-      "platforms": ["espressif32"]
-    },
-    {
       "name": "RemoteDebug",
-      "version": "https://github.com/JoaoLopesF/RemoteDebug.git#0b5a9c1a49fd2ade0e3cadc3a3707781e819359a" }
+      "version": "https://github.com/JoaoLopesF/RemoteDebug.git#0b5a9c1a49fd2ade0e3cadc3a3707781e819359a" 
+    }
   ],
   "version": "0.5.1",
   "frameworks": "arduino",

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,8 +25,6 @@ default_envs =
 framework = arduino
 lib_ldf_mode = deep
 monitor_speed = 115200
-
-[common_env_data]
 lib_deps =
    ReactESP
    ESP8266WebServer
@@ -63,8 +61,6 @@ build_flags =
    -Wall
    -Wno-reorder
 extra_scripts = extra_script.py
-lib_deps=
-   ${common_env_data.lib_deps}
 
 [env:d1_mini]
 extends = espressif8266_base
@@ -82,9 +78,6 @@ platform = espressif32
 build_unflags = -Werror=reorder
 board_build.partitions = min_spiffs.csv
 monitor_filters = esp32_exception_decoder
-lib_deps=
-    ${common_env_data.lib_deps}
-    EspSoftwareSerial
 
 [env:esp32dev]
 extends = espressif32_base


### PR DESCRIPTION
As discussed in #283, this PR removes the EspSoftwareSerial PR altogether. I refactored the gps_compass example to use SoftwareSerial (which is provided by the Arduino SDK) on ESP8266 and another HardwareSerial UART on ESP32. The resulting #ifdefs are a bit messy but at least the dependency could be removed for good.

Fixes #262.
