### PR TITLE
Doxygen, fix data member names, remove "value" from Config UI for many Sensors

### DIFF
--- a/src/sensors/bme280.cpp
+++ b/src/sensors/bme280.cpp
@@ -1,13 +1,12 @@
 #include "bme280.h"
 
 #include "sensesp.h"
-//#include "i2c_tools.h"
 #include <RemoteDebug.h>
 
 // BME280 represents an ADAfruit (or compatible) BME280 temperature / pressure /
 // humidity sensor.
-BME280::BME280(uint8_t addr, String config_path)
-    : Sensor(config_path), addr_{addr} {
+BME280::BME280(uint8_t addr)
+    : Sensor(), addr_{addr} {
   load_configuration();
   adafruit_bme280_ = new Adafruit_BME280();
   check_status();
@@ -59,14 +58,12 @@ void BME280Value::enable() {
 
 void BME280Value::get_configuration(JsonObject& root) {
   root["read_delay"] = read_delay_;
-  root["value"] = output;
 };
 
 static const char SCHEMA[] PROGMEM = R"###({
     "type": "object",
     "properties": {
-        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" },
-        "value": { "title": "Last value", "type" : "number", "readOnly": true }
+        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" }
     }
   })###";
 

--- a/src/sensors/bme280.cpp
+++ b/src/sensors/bme280.cpp
@@ -7,19 +7,19 @@
 // BME280 represents an ADAfruit (or compatible) BME280 temperature / pressure /
 // humidity sensor.
 BME280::BME280(uint8_t addr, String config_path)
-    : Sensor(config_path), addr{addr} {
+    : Sensor(config_path), addr_{addr} {
   load_configuration();
-  adafruit_bme280 = new Adafruit_BME280();
+  adafruit_bme280_ = new Adafruit_BME280();
   check_status();
 }
 
 void BME280::check_status() {
-  bool started = adafruit_bme280->begin(addr);
+  bool started = adafruit_bme280_->begin(addr_);
   if (!started) {
     debugI(
         "Could not find a valid BME280 sensor. Check wiring, address, and "
         "sensor ID.");
-    debugI("SensorID is: 0x%d", adafruit_bme280->sensorID());
+    debugI("SensorID is: 0x%d", adafruit_bme280_->sensorID());
     debugI("0xFF: is a BMP180 or BMP085, or a bad address");
     debugI("0x56-0x58 is a BMP280");
     debugI("0x60 is a BME280");
@@ -31,9 +31,9 @@ void BME280::check_status() {
 BME280Value::BME280Value(BME280* bme280, BME280ValType val_type,
                          uint read_delay, String config_path)
     : NumericSensor(config_path),
-      bme280{bme280},
-      val_type{val_type},
-      read_delay{read_delay} {
+      bme280_{bme280},
+      val_type_{val_type},
+      read_delay_{read_delay} {
   load_configuration();
 }
 
@@ -41,14 +41,14 @@ BME280Value::BME280Value(BME280* bme280, BME280ValType val_type,
 // Signal K. Pressure is output in Pascals, Humidity is output in relative
 // humidity (0 - 100%)
 void BME280Value::enable() {
-  app.onRepeat(read_delay, [this]() {
-    if (val_type == temperature) {
-      output = bme280->adafruit_bme280->readTemperature() +
+  app.onRepeat(read_delay_, [this]() {
+    if (val_type_ == temperature) {
+      output = bme280_->adafruit_bme280_->readTemperature() +
                273.15;  // Kelvin is Celsius + 273.15
-    } else if (val_type == pressure) {
-      output = bme280->adafruit_bme280->readPressure();
-    } else if (val_type == humidity) {
-      output = bme280->adafruit_bme280->readHumidity();
+    } else if (val_type_ == pressure) {
+      output = bme280_->adafruit_bme280_->readPressure();
+    } else if (val_type_ == humidity) {
+      output = bme280_->adafruit_bme280_->readHumidity();
     } else {
       output = 0.0;
     }
@@ -58,7 +58,7 @@ void BME280Value::enable() {
 }
 
 void BME280Value::get_configuration(JsonObject& root) {
-  root["read_delay"] = read_delay;
+  root["read_delay"] = read_delay_;
   root["value"] = output;
 };
 
@@ -79,6 +79,6 @@ bool BME280Value::set_configuration(const JsonObject& config) {
       return false;
     }
   }
-  read_delay = config["read_delay"];
+  read_delay_ = config["read_delay"];
   return true;
 }

--- a/src/sensors/bme280.cpp
+++ b/src/sensors/bme280.cpp
@@ -7,7 +7,6 @@
 // humidity sensor.
 BME280::BME280(uint8_t addr)
     : Sensor(), addr_{addr} {
-  load_configuration();
   adafruit_bme280_ = new Adafruit_BME280();
   check_status();
 }

--- a/src/sensors/bme280.h
+++ b/src/sensors/bme280.h
@@ -26,7 +26,7 @@
  **/
 class BME280 : public Sensor {
  public:
-  BME280(uint8_t addr = 0x77, String config_path = "");
+  BME280(uint8_t addr = 0x77);
   Adafruit_BME280* adafruit_bme280_;
 
  private:

--- a/src/sensors/bme280.h
+++ b/src/sensors/bme280.h
@@ -8,11 +8,11 @@
 
 // The BME280 classes are based on the ADAfruit_BME280 library.
 
-/** 
+/**
  * @brief Represents an ADAfruit (or compatible) BME280 temperature / pressure /
- * humidity sensor. 
+ * humidity sensor.
  * 
- * The constructore creates a pointer to the instance, and
+ * The constructor creates a pointer to the sensor and
  * starts up the sensor. The pointer is passed to BME280value, which retrieves
  * the specified value. If you want to change any of the values with the
  * Adafruit_BME280::setSampling() method, it's public, so you can call that
@@ -20,30 +20,44 @@
  * sensor_object->adafruit_bme280->setSampling(); See the Adafruit
  * library for details.
  * @see https://github.com/adafruit/Adafruit_BME280_Library/blob/master/Adafruit_BME280.h
- */
+ * 
+ * @param addr The memory address where the sensor can be read. Default is 0x77. Some
+ * sensors use, or can use, different addresses - check your datasheet.
+ **/
 class BME280 : public Sensor {
  public:
   BME280(uint8_t addr = 0x77, String config_path = "");
-  Adafruit_BME280* adafruit_bme280;
+  Adafruit_BME280* adafruit_bme280_;
 
  private:
-  uint8_t addr;
+  uint8_t addr_;
   void check_status();
 };
 
 
-// BME280Value reads and outputs the specified value of a BME280 sensor.
+/** 
+ * @brief BME280Value reads and outputs the specified value of a BME280 sensor
+ * 
+ * @param bme280 A pointer to an instance of a BME280.
+ * 
+ * @param val_type The type of value you're reading: temperature, pressure, or
+ * humidity.
+ * 
+ * @param read_delay How often to read the sensor - in ms.
+ * 
+ * @param config_path Path in the Config UI to configure read_delay
+ **/ 
 class BME280Value : public NumericSensor {
  public:
   enum BME280ValType { temperature, pressure, humidity };
   BME280Value(BME280* bme280, BME280ValType val_type, uint read_delay = 500,
               String config_path = "");
   void enable() override final;
-  BME280* bme280;
+  BME280* bme280_;
 
  private:
-  BME280ValType val_type;
-  uint read_delay;
+  BME280ValType val_type_;
+  uint read_delay_;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensors/digital_output.cpp
+++ b/src/sensors/digital_output.cpp
@@ -3,11 +3,11 @@
 #include "Arduino.h"
 
 DigitalOutput::DigitalOutput(int pin) {
-  pin_number = pin;
+  pin_number_ = pin;
   pinMode(pin, OUTPUT);
 }
 
 void DigitalOutput::set_input(bool new_value, uint8_t inputChannel) {
-  digitalWrite(pin_number, new_value);
+  digitalWrite(pin_number_, new_value);
   this->emit(new_value);
 }

--- a/src/sensors/digital_output.h
+++ b/src/sensors/digital_output.h
@@ -7,13 +7,8 @@
 #include "transforms/transform.h"
 
 /**
- * @brief Configures the specified GPIO pin
- * as an output pin, then sets the status of that
- * pin to HIGH whenever set_input() is called
- * and new_value is true. The pin is set to LOW when
- * new_value is false. After the output pin's state
- * is set, the new_value is passed through unmodified
- * as the value returned by BooleanTransform::get().
+ * @brief Sets a GPIO pin to whatever the input is (true = HIGH,
+ * false = LOW), and passes the value on to the next ValueConsumer.
  */
 class DigitalOutput : public BooleanTransform {
  public:
@@ -21,7 +16,7 @@ class DigitalOutput : public BooleanTransform {
   void set_input(bool new_value, uint8_t input_channel = 0) override;
 
  private:
-  int pin_number;
+  int pin_number_;
 };
 
 #endif

--- a/src/sensors/digital_output.h
+++ b/src/sensors/digital_output.h
@@ -9,6 +9,8 @@
 /**
  * @brief Sets a GPIO pin to whatever the input is (true = HIGH,
  * false = LOW), and passes the value on to the next ValueConsumer.
+ * 
+ * @param pin Pin number of the pin you want to output to.
  */
 class DigitalOutput : public BooleanTransform {
  public:

--- a/src/sensors/gps.cpp
+++ b/src/sensors/gps.cpp
@@ -4,9 +4,9 @@
 
 #include "sensesp.h"
 
-GPSInput::GPSInput(Stream* rx_stream, String config_path)
-    : Sensor(config_path) {
-  this->rx_stream_ = rx_stream;
+GPSInput::GPSInput(Stream* rx_stream)
+    : Sensor() {
+  rx_stream_ = rx_stream;
 
   nmea_parser_.add_sentence_parser(new GPGGASentenceParser(&nmea_data_));
   nmea_parser_.add_sentence_parser(new GPGLLSentenceParser(&nmea_data_));
@@ -15,14 +15,13 @@ GPSInput::GPSInput(Stream* rx_stream, String config_path)
   nmea_parser_.add_sentence_parser(new PSTI030SentenceParser(&nmea_data_));
   nmea_parser_.add_sentence_parser(new PSTI032SentenceParser(&nmea_data_));
 
-  load_configuration();
 }
 
 void GPSInput::enable() {
   // enable reading the serial port
   app.onAvailable(*rx_stream_, [this]() {
-    while (this->rx_stream_->available()) {
-      nmea_parser_.handle(this->rx_stream_->read());
+    while (rx_stream_->available()) {
+      nmea_parser_.handle(rx_stream_->read());
     }
   });
 

--- a/src/sensors/gps.cpp
+++ b/src/sensors/gps.cpp
@@ -6,23 +6,23 @@
 
 GPSInput::GPSInput(Stream* rx_stream, String config_path)
     : Sensor(config_path) {
-  this->rx_stream = rx_stream;
+  this->rx_stream_ = rx_stream;
 
-  nmea_parser.add_sentence_parser(new GPGGASentenceParser(&nmea_data));
-  nmea_parser.add_sentence_parser(new GPGLLSentenceParser(&nmea_data));
-  nmea_parser.add_sentence_parser(new GPRMCSentenceParser(&nmea_data));
-  nmea_parser.add_sentence_parser(new PSTISentenceParser(&nmea_data));
-  nmea_parser.add_sentence_parser(new PSTI030SentenceParser(&nmea_data));
-  nmea_parser.add_sentence_parser(new PSTI032SentenceParser(&nmea_data));
+  nmea_parser_.add_sentence_parser(new GPGGASentenceParser(&nmea_data_));
+  nmea_parser_.add_sentence_parser(new GPGLLSentenceParser(&nmea_data_));
+  nmea_parser_.add_sentence_parser(new GPRMCSentenceParser(&nmea_data_));
+  nmea_parser_.add_sentence_parser(new PSTISentenceParser(&nmea_data_));
+  nmea_parser_.add_sentence_parser(new PSTI030SentenceParser(&nmea_data_));
+  nmea_parser_.add_sentence_parser(new PSTI032SentenceParser(&nmea_data_));
 
   load_configuration();
 }
 
 void GPSInput::enable() {
   // enable reading the serial port
-  app.onAvailable(*rx_stream, [this]() {
-    while (this->rx_stream->available()) {
-      nmea_parser.handle(this->rx_stream->read());
+  app.onAvailable(*rx_stream_, [this]() {
+    while (this->rx_stream_->available()) {
+      nmea_parser_.handle(this->rx_stream_->read());
     }
   });
 

--- a/src/sensors/gps.h
+++ b/src/sensors/gps.h
@@ -4,17 +4,22 @@
 #include "sensor.h"
 #include "system/nmea_parser.h"
 
-// Support for a GPS module communicating with NMEA-0183
-// messages over a serial interface
+/**
+ * @brief Support for a GPS module communicating with NMEA-0183
+ * messages over a serial interface.
+ * 
+ * @param rx_stream Pointer to the Stream of incoming GPS data over
+ * a serial connection. 
+ **/ 
 
 class GPSInput : public Sensor {
  public:
   GPSInput(Stream* rx_stream, String config_path="");
   virtual void enable() override final;
-  NMEAData nmea_data;
+  NMEAData nmea_data_;
  private:
-  Stream* rx_stream;
-  NMEAParser nmea_parser;
+  Stream* rx_stream_;
+  NMEAParser nmea_parser_;
 };
 
 // must parse the following sentences:

--- a/src/sensors/gps.h
+++ b/src/sensors/gps.h
@@ -14,7 +14,7 @@
 
 class GPSInput : public Sensor {
  public:
-  GPSInput(Stream* rx_stream, String config_path="");
+  GPSInput(Stream* rx_stream);
   virtual void enable() override final;
   NMEAData nmea_data_;
  private:

--- a/src/sensors/ina219.cpp
+++ b/src/sensors/ina219.cpp
@@ -6,10 +6,8 @@
 
 // INA219 represents an ADAfruit (or compatible) INA219 High Side DC Current
 // Sensor.
-INA219::INA219(uint8_t addr, INA219CAL_t calibration_setting,
-               String config_path)
-    : Sensor(config_path) {
-  load_configuration();
+INA219::INA219(uint8_t addr, INA219CAL_t calibration_setting)
+    : Sensor() {
   ina219 = new Adafruit_INA219(addr);
   ina219->begin();
   // Default calibration in the Adafruit_INA219 constructor is 32V and 2A, so

--- a/src/sensors/ina219.cpp
+++ b/src/sensors/ina219.cpp
@@ -24,33 +24,33 @@ INA219::INA219(uint8_t addr, INA219CAL_t calibration_setting)
 INA219Value::INA219Value(INA219* ina219, INA219ValType val_type,
                          uint read_delay, String config_path)
     : NumericSensor(config_path),
-      ina219{ina219},
-      val_type{val_type},
-      read_delay{read_delay} {
+      ina219_{ina219},
+      val_type_{val_type},
+      read_delay_{read_delay} {
   load_configuration();
 }
 
 void INA219Value::enable() {
-  app.onRepeat(read_delay, [this]() {
-    switch (val_type) {
+  app.onRepeat(read_delay_, [this]() {
+    switch (val_type_) {
       case bus_voltage:
-        output = ina219->ada_ina219_->getBusVoltage_V();
+        output = ina219_->ada_ina219_->getBusVoltage_V();
         break;
       case shunt_voltage:
-        output = (ina219->ada_ina219_->getShuntVoltage_mV() /
+        output = (ina219_->ada_ina219_->getShuntVoltage_mV() /
                   1000);  // SK wants volts, not mV
         break;
       case current:
         output =
-            (ina219->ada_ina219_->getCurrent_mA() / 1000);  // SK wants amps, not mA
+            (ina219_->ada_ina219_->getCurrent_mA() / 1000);  // SK wants amps, not mA
         break;
       case power:
         output =
-            (ina219->ada_ina219_->getPower_mW() / 1000);  // SK want watts, not mW
+            (ina219_->ada_ina219_->getPower_mW() / 1000);  // SK want watts, not mW
         break;
       case load_voltage:
-        output = (ina219->ada_ina219_->getBusVoltage_V() +
-                  (ina219->ada_ina219_->getShuntVoltage_mV() / 1000));
+        output = (ina219_->ada_ina219_->getBusVoltage_V() +
+                  (ina219_->ada_ina219_->getShuntVoltage_mV() / 1000));
         break;
       default:
         debugE("FATAL: invalid val_type parameter.");
@@ -61,7 +61,7 @@ void INA219Value::enable() {
 }
 
 void INA219Value::get_configuration(JsonObject& root) {
-  root["read_delay"] = read_delay;
+  root["read_delay"] = read_delay_;
   root["value"] = output;
 }
 
@@ -82,6 +82,6 @@ bool INA219Value::set_configuration(const JsonObject& config) {
       return false;
     }
   }
-  read_delay = config["read_delay"];
+  read_delay_ = config["read_delay"];
   return true;
 }

--- a/src/sensors/ina219.cpp
+++ b/src/sensors/ina219.cpp
@@ -8,15 +8,15 @@
 // Sensor.
 INA219::INA219(uint8_t addr, INA219CAL_t calibration_setting)
     : Sensor() {
-  ina219 = new Adafruit_INA219(addr);
-  ina219->begin();
+  ada_ina219_ = new Adafruit_INA219(addr);
+  ada_ina219_->begin();
   // Default calibration in the Adafruit_INA219 constructor is 32V and 2A, so
   // that's what it will be unless it's set to something different in the call
   // to this constructor:
   if (calibration_setting == cal32_1) {
-    ina219->setCalibration_32V_1A();
+    ada_ina219_->setCalibration_32V_1A();
   } else if (calibration_setting == cal16_400) {
-    ina219->setCalibration_16V_400mA();
+    ada_ina219_->setCalibration_16V_400mA();
   }
 }
 
@@ -34,23 +34,23 @@ void INA219Value::enable() {
   app.onRepeat(read_delay, [this]() {
     switch (val_type) {
       case bus_voltage:
-        output = ina219->ina219->getBusVoltage_V();
+        output = ina219->ada_ina219_->getBusVoltage_V();
         break;
       case shunt_voltage:
-        output = (ina219->ina219->getShuntVoltage_mV() /
+        output = (ina219->ada_ina219_->getShuntVoltage_mV() /
                   1000);  // SK wants volts, not mV
         break;
       case current:
         output =
-            (ina219->ina219->getCurrent_mA() / 1000);  // SK wants amps, not mA
+            (ina219->ada_ina219_->getCurrent_mA() / 1000);  // SK wants amps, not mA
         break;
       case power:
         output =
-            (ina219->ina219->getPower_mW() / 1000);  // SK want watts, not mW
+            (ina219->ada_ina219_->getPower_mW() / 1000);  // SK want watts, not mW
         break;
       case load_voltage:
-        output = (ina219->ina219->getBusVoltage_V() +
-                  (ina219->ina219->getShuntVoltage_mV() / 1000));
+        output = (ina219->ada_ina219_->getBusVoltage_V() +
+                  (ina219->ada_ina219_->getShuntVoltage_mV() / 1000));
         break;
       default:
         debugE("FATAL: invalid val_type parameter.");

--- a/src/sensors/ina219.cpp
+++ b/src/sensors/ina219.cpp
@@ -52,24 +52,19 @@ void INA219Value::enable() {
         output = (ina219_->ada_ina219_->getBusVoltage_V() +
                   (ina219_->ada_ina219_->getShuntVoltage_mV() / 1000));
         break;
-      default:
-        debugE("FATAL: invalid val_type parameter.");
     }
-
     notify();
   });
 }
 
 void INA219Value::get_configuration(JsonObject& root) {
   root["read_delay"] = read_delay_;
-  root["value"] = output;
 }
 
 static const char SCHEMA[] PROGMEM = R"###({
     "type": "object",
     "properties": {
-        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" },
-        "value": { "title": "Last value", "type" : "number", "readOnly": true }
+        "read_delay": { "title": "Read delay", "type": "number", "description": "The time, in milliseconds, between each read of the input" }
     }
   })###";
 

--- a/src/sensors/ina219.h
+++ b/src/sensors/ina219.h
@@ -56,11 +56,11 @@ class INA219Value : public NumericSensor {
   INA219Value(INA219* ina219, INA219ValType val_type, uint read_delay = 500,
               String config_path = "");
   void enable() override final;
-  INA219* ina219;
+  INA219* ina219_;
 
  private:
-  INA219ValType val_type;
-  uint read_delay;
+  INA219ValType val_type_;
+  uint read_delay_;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensors/ina219.h
+++ b/src/sensors/ina219.h
@@ -34,14 +34,14 @@ enum INA219CAL_t { cal32_2, cal32_1, cal16_400 };
 class INA219 : public Sensor {
  public:
   INA219(uint8_t addr = 0x40, INA219CAL_t calibration_setting = cal32_2);
-  Adafruit_INA219* ina219;
+  Adafruit_INA219* ada_ina219_;
 };
 
 
 /**
  * @brief INA219Value reads and outputs the specified value of an INA219 sensor.
  * 
- * @param ina219 A pointer to an instance of an INA2xx.
+ * @param ina219 A pointer to an instance of an INA219.
  * 
  * @param val_type The type of value you're reading:
  *      bus_voltage, shunt_voltage, current, power, or load_voltage.

--- a/src/sensors/ina219.h
+++ b/src/sensors/ina219.h
@@ -6,28 +6,50 @@
 
 #include "sensor.h"
 
-// The INA219 classes are based on the ADAfruit_INA219 library.
+/* The INA219 classes are based on the ADAfruit_INA219 library. */
 
-// These are the used to tell the constructor what to set for maximum voltage
-// and amperage. The default in the Adafruit constructor is 32V and 2A, so we
-// only need to handle the other two.
+/**
+ * These are used to tell the constructor what to set for maximum voltage
+ * and amperage. The default in the Adafruit constructor is 32V and 2A.
+ **/
+
 enum INA219CAL_t { cal32_2, cal32_1, cal16_400 };
 
 /**
  * @brief  Represents an ADAfruit (or compatible) INA219 High Side DC Current
- * Sensor. The constructor creates a pointer to the instance, and starts up the
+ * Sensor. 
+ * 
+ * The constructor creates a pointer to the sensor, and starts up the
  * sensor. The pointer is passed to INA219value, which retrieves the specified
  * value.
+ * 
+ * @param addr Memory address where the sensor is read. Defaults to 0x40. Some
+ * sensors can use a different address - see the datasheet.
+ * 
+ * @param calibration_setting Determines the maximum voltage and amperage to be
+ * read. Choices are cal32_2 (the default), cal32_1, and cal16_400. See the
+ * Adafruit library for details. 
+ * @see https://github.com/adafruit/Adafruit_INA219
  */
 class INA219 : public Sensor {
  public:
-  INA219(uint8_t addr = 0x40, INA219CAL_t calibration_setting = cal32_2,
-         String config_path = "");
+  INA219(uint8_t addr = 0x40, INA219CAL_t calibration_setting = cal32_2);
   Adafruit_INA219* ina219;
 };
 
 
-// INA219Value reads and outputs the specified value of a INA219 sensor.
+/**
+ * @brief INA219Value reads and outputs the specified value of an INA219 sensor.
+ * 
+ * @param ina219 A pointer to an instance of an INA2xx.
+ * 
+ * @param val_type The type of value you're reading:
+ *      bus_voltage, shunt_voltage, current, power, or load_voltage.
+ * 
+ * @param read_delay How often to read the sensor, in ms. Default is 500.
+ * 
+ * @param config_path Path in the Config UI to configure read_delay
+ */
 class INA219Value : public NumericSensor {
  public:
   enum INA219ValType { bus_voltage, shunt_voltage, current, power, load_voltage };

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -30,9 +30,9 @@ bool string_to_owda(OWDevAddr* addr, const char* str) {
 
 DallasTemperatureSensors::DallasTemperatureSensors(int pin, String config_path)
     : Sensor(config_path) {
-  onewire = new OneWire(pin);
-  sensors = new DallasTemperature(onewire);
-  sensors->begin();
+  onewire_ = new OneWire(pin);
+  sensors_ = new DallasTemperature(onewire_);
+  sensors_->begin();
 
   // DallasTemperature::getDeviceCount() doesn't work reliably with ESP32,
   // so sensors are found using getAddress()
@@ -42,9 +42,9 @@ DallasTemperatureSensors::DallasTemperatureSensors(int pin, String config_path)
   bool check_again = true;
   uint8_t sensor_index = 0;
   while (check_again) {
-    if (sensors->getAddress(addr, sensor_index)) {
+    if (sensors_->getAddress(addr, sensor_index)) {
       std::copy(std::begin(addr), std::end(addr), std::begin(owda));
-      known_addresses.insert(owda);
+      known_addresses_.insert(owda);
 #ifndef DEBUG_DISABLED
       char addrstr[24];
       owda_to_string(addrstr, owda);
@@ -56,33 +56,33 @@ DallasTemperatureSensors::DallasTemperatureSensors(int pin, String config_path)
   }
 
   // all conversions will by async
-  sensors->setWaitForConversion(false);
+  sensors_->setWaitForConversion(false);
   // always use maximum resolution
-  sensors->setResolution(12);
+  sensors_->setResolution(12);
 }
 
 bool DallasTemperatureSensors::register_address(const OWDevAddr& addr) {
-  auto search_known = known_addresses.find(addr);
-  if (search_known == known_addresses.end()) {
+  auto search_known = known_addresses_.find(addr);
+  if (search_known == known_addresses_.end()) {
     // address is not known
     return false;
   }
-  auto search_reg = registered_addresses.find(addr);
-  if (search_reg != registered_addresses.end()) {
+  auto search_reg = registered_addresses_.find(addr);
+  if (search_reg != registered_addresses_.end()) {
     // address is already registered
     return false;
   }
 
-  registered_addresses.insert(addr);
+  registered_addresses_.insert(addr);
   return true;
 }
 
 bool DallasTemperatureSensors::get_next_address(OWDevAddr* addr) {
   // find the next address from known_addresses which is
   // not present in registered_addresses
-  for (auto known : known_addresses) {
-    auto reg_it = registered_addresses.find(known);
-    if (reg_it == registered_addresses.end()) {
+  for (auto known : known_addresses_) {
+    auto reg_it = registered_addresses_.find(known);
+    if (reg_it == registered_addresses_.end()) {
       *addr = known;
       return true;
     }
@@ -92,58 +92,58 @@ bool DallasTemperatureSensors::get_next_address(OWDevAddr* addr) {
 
 OneWireTemperature::OneWireTemperature(DallasTemperatureSensors* dts,
                                        uint read_delay, String config_path)
-    : NumericSensor(config_path), dts{dts}, read_delay{read_delay} {
+    : NumericSensor(config_path), dts_{dts}, read_delay_{read_delay} {
   load_configuration();
-  if (address == null_ow_addr) {
+  if (address_ == null_ow_addr) {
     // previously unconfigured sensor
-    bool success = dts->get_next_address(&address);
+    bool success = dts_->get_next_address(&address_);
     if (!success) {
       debugE(
           "FATAL: Unable to allocate a OneWire sensor for %s. "
           "All sensors have already been configured. "
           "Check the physical wiring of your sensors.",
           config_path.c_str());
-      found = false;
+      found_ = false;
     } else {
       debugD("Registered a new OneWire sensor");
-      dts->register_address(address);
+      dts_->register_address(address_);
     }
   } else {
-    bool success = dts->register_address(address);
+    bool success = dts_->register_address(address_);
     if (!success) {
       char addrstr[24];
-      owda_to_string(addrstr, address);
+      owda_to_string(addrstr, address_);
       debugE(
           "FATAL: OneWire sensor %s at %s is missing. "
           "Check the physical wiring of your sensors.",
           config_path.c_str(), addrstr);
-      found = false;
+      found_ = false;
     }
   }
 }
 
 void OneWireTemperature::enable() {
-  if (found) {
-    app.onRepeat(read_delay, [this]() { this->update(); });
+  if (found_) {
+    app.onRepeat(read_delay_, [this]() { this->update(); });
   }
 }
 
 void OneWireTemperature::update() {
-  dts->sensors->requestTemperaturesByAddress(address.data());
+  dts_->sensors_->requestTemperaturesByAddress(address_.data());
   // temp converstion can take up to 750 ms, so wait before reading
   app.onDelay(750, [this]() { this->read_value(); });
 }
 
 void OneWireTemperature::read_value() {
   // getTempC returns degrees Celsius but Signal K expects Kelvin
-  this->emit(dts->sensors->getTempC(address.data()) + 273.15);
+  this->emit(dts_->sensors_->getTempC(address_.data()) + 273.15);
 }
 
 void OneWireTemperature::get_configuration(JsonObject& root) {
   char addr_str[24];
-  owda_to_string(addr_str, address);
+  owda_to_string(addr_str, address_);
   root["address"] = addr_str;
-  root["found"] = found;
+  root["found"] = found_;
 }
 
 static const char SCHEMA[] PROGMEM = R"({
@@ -160,6 +160,6 @@ bool OneWireTemperature::set_configuration(const JsonObject& config) {
   if (!config.containsKey("address")) {
     return false;
   }
-  string_to_owda(&address, config["address"]);
+  string_to_owda(&address_, config["address"]);
   return true;
 }

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -140,7 +140,6 @@ void OneWireTemperature::read_value() {
 }
 
 void OneWireTemperature::get_configuration(JsonObject& root) {
-  root["value"] = output;
   char addr_str[24];
   owda_to_string(addr_str, address);
   root["address"] = addr_str;
@@ -151,8 +150,7 @@ static const char SCHEMA[] PROGMEM = R"({
     "type": "object",
     "properties": {
         "address": { "title": "OneWire address", "type": "string" },
-        "found": { "title": "Device found", "type": "boolean", "readOnly": true },
-        "value": { "title": "Last value", "type" : "number", "readOnly": true }
+        "found": { "title": "Device found", "type": "boolean", "readOnly": true }
     }
   })";
 

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -130,12 +130,12 @@ void OneWireTemperature::enable() {
 
 void OneWireTemperature::update() {
   dts->sensors->requestTemperaturesByAddress(address.data());
-
+  // temp converstion can take up to 750 ms, so wait before reading
   app.onDelay(750, [this]() { this->read_value(); });
 }
 
 void OneWireTemperature::read_value() {
-  // getTempC returns degrees Celsius but Signal K expects Kelvins
+  // getTempC returns degrees Celsius but Signal K expects Kelvin
   this->emit(dts->sensors->getTempC(address.data()) + 273.15);
 }
 

--- a/src/sensors/onewire_temperature.h
+++ b/src/sensors/onewire_temperature.h
@@ -34,7 +34,6 @@ class DallasTemperatureSensors : public Sensor {
   DallasTemperature* sensors_;
  private:
   OneWire* onewire_;
-  //uint8_t next_sensor_ = 0;
   std::set<OWDevAddr> known_addresses_;
   std::set<OWDevAddr> registered_addresses_;
 };
@@ -75,7 +74,6 @@ class OneWireTemperature : public NumericSensor {
   virtual String get_config_schema() override;
 
  private:
-  //OneWire* onewire;
   DallasTemperatureSensors* dts_;
   uint read_delay_;
   bool found_ = true;

--- a/src/sensors/onewire_temperature.h
+++ b/src/sensors/onewire_temperature.h
@@ -10,6 +10,21 @@
 
 typedef std::array<uint8_t, 8> OWDevAddr;
 
+/**
+ * @brief Finds all 1-Wire temperature sensors that are connected
+ * to the ESP and makes the address(es) and temperature data available
+ * to the OneWireTemperature class.
+ * 
+ * This class has no pre-defined limit on the number of 1-Wire sensors
+ * it can work with. From a practical standpoint, it should handle all
+ * the sensors you're likely to connect to a single ESP.
+ * 
+ * @param pin The GPIO pin to which you have the data wire of the
+ * 1-Wire sensor(s) connected.
+ * 
+ * @param config_path Currently not used for this class, don't provide
+ * it - it defaults to a blank String.
+ **/ 
 class DallasTemperatureSensors : public Sensor {
  public:
   DallasTemperatureSensors(int pin, String config_path="");
@@ -24,6 +39,29 @@ class DallasTemperatureSensors : public Sensor {
   std::set<OWDevAddr> registered_addresses;
 };
 
+/**
+ * @brief Used to read the temperature from a single 1-Wire temperature
+ * sensor. If you have X sensors connected to your ESP, you need to create
+ * X instances of this class in main.cpp.
+ * 
+ * Temperature is read in Celsius, then converted to Kelvin before sending
+ * to Signal K.
+ * 
+ * It will use the next available sensor address from all those found by the
+ * DallasTemperatureSensors class. Once a sensor is "registered" by this class,
+ * it will keep reading that sensor (by its unique hardware address) unless you
+ * change the address in the Config UI.
+ * 
+ * @see https://github.com/SignalK/SensESP/tree/master/examples/thermocouple_temperature_sensor
+ * 
+ * @param dts Pointer to an instance of a DalassTemperatureSensors class.
+ * 
+ * @param read_delay How often to read the temperature. It takes up to 750 ms for the data
+ * to be read by the chip, so this parameter should not be less than 750. You should
+ * probably make it 1000 or more, to be safe.
+ * 
+ * @param config_path The path to configure the sensor address in the Config UI.
+ **/ 
 class OneWireTemperature : public NumericSensor {
  public:
   OneWireTemperature(DallasTemperatureSensors* dts, uint read_delay = 1000,

--- a/src/sensors/onewire_temperature.h
+++ b/src/sensors/onewire_temperature.h
@@ -31,12 +31,12 @@ class DallasTemperatureSensors : public Sensor {
   void enable() override final {}
   bool register_address(const OWDevAddr& addr);
   bool get_next_address(OWDevAddr* addr);
-  DallasTemperature* sensors;
+  DallasTemperature* sensors_;
  private:
-  OneWire* onewire;
-  uint8_t next_sensor = 0;
-  std::set<OWDevAddr> known_addresses;
-  std::set<OWDevAddr> registered_addresses;
+  OneWire* onewire_;
+  //uint8_t next_sensor_ = 0;
+  std::set<OWDevAddr> known_addresses_;
+  std::set<OWDevAddr> registered_addresses_;
 };
 
 /**
@@ -61,7 +61,7 @@ class DallasTemperatureSensors : public Sensor {
  * 
  * @param read_delay How often to read the temperature. It takes up to 750 ms for the data
  * to be read by the chip, so this parameter should not be less than 750. You should
- * probably make it 1000 or more, to be safe.
+ * probably make it 1000 (the default) or more, to be safe.
  * 
  * @param config_path The path to configure the sensor address in the Config UI.
  **/ 
@@ -75,11 +75,11 @@ class OneWireTemperature : public NumericSensor {
   virtual String get_config_schema() override;
 
  private:
-  OneWire* onewire;
-  DallasTemperatureSensors* dts;
-  uint read_delay;
-  bool found = true;
-  OWDevAddr address = {};
+  //OneWire* onewire;
+  DallasTemperatureSensors* dts_;
+  uint read_delay_;
+  bool found_ = true;
+  OWDevAddr address_ = {};
   void update();
   void read_value();
 };

--- a/src/sensors/onewire_temperature.h
+++ b/src/sensors/onewire_temperature.h
@@ -44,6 +44,9 @@ class DallasTemperatureSensors : public Sensor {
  * sensor. If you have X sensors connected to your ESP, you need to create
  * X instances of this class in main.cpp.
  * 
+ * All instances of this class have
+ * a pointer to the same instance of DallasTemperatureSensors.
+ * 
  * Temperature is read in Celsius, then converted to Kelvin before sending
  * to Signal K.
  * 
@@ -54,7 +57,7 @@ class DallasTemperatureSensors : public Sensor {
  * 
  * @see https://github.com/SignalK/SensESP/tree/master/examples/thermocouple_temperature_sensor
  * 
- * @param dts Pointer to an instance of a DalassTemperatureSensors class.
+ * @param dts Pointer to an instance of a DallasTemperatureSensors class.
  * 
  * @param read_delay How often to read the temperature. It takes up to 750 ms for the data
  * to be read by the chip, so this parameter should not be less than 750. You should

--- a/src/wiring_helpers.cpp
+++ b/src/wiring_helpers.cpp
@@ -79,35 +79,35 @@ void setup_fuel_flow_meter(int inflow_pin, int return_flow_pin) {
 
 GPSInput* setup_gps(Stream* rx_stream) {
   GPSInput* gps = new GPSInput(rx_stream);
-  gps->nmea_data.position.connect_to(
+  gps->nmea_data_.position.connect_to(
       new SKOutputPosition("navigation.position", ""));
-  gps->nmea_data.gnss_quality.connect_to(
+  gps->nmea_data_.gnss_quality.connect_to(
       new SKOutputString("navigation.methodQuality", ""));
-  gps->nmea_data.num_satellites.connect_to(
+  gps->nmea_data_.num_satellites.connect_to(
       new SKOutputInt("navigation.satellites", ""));
-  gps->nmea_data.horizontal_dilution.connect_to(
+  gps->nmea_data_.horizontal_dilution.connect_to(
       new SKOutputNumber("navigation.horizontalDilution", ""));
-  gps->nmea_data.geoidal_separation.connect_to(
+  gps->nmea_data_.geoidal_separation.connect_to(
       new SKOutputNumber("navigation.geoidalSeparation", ""));
-  gps->nmea_data.dgps_age.connect_to(
+  gps->nmea_data_.dgps_age.connect_to(
       new SKOutputNumber("navigation.differentialAge", ""));
-  gps->nmea_data.dgps_id.connect_to(
+  gps->nmea_data_.dgps_id.connect_to(
       new SKOutputNumber("navigation.differentialReference", ""));
-  gps->nmea_data.datetime.connect_to(
+  gps->nmea_data_.datetime.connect_to(
       new SKOutputTime("navigation.datetime", ""));
-  gps->nmea_data.speed.connect_to(
+  gps->nmea_data_.speed.connect_to(
       new SKOutputNumber("navigation.speedOverGround", ""));
-  gps->nmea_data.true_course.connect_to(
+  gps->nmea_data_.true_course.connect_to(
       new SKOutputNumber("navigation.courseOverGroundTrue", ""));
-  gps->nmea_data.variation.connect_to(
+  gps->nmea_data_.variation.connect_to(
       new SKOutputNumber("navigation.magneticVariation", ""));
-  gps->nmea_data.rtk_age.connect_to(
+  gps->nmea_data_.rtk_age.connect_to(
       new SKOutputNumber("navigation.rtkAge", ""));
-  gps->nmea_data.rtk_ratio.connect_to(
+  gps->nmea_data_.rtk_ratio.connect_to(
       new SKOutputNumber("navigation.rtkRatio", ""));
-  gps->nmea_data.baseline_length.connect_to(
+  gps->nmea_data_.baseline_length.connect_to(
       new SKOutputNumber("navigation.rtkBaselineLength", ""));
-  gps->nmea_data.baseline_course
+  gps->nmea_data_.baseline_course
       .connect_to(new SKOutputNumber("navigation.rtkBaselineCourse"))
       ->connect_to(new AngleCorrection(0, 0, "/sensors/heading/correction"))
       ->connect_to(new SKOutputNumber("navigation.headingTrue", ""));


### PR DESCRIPTION
Going through all the Sensor files to make sure they:
- Have Doxygen-style comments
- Have data member names with trailing "_"
- Don't have "value" as a read-only entry in the Config UI

~~This is enough for one PR. I'll keep going in other PR's.~~
Oh, what the heck. I'll do another one or two in this PR.

OK, NOW this is ready for review. Lots of commits, all of them very small and "focused" - should be easy to review.