### PR TITLE
Fix #213 Access Token Lost on network problem

### DIFF
--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -256,14 +256,14 @@ bool WSClient::get_mdns_service(String& server_address, uint16_t& server_port) {
 }
 
 void WSClient::connect() {
-  debugI("WSClient connect attempt (state=%d)", connection_state.get());
+  debugI("WSClient websocket connect attempt (state=%d)", connection_state.get());
 
   if (connection_state != kWSDisconnected) {
     return;
   }
 
   if (WiFi.isConnected()) {
-    debugD("Initiating connection");
+    debugD("Initiating websocket connection with server...");
 
     connection_state = kWSAuthorizing;
 

--- a/src/net/ws_client.h
+++ b/src/net/ws_client.h
@@ -70,7 +70,8 @@ class WSClient : public Configurable, public ValueProducer<WSConnectionState> {
   String auth_token = NULL_AUTH_TOKEN;
   String sk_permission;
   bool server_detected = false;
-
+  bool token_test_success = false;
+  
   ObservableValue<WSConnectionState> connection_state = kWSDisconnected;
   WiFiClient wifi_client;
   WebSocketsClient client;


### PR DESCRIPTION
This fix is for the loss of device authentication when the SignalK server or network goes down AFTER the initial authentication check. SensESP would clear the token and request a new one in this scenario.  Fixes #213 

Source code provided by @JohnySeven