### PR TITLE
Fixed compiler warning re: non-trivial Observable move

### DIFF
--- a/src/system/observable.cpp
+++ b/src/system/observable.cpp
@@ -1,5 +1,7 @@
 #include "observable.h"
 
+Observable::Observable(Observable&& other) : observers{other.observers} {}
+
 void Observable::notify() {
   for (auto o : observers) {
     o();

--- a/src/system/observable.h
+++ b/src/system/observable.h
@@ -13,6 +13,11 @@
 
 class Observable {
  public:
+  Observable() {}
+
+  /// Move constructor
+  Observable(Observable&& other);
+
   void notify();
   void attach(std::function<void()> observer);
 


### PR DESCRIPTION
Observable needed an explicit move constructor to prevent this warning:

```
warning: defaulted move assignment calls a non-trivial move assignment operator for 
virtual base virtual-move-assign
```