### PR TITLE
SKMetadata timeout is a float

### DIFF
--- a/src/signalk/signalk_metadata.cpp
+++ b/src/signalk/signalk_metadata.cpp
@@ -1,7 +1,7 @@
 #include "signalk_metadata.h"
 
 SKMetadata::SKMetadata(String units, String display_name, String description,
-                       String short_name, String timeout)
+                       String short_name, float timeout)
     : units_{units},
       display_name_{display_name},
       description_{description},
@@ -31,7 +31,7 @@ void SKMetadata::add_entry(String sk_path, JsonArray& meta) {
     val["shortName"] = this->short_name_;
   }
 
-  if (!this->timeout_.isEmpty()) {
+  if (this->timeout_ >= 0.0) {
     val["timeout"] = this->timeout_;
   }
 }

--- a/src/signalk/signalk_metadata.h
+++ b/src/signalk/signalk_metadata.h
@@ -25,7 +25,7 @@ class SKMetadata {
   String units_;
   String description_;
   String short_name_;
-  String timeout_;
+  float timeout_;
 
   /**
    * @param units The unit of measurement the value represents. See
@@ -39,13 +39,14 @@ class SKMetadata {
    * value. The short version may be used by consumers where space is at a
    * premium
    * @param timeout Tells the consumer how long it should consider the value
-   * valid. This value is specified in seconds.
+   * valid. This value is specified in seconds. Specify -1.0 if you do not
+   * want to specify a timeout.
    */
   SKMetadata(String units, String display_name = "", String description = "",
-             String short_name = "", String timeout = "");
+             String short_name = "", float timeout = -1.0);
 
   /// Default constructor creates a blank Metadata structure
-  SKMetadata() {}
+  SKMetadata() : timeout_{-1} {}
 
   /**
    * Adds an entry to the specified meta array that represents this metadata


### PR DESCRIPTION
This field should be a `float`.  Our default value of -1 means the timeout is not specified (so it won't be explicitly sent, and will use the server's default).