### PR TITLE
BMP280 - overload the constructor, code cleanup

### DIFF
--- a/examples/bmp280_example.cpp
+++ b/examples/bmp280_example.cpp
@@ -19,6 +19,8 @@ ReactESP app([]() {
 
   // Create a BMP280, which represents the physical sensor.
   // 0x77 is the default address. Some chips use 0x76, which is shown here.
+  // If you need to use the TwoWire library instead of the Wire library, there
+  // is a different constructor: see bmp280.h
   auto* bmp280 = new BMP280(0x76);
 
   // If you want to change any of the settings that are set by

--- a/src/sensors/bmp280.cpp
+++ b/src/sensors/bmp280.cpp
@@ -6,23 +6,15 @@
 
 // BMP280 represents an ADAfruit (or compatible) BMP280 temperature & pressure
 // sensor.
-BMP280::BMP280(uint8_t addr, String config_path)
+BMP280::BMP280(uint8_t addr, String config_path, Adafruit_BMP280* sensor)
     : Sensor(config_path), addr_{addr} {
   load_configuration();
-  adafruit_bmp280_ = new Adafruit_BMP280();
+  adafruit_bmp280_ = sensor;
   if (!adafruit_bmp280_->begin(addr_)) {
     debugE("Could not find a valid BMP280 sensor: check address and wiring");
   }
 }
 
-BMP280::BMP280(uint8_t addr, TwoWire* two_wire, String config_path)
-    : Sensor(config_path), addr_{addr} {
-  load_configuration();
-  adafruit_bmp280_ = new Adafruit_BMP280(two_wire);
-  if (!adafruit_bmp280_->begin(addr_)) {
-    debugE("Could not find a valid BMP280 sensor: check address and wiring");
-  }
-}
 
 // BMP280Value reads and outputs the specified type of value of a BMP280 sensor
 BMP280Value::BMP280Value(BMP280* bmp280, BMP280ValType val_type,

--- a/src/sensors/bmp280.cpp
+++ b/src/sensors/bmp280.cpp
@@ -15,6 +15,15 @@ BMP280::BMP280(uint8_t addr, String config_path)
   }
 }
 
+BMP280::BMP280(uint8_t addr, TwoWire* two_wire, String config_path)
+    : Sensor(config_path), addr{addr} {
+  load_configuration();
+  adafruit_bmp280 = new Adafruit_BMP280(two_wire);
+  if (!adafruit_bmp280->begin(addr)) {
+    debugE("Could not find a valid BMP280 sensor: check address and wiring");
+  }
+}
+
 // BMP280Value reads and outputs the specified type of value of a BMP280 sensor
 BMP280Value::BMP280Value(BMP280* bmp280, BMP280ValType val_type,
                          uint read_delay, String config_path)

--- a/src/sensors/bmp280.cpp
+++ b/src/sensors/bmp280.cpp
@@ -53,14 +53,12 @@ void BMP280Value::enable() {
 
 void BMP280Value::get_configuration(JsonObject& root) {
   root["read_delay"] = read_delay_;
-  root["value"] = output;
 };
 
 static const char SCHEMA[] PROGMEM = R"###({
     "type": "object",
     "properties": {
-        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" },
-        "value": { "title": "Last value", "type" : "number", "readOnly": true }
+        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" }
     }
   })###";
 

--- a/src/sensors/bmp280.cpp
+++ b/src/sensors/bmp280.cpp
@@ -9,6 +9,9 @@
 BMP280::BMP280(uint8_t addr, String config_path, Adafruit_BMP280* sensor)
     : Sensor(config_path), addr_{addr} {
   load_configuration();
+  if (sensor == NULL) {
+    sensor = new Adafruit_BMP280();
+  }
   adafruit_bmp280_ = sensor;
   if (!adafruit_bmp280_->begin(addr_)) {
     debugE("Could not find a valid BMP280 sensor: check address and wiring");

--- a/src/sensors/bmp280.cpp
+++ b/src/sensors/bmp280.cpp
@@ -6,14 +6,13 @@
 
 // BMP280 represents an ADAfruit (or compatible) BMP280 temperature & pressure
 // sensor.
-BMP280::BMP280(uint8_t addr, String config_path, Adafruit_BMP280* sensor)
-    : Sensor(config_path), addr_{addr} {
-  load_configuration();
+BMP280::BMP280(uint8_t addr, Adafruit_BMP280* sensor)
+    : Sensor() {
   if (sensor == NULL) {
     sensor = new Adafruit_BMP280();
   }
   adafruit_bmp280_ = sensor;
-  if (!adafruit_bmp280_->begin(addr_)) {
+  if (!adafruit_bmp280_->begin(addr)) {
     debugE("Could not find a valid BMP280 sensor: check address and wiring");
   }
 }

--- a/src/sensors/bmp280.cpp
+++ b/src/sensors/bmp280.cpp
@@ -7,19 +7,19 @@
 // BMP280 represents an ADAfruit (or compatible) BMP280 temperature & pressure
 // sensor.
 BMP280::BMP280(uint8_t addr, String config_path)
-    : Sensor(config_path), addr{addr} {
+    : Sensor(config_path), addr_{addr} {
   load_configuration();
-  adafruit_bmp280 = new Adafruit_BMP280();
-  if (!adafruit_bmp280->begin(addr)) {
+  adafruit_bmp280_ = new Adafruit_BMP280();
+  if (!adafruit_bmp280_->begin(addr_)) {
     debugE("Could not find a valid BMP280 sensor: check address and wiring");
   }
 }
 
 BMP280::BMP280(uint8_t addr, TwoWire* two_wire, String config_path)
-    : Sensor(config_path), addr{addr} {
+    : Sensor(config_path), addr_{addr} {
   load_configuration();
-  adafruit_bmp280 = new Adafruit_BMP280(two_wire);
-  if (!adafruit_bmp280->begin(addr)) {
+  adafruit_bmp280_ = new Adafruit_BMP280(two_wire);
+  if (!adafruit_bmp280_->begin(addr_)) {
     debugE("Could not find a valid BMP280 sensor: check address and wiring");
   }
 }
@@ -28,21 +28,21 @@ BMP280::BMP280(uint8_t addr, TwoWire* two_wire, String config_path)
 BMP280Value::BMP280Value(BMP280* bmp280, BMP280ValType val_type,
                          uint read_delay, String config_path)
     : NumericSensor(config_path),
-      bmp280{bmp280},
-      val_type{val_type},
-      read_delay{read_delay} {
+      bmp280_{bmp280},
+      val_type_{val_type},
+      read_delay_{read_delay} {
   load_configuration();
 }
 
 // BMP280 outputs temp in Celsius. Need to convert to Kelvin before sending to
 // Signal K. Pressure is output in Pascals.
 void BMP280Value::enable() {
-  app.onRepeat(read_delay, [this]() {
-    if (val_type == temperature) {
-      output = bmp280->adafruit_bmp280->readTemperature() +
+  app.onRepeat(read_delay_, [this]() {
+    if (val_type_ == temperature) {
+      output = bmp280_->adafruit_bmp280_->readTemperature() +
                273.15;  // Kelvin is Celsius + 273.15
-    } else if (val_type == pressure) {
-      output = bmp280->adafruit_bmp280->readPressure();
+    } else if (val_type_ == pressure) {
+      output = bmp280_->adafruit_bmp280_->readPressure();
     } else {
       output = 0.0;
     }
@@ -52,7 +52,7 @@ void BMP280Value::enable() {
 }
 
 void BMP280Value::get_configuration(JsonObject& root) {
-  root["read_delay"] = read_delay;
+  root["read_delay"] = read_delay_;
   root["value"] = output;
 };
 
@@ -73,6 +73,6 @@ bool BMP280Value::set_configuration(const JsonObject& config) {
       return false;
     }
   }
-  read_delay = config["read_delay"];
+  read_delay_ = config["read_delay"];
   return true;
 }

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -8,7 +8,7 @@
 
 // The BMP280 classes are based on the ADAfruit_BMP280 library.
 
-/* * 
+/** 
  * @brief BMP280 represents an ADAfruit or compatible BMP280 temperature & pressure
  * sensor. 
  * 
@@ -44,7 +44,7 @@ class BMP280 : public Sensor {
 };
 
 
-/* 
+/**
  * @brief BMP280Value reads and outputs the specified value of a BMP280 sensor.
  * 
  * @param bmp280 A pointer to an instance of a BMP280.

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -24,16 +24,19 @@
  * @param addr The memory address of the sensor. Defaults to 0x77, but other
  * addresses are available for some BME280 chips. See the datasheet.
  * 
- * @param two_wire A pointer to the instance of Wire that has previously been
- * created in your main.cpp. Not used if the typical Wire library works with
- * your particular ESP.
+ * @param config_path Will always be "", since there is nothing to configure in the
+ * Config UI.
+ * 
+ * @param sensor A pointer to the actual BME280 sensor, returned by a constructor to
+ * an Adafruit_BMP280 object. By default, SensESP uses the default Adafruit_BMP280
+ * constructor - the one with no parameters. If your ESP doesn't use standard I2C pins
+ * for SDA and SCL, you'll need to do something like this in main.cpp:
+ *   Wire.begin(SDA_PIN, SCL_PIN, FREQUENCY); // ESP32 uses FREQUENCY, ESP8266 does not
+ *   auto* bmp280 = new BMP280(0x76, "/some_config/path", new Adafruit_BMP280(&Wire));
 */
 class BMP280 : public Sensor {
  public:
-  // Uses the typical Wire library for I2C
-  BMP280(uint8_t addr = 0x77, String config_path = "");
-  // Uses the TwoWire library for I2C
-  BMP280(uint8_t addr, TwoWire* two_wire, String config_path = "");
+  BMP280(uint8_t addr = 0x77, String config_path = "", Adafruit_BMP280* sensor = new Adafruit_BMP280());
   Adafruit_BMP280* adafruit_bmp280_;
 
  private:

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -22,7 +22,7 @@
  * https://github.com/adafruit/Adafruit_BMP280_Library/blob/master/Adafruit_BMP280.h
  * 
  * @param addr The memory address of the sensor. Defaults to 0x77, but other
- * addresses are available for some P280 chips. See the datasheet.
+ * addresses are available for some BMP280 chips. See the datasheet.
  * 
  * @param sensor A pointer to the actual Adafruit_BMP280 sensor. It is NULL by default,
  * which means "use the default constructor for the Adafruit_BMP20", which is:

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -36,7 +36,7 @@
 */
 class BMP280 : public Sensor {
  public:
-  BMP280(uint8_t addr = 0x77, String config_path = "", Adafruit_BMP280* sensor = new Adafruit_BMP280());
+  BMP280(uint8_t addr = 0x77, String config_path = "", Adafruit_BMP280* sensor = NULL);
   Adafruit_BMP280* adafruit_bmp280_;
 
  private:

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -24,9 +24,6 @@
  * @param addr The memory address of the sensor. Defaults to 0x77, but other
  * addresses are available for some BME280 chips. See the datasheet.
  * 
- * @param config_path Will always be "", since there is nothing to configure in the
- * Config UI.
- * 
  * @param sensor A pointer to the actual BME280 sensor, returned by a constructor to
  * an Adafruit_BMP280 object. By default, SensESP uses the default Adafruit_BMP280
  * constructor - the one with no parameters. If your ESP doesn't use standard I2C pins
@@ -36,11 +33,8 @@
 */
 class BMP280 : public Sensor {
  public:
-  BMP280(uint8_t addr = 0x77, String config_path = "", Adafruit_BMP280* sensor = NULL);
+  BMP280(uint8_t addr = 0x77, Adafruit_BMP280* sensor = NULL);
   Adafruit_BMP280* adafruit_bmp280_;
-
- private:
-  uint8_t addr_;
 };
 
 

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -22,14 +22,20 @@
  * https://github.com/adafruit/Adafruit_BMP280_Library/blob/master/Adafruit_BMP280.h
  * 
  * @param addr The memory address of the sensor. Defaults to 0x77, but other
- * addresses are available for some BME280 chips. See the datasheet.
+ * addresses are available for some P280 chips. See the datasheet.
  * 
- * @param sensor A pointer to the actual BME280 sensor, returned by a constructor to
- * an Adafruit_BMP280 object. By default, SensESP uses the default Adafruit_BMP280
- * constructor - the one with no parameters. If your ESP doesn't use standard I2C pins
- * for SDA and SCL, you'll need to do something like this in main.cpp:
- *   Wire.begin(SDA_PIN, SCL_PIN, FREQUENCY); // ESP32 uses FREQUENCY, ESP8266 does not
- *   auto* bmp280 = new BMP280(0x76, "/some_config/path", new Adafruit_BMP280(&Wire));
+ * @param sensor A pointer to the actual Adafruit_BMP280 sensor. It is NULL by default,
+ * which means "use the default constructor for the Adafruit_BMP20", which is:
+     
+     sensor = new Adafruit_BMP280();  // no parameters
+   
+ * If your ESP doesn't use standard I2C pins for SDA and SCL, you'll need to do something
+ * like this in main.cpp:
+ 
+    Wire.begin(SDA_PIN, SCL_PIN, FREQUENCY); // ESP32 uses FREQUENCY, ESP8266 does not
+    Adafruit_BMP280* bmp_280_sensor = new Adafruit_BMP280(&Wire);
+    auto* bmp280 = new BMP280(0x76, bmp_280_sensor);
+
 */
 class BMP280 : public Sensor {
  public:

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -8,18 +8,32 @@
 
 // The BMP280 classes are based on the ADAfruit_BMP280 library.
 
-// BMP280 represents an ADAfruit (or compatible) BMP280 temperature & pressure
-// sensor. The constructore creates a pointer to the instance, and starts up the
-// sensor. The pointer is passed to BMP280value, which retrieves the specified
-// value. If you want to change any of the values with the
-// Adafruit_BMP280::setSampling() method, it's public, so you can call that
-// after you instantiate the BMP280 and before you start using it, with:
-// yourInstanceVariable->bmp280->setSampling(); See the Adafruit library for
-// details.
-// https://github.com/adafruit/Adafruit_BMP280_Library/blob/master/Adafruit_BMP280.h
+/* * 
+ * @brief BMP280 represents an ADAfruit or compatible BMP280 temperature & pressure
+ * sensor. 
+ * 
+ * The constructor creates a pointer to the instance, and starts up the
+ * sensor. The pointer is passed to BMP280Value, which retrieves the specified
+ * value. If you want to change any of the values with the
+ * Adafruit_BMP280::setSampling() method, it's public, so you can call that
+ * after you instantiate the BMP280 and before you start using it, with:
+ * yourInstanceVariable->bmp280->setSampling(); See the Adafruit library for
+ * details.
+ * https://github.com/adafruit/Adafruit_BMP280_Library/blob/master/Adafruit_BMP280.h
+ * 
+ * @param addr The memory address of the sensor. Defaults to 0x77, but other
+ * addresses are available for some BME280 chips. See the datasheet.
+ * 
+ * @param two_wire A pointer to the instance of Wire that has previously been
+ * created in your main.cpp. Not used if the typical Wire library works with
+ * your particular ESP.
+*/
 class BMP280 : public Sensor {
  public:
+  // Uses the typical Wire library for I2C
   BMP280(uint8_t addr = 0x77, String config_path = "");
+  // Uses the TwoWire library for I2C
+  BMP280(uint8_t addr, TwoWire* two_wire, String config_path = "");
   Adafruit_BMP280* adafruit_bmp280;
 
  private:
@@ -27,7 +41,17 @@ class BMP280 : public Sensor {
 };
 
 
-// BMP280Value reads and outputs the specified value of a BMP280 sensor.
+/* 
+ * @brief BMP280Value reads and outputs the specified value of a BMP280 sensor.
+ * 
+ * @param bmp280 A pointer to an instance of a BMP280.
+ * 
+ * @param val_type The type of value you're reading: temperature or pressure.
+ * 
+ * @param read_delay How often to read the sensor - in ms.
+ * 
+ * @param config_path Path in the Config UI to configure read_delay
+ */
 class BMP280Value : public NumericSensor {
  public:
   

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -34,10 +34,10 @@ class BMP280 : public Sensor {
   BMP280(uint8_t addr = 0x77, String config_path = "");
   // Uses the TwoWire library for I2C
   BMP280(uint8_t addr, TwoWire* two_wire, String config_path = "");
-  Adafruit_BMP280* adafruit_bmp280;
+  Adafruit_BMP280* adafruit_bmp280_;
 
  private:
-  uint8_t addr;
+  uint8_t addr_;
 };
 
 
@@ -59,11 +59,11 @@ class BMP280Value : public NumericSensor {
   BMP280Value(BMP280* bmp280, BMP280ValType val_type, uint read_delay = 500,
               String config_path = "");
   void enable() override final;
-  BMP280* bmp280;
+  BMP280* bmp280_;
 
  private:
-  BMP280ValType val_type;
-  uint read_delay;
+  BMP280ValType val_type_;
+  uint read_delay_;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;


### PR DESCRIPTION
Someone needed to be able to use the TwoWire I2C interface, which required a different constructor.

Cleaned up comments and member variable names, and remove "value" from the display in the Config UI to be consistent with changes we've been making to other classes.