### PR TITLE
Configurable test of auth token on each connect

### DIFF
--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -21,6 +21,8 @@
 
 WSClient* ws_client;
 
+bool WSClient::test_auth_on_each_connect_ = true;
+
 void webSocketClientEvent(WStype_t type, uint8_t* payload, size_t length) {
   switch (type) {
     case WStype_DISCONNECTED:
@@ -295,7 +297,7 @@ void WSClient::connect() {
       return;
     }
 
-    if (!token_test_success) {
+    if (test_auth_on_each_connect_ || !token_test_success) {
       // Test the validity of the authorization token for the first time...
       this->test_token(server_address, server_port);
     } else {

--- a/src/net/ws_client.h
+++ b/src/net/ws_client.h
@@ -62,6 +62,12 @@ class WSClient : public Configurable, public ValueProducer<WSConnectionState> {
     return delta_count_producer;
   };
 
+  // If set to TRUE, the authentication token will be tested each
+  // time the device connects to the server. If set to false,
+  // the authentication token will not be retested on subsequent
+  // connections.
+  static bool test_auth_on_each_connect_;
+
  private:
   String server_address = "";
   uint16_t server_port = 80;

--- a/src/net/ws_client.h
+++ b/src/net/ws_client.h
@@ -62,10 +62,10 @@ class WSClient : public Configurable, public ValueProducer<WSConnectionState> {
     return delta_count_producer;
   };
 
-  // If set to TRUE, the authentication token will be tested each
-  // time the device connects to the server. If set to false,
-  // the authentication token will not be retested on subsequent
-  // connections.
+  /// If set to TRUE, the authentication token will be tested each
+  /// time the device connects to the server. If set to false,
+  /// the authentication token will not be retested on subsequent
+  /// connections.
   static bool test_auth_on_each_connect_;
 
  private:

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -41,6 +41,10 @@ class SensESPAppBuilder {
     app->set_system_status_led(system_status_led);
     return this;
   }
+  SensESPAppBuilder* set_test_auth_on_each_connect(bool val) {
+    WSClient::test_auth_on_each_connect_ = val;
+    return this;
+  }
   SensESPApp* get_app() {
     app->setup();
     return app;


### PR DESCRIPTION
This is the fix for #314. It has, by default, the authorization token retested each time the device connects to the Signal K server.  This feature can be turned OFF for limited power situations (like smart watches) by calling the `SensESPAppBuilde`r's new `set_test_auth_on_each_connect()`, or by setting the global static `WSClient::test_auth_on_each_connect_` member.