### PR TITLE
Easy units and meta warnings for numeric SK outputs

### DIFF
--- a/examples/ads1x15_volt_meter.cpp
+++ b/examples/ads1x15_volt_meter.cpp
@@ -82,7 +82,7 @@ ReactESP app([]() {
 
   tank_level->connect_to(new Linear(multiplier, offset, "/tank_level/linear"))
       ->connect_to(new SKOutputNumber("tanks.freshWater.currentLevel",
-                                      "/tank_level/skPath"));
+                                      "/tank_level/skPath", "ratio"));
 
   sensesp_app->enable();
 });

--- a/src/signalk/signalk_output.cpp
+++ b/src/signalk/signalk_output.cpp
@@ -1,0 +1,13 @@
+#include "signalk_output.h"
+
+template <typename T>
+SKOutputNumeric<T>::SKOutputNumeric(String sk_path, String config_path, SKMetadata* meta) :
+   SKOutput<T>(sk_path, config_path, meta) {
+ 
+   if (this->meta_ == NULL && !this->sk_path.isEmpty()) {
+       debugW("WARNING - No metadata for %s. Numeric values should specify units", this->sk_path.c_str());
+   }
+}
+
+template class SKOutputNumeric<float>;
+template class SKOutputNumeric<int>;

--- a/src/signalk/signalk_output.h
+++ b/src/signalk/signalk_output.h
@@ -33,6 +33,11 @@ class SKOutput : public SKEmitter, public SymmetricTransform<T> {
     Enable::set_priority(-5);
   }
 
+
+  SKOutput(String sk_path, SKMetadata* meta) :
+    SKOutput(sk_path, "", meta) {}
+
+
   virtual void set_input(T new_value, uint8_t input_channel = 0) override {
     this->ValueProducer<T>::emit(new_value);
   }
@@ -84,6 +89,11 @@ class SKOutputNumeric : public SKOutput<T> {
 
    public:
       SKOutputNumeric(String sk_path, String config_path = "", SKMetadata* meta = NULL);
+
+
+      SKOutputNumeric(String sk_path, SKMetadata* meta) :
+        SKOutputNumeric(sk_path, "", meta) {}
+
 
       /// The Signal K specification requires that numeric values sent
       /// to the server should at minimum specify a "units". This

--- a/src/signalk/signalk_output.h
+++ b/src/signalk/signalk_output.h
@@ -71,12 +71,34 @@ class SKOutput : public SKEmitter, public SymmetricTransform<T> {
 
   virtual SKMetadata* get_metadata() override { return meta_; }
 
-  private:
+  protected:
     SKMetadata* meta_;
 };
 
-typedef SKOutput<float> SKOutputNumber;
-typedef SKOutput<int> SKOutputInt;
+
+/**
+ * A special class for outputting numeric values.
+ */
+template <typename T>
+class SKOutputNumeric : public SKOutput<T> {
+
+   public:
+      SKOutputNumeric(String sk_path, String config_path = "", SKMetadata* meta = NULL);
+
+      /// The Signal K specification requires that numeric values sent
+      /// to the server should at minimum specify a "units". This
+      /// constructor allows you to conveniently specify the numeric
+      /// units as a third parameter.
+      /// @param units The unit value for the number this outputs on the specified
+      ///  Signal K path. See https://github.com/SignalK/specification/blob/master/schemas/definitions.json#L87
+      ///   
+      /// @see SKMetadata
+      SKOutputNumeric(String sk_path, String config_path, String units) :
+         SKOutputNumeric(sk_path, config_path, new SKMetadata(units)) {}
+};
+
+typedef SKOutputNumeric<float> SKOutputNumber;
+typedef SKOutputNumeric<int> SKOutputInt;
 typedef SKOutput<bool> SKOutputBool;
 typedef SKOutput<String> SKOutputString;
 


### PR DESCRIPTION
This PR adds a warning when outputting numeric values without metadata.  Also, an additional (optional) constructor parameter has been added to allow a quick specification of the "units" field by using a String as the third parameter.

This was from an idea sparked from discussions in #323