### PR TITLE
Limit the number of examples to be built in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,34 +8,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        example: [
-          examples/ads1x15_volt_meter.cpp,
-          examples/analog_input.cpp,
-          examples/bme280_example.cpp,
-          examples/bmp280_example.cpp,
-          examples/fuel_flow_meter.cpp,
-          examples/fuel_level_sensor/fuel_level_sensor_example.cpp,
-          examples/gps_compass.cpp,
-          examples/hysteresis.cpp,
-          examples/ina219_example.cpp,
-          examples/lambda_transform.cpp,
-          examples/milone_level_sensor/milone_level_sensor.cpp,
-          examples/onewire_temperature/onewire_temperature_example.cpp,
-          examples/relay_control.cpp,
-          examples/rpm_counter.cpp,
-          examples/sht31_example.cpp,
-          examples/temperature_sender.cpp,
-          examples/thermocouple_temperature_sensor/max31856_thermocouple_example.cpp,
-          examples/ultrasonic_level_sensor/ultrasonic_dvp_example.cpp]
+        example:
+          - examples/ads1x15_volt_meter.cpp
+          - examples/analog_input.cpp
+          - examples/bme280_example.cpp
+          - examples/hysteresis.cpp
+          - examples/lambda_transform.cpp
+          - examples/onewire_temperature/onewire_temperature_example.cpp
+          - examples/relay_control.cpp
+          - examples/rpm_counter.cpp
+          - examples/ultrasonic_level_sensor/ultrasonic_dvp_example.cpp
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
-      uses: actions/setup-python@v1
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install platformio
-    - name: Run PlatformIO
-      run: platformio ci -v --lib . -c ./platformio.ini
-      env:
-        PLATFORMIO_CI_SRC: ${{ matrix.example }}
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install platformio
+      - name: Run PlatformIO
+        run: platformio ci -v --lib . -c ./platformio.ini
+        env:
+          PLATFORMIO_CI_SRC: ${{ matrix.example }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
           - examples/relay_control.cpp
           - examples/rpm_counter.cpp
           - examples/ultrasonic_level_sensor/ultrasonic_dvp_example.cpp
+        target_device:
+          - d1_mini
+          - esp32dev
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python
@@ -27,6 +30,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install platformio
       - name: Run PlatformIO
-        run: platformio ci -v --lib . -c ./platformio.ini
+        run: ci/run-ci.sh
         env:
           PLATFORMIO_CI_SRC: ${{ matrix.example }}
+          CI_TARGET_DEVICE: ${{ matrix.target_device }}

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,4 @@
+# CI directory contents
+
+This directory contains files required for running the Continuous Integration tests in GitHub.
+It is not required for other uses and should be ignored unless you want to modify the CI functionality.

--- a/ci/platformio-d1_mini.ini
+++ b/ci/platformio-d1_mini.ini
@@ -1,0 +1,18 @@
+; CI platformio.ini for d1_mini
+
+[env]
+; Global data for all [env:***]
+framework = arduino
+lib_ldf_mode = deep
+monitor_speed = 115200
+lib_deps = ${PROJDIR}
+
+[env:d1_mini]
+platform = espressif8266
+board = d1_mini
+board_build.ldscript = eagle.flash.4m1m.ld
+build_flags =
+   -Wall
+   -Wno-reorder
+   -D LED_BUILTIN=2
+board_build.f_cpu = 160000000L

--- a/ci/platformio-esp32dev.ini
+++ b/ci/platformio-esp32dev.ini
@@ -1,0 +1,17 @@
+; CI platformio.ini for d1_mini
+
+[env]
+; Global data for all [env:***]
+framework = arduino
+lib_ldf_mode = deep
+monitor_speed = 115200
+lib_deps = ${PROJDIR}
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+build_unflags = -Werror=reorder
+board_build.partitions = min_spiffs.csv
+monitor_filters = esp32_exception_decoder
+build_flags =
+   -D LED_BUILTIN=2

--- a/ci/run-ci.sh
+++ b/ci/run-ci.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# assume this command is always run from the project root directory
+
+PROJDIR=$(pwd)
+
+# replace the 
+sed -e "s|\${PROJDIR}|$PROJDIR|" ci/platformio-${CI_TARGET_DEVICE}.ini > ci/platformio.ini
+
+# the example to build comes from $PLATFORMIO_CI_SRC
+
+pio ci -c ci/platformio.ini


### PR DESCRIPTION
I began tweaking our `.github/workflows/test.yml` file to enable testing on esp32 as well but then realized that we _are_ building against that, too. Similarly to running `pio run` on the command line, it builds all default environments. It's not terribly visible in the CI details because the esp32 build is after the super-long esp8266 build log, but it is there nevertheless.

So instead of doing anything for that, I limited the number of examples to be built to make the build a bit faster. I removed examples that I thought didn't test any new features. Or at least that was the intention...

Fixes #288. (Actually it wasn't broken to begin with.)