### PR TITLE
Estimate the required delta serialization buffer size based on data

### DIFF
--- a/src/signalk/signalk_delta.cpp
+++ b/src/signalk/signalk_delta.cpp
@@ -3,7 +3,6 @@
 #include "Arduino.h"
 #include "ArduinoJson.h"
 #include "sensesp.h"
-
 #include "signalk/signalk_emitter.h"
 
 SKDelta::SKDelta(const String& hostname, unsigned int max_buffer_size)
@@ -18,8 +17,62 @@ void SKDelta::append(const String val) {
 
 bool SKDelta::data_available() { return buffer.size() > 0; }
 
+unsigned int SKDelta::get_doc_size_estimate() {
+  int buf_size = buffer.size();
+  int estimate =
+      2 * JSON_OBJECT_SIZE(1) +         // source and one update
+      JSON_ARRAY_SIZE(1) +              // one update
+      JSON_ARRAY_SIZE(buf_size) +       // buf_size values in the update
+      buf_size * JSON_OBJECT_SIZE(2) +  // two key-value pairs in each object
+      200;  // some extra headroom to hide embarrassing bugs
+
+  for (auto item : buffer) {
+    // also reserve space for the pre-rendered strings
+    estimate += item.length() + 1;
+  }
+  return estimate;  
+}
+
+unsigned int SKDelta::get_metadata_size_estimate() {
+  int num_metadata = SKEmitter::get_sources().size();
+  int estimate = JSON_ARRAY_SIZE(num_metadata);
+
+  int num_fields;
+  auto update_estimate = [&](String& field) {
+    if (!field.isEmpty()) {
+      num_fields++;
+      estimate += field.length() + 1;
+    }
+  };
+
+  for (auto const& source : SKEmitter::get_sources()) {
+    num_fields = 0;
+    auto metadata = source->get_metadata();
+    if (metadata == NULL) {
+      continue;
+    }
+    update_estimate(metadata->units_);
+    update_estimate(metadata->display_name_);
+    update_estimate(metadata->description_);
+    update_estimate(metadata->short_name_);
+    
+    estimate += JSON_OBJECT_SIZE(num_fields);
+  }
+  return estimate;
+}
+
 void SKDelta::get_delta(String& output) {
-  DynamicJsonDocument jsonDoc(1024);
+  // estimate the size of the serialized json string
+
+  unsigned int doc_size_estimate = get_doc_size_estimate();
+
+  debugD("doc size estimate: %d", doc_size_estimate);
+
+  if (!meta_sent_) {
+    doc_size_estimate += JSON_OBJECT_SIZE(1) + get_metadata_size_estimate();
+  }
+
+  DynamicJsonDocument jsonDoc(doc_size_estimate);
 
   // JsonObject delta = jsonDoc.as<JsonObject>();
   JsonArray updates = jsonDoc.createNestedArray("updates");
@@ -40,15 +93,14 @@ void SKDelta::get_delta(String& output) {
 
   serializeJson(jsonDoc, output);
 
-  debugD("SKDelta::get_delta: %s", output.c_str());
+  debugD("delta: %s", output.c_str());
 }
 
 void SKDelta::add_metadata(JsonArray updates) {
-
-    JsonObject new_entry = updates.createNestedObject();
-    JsonArray meta = new_entry.createNestedArray("meta");;
-    for (auto const& sk_source : SKEmitter::get_sources()) {
-       sk_source->add_metadata(meta);
-    } // for
-    meta_sent_ = true;
+  JsonObject new_entry = updates.createNestedObject();
+  JsonArray meta = new_entry.createNestedArray("meta");
+  for (auto const& sk_source : SKEmitter::get_sources()) {
+    sk_source->add_metadata(meta);
+  }
+  meta_sent_ = true;
 }

--- a/src/signalk/signalk_delta.h
+++ b/src/signalk/signalk_delta.h
@@ -26,6 +26,9 @@ class SKDelta {
   std::list<String> buffer;
   bool meta_sent_;
 
+  unsigned int get_doc_size_estimate();
+  unsigned int get_metadata_size_estimate();
+
   // Adds Signal K meta data to the specified document
   void add_metadata(JsonArray updates);
 };


### PR DESCRIPTION
The delta output serialization buffer was fixed to 1024 characters. That wouldn't be enough if there're many paths or metadata to transmit.

This PR adds some crummy heuristics for estimating the required buffer size based on the data to be transmitted. An added benefit is somewhat smaller buffers for simple programs.