### PR TITLE
Prevent duplicate PUT requests

### DIFF
--- a/examples/smart_switch/remote_switch_example.cpp
+++ b/examples/smart_switch/remote_switch_example.cpp
@@ -85,7 +85,7 @@ ReactESP app([]() {
 
   // Create a switch controller to handle the user press logic and 
   // connect it a server PUT request...
-  SmartSwitchController* controller = new SmartSwitchController();
+  SmartSwitchController* controller = new SmartSwitchController(false);
   controller->connect_to(new SKBooleanPutRequest(sk_path));
 
   // Also connect the controller to an onboard LED...

--- a/src/controllers/smart_switch_controller.cpp
+++ b/src/controllers/smart_switch_controller.cpp
@@ -2,7 +2,9 @@
 #include "transforms/truth_text.h"
 
 void SmartSwitchController::enable() {
-    this->emit(is_on);
+    if (auto_initialize_) {
+       this->emit(is_on);
+    }
 }
 
 void SmartSwitchController::set_input(bool new_value, uint8_t input_channel) {

--- a/src/controllers/smart_switch_controller.h
+++ b/src/controllers/smart_switch_controller.h
@@ -34,6 +34,14 @@ class SmartSwitchController : public BooleanTransform,
                               public ValueConsumer<String> {
 
      public:
+       /**
+        * The constructor
+        * @param auto_initialize If TRUE, the controller will emit an
+        *  initial "off" status when enabled. This is generally the
+        *  desired case unless this controller is mirroring the state
+        *  of a remote load.
+        */
+       SmartSwitchController(bool auto_initialize = true) : auto_initialize_{auto_initialize} {}
        void enable() override;
        void set_input(bool new_value, uint8_t input_channel = 0) override;
        void set_input(String new_value, uint8_t input_channel = 0) override;
@@ -41,6 +49,7 @@ class SmartSwitchController : public BooleanTransform,
 
      protected:
        bool is_on = false;
+       bool auto_initialize_;
 };
 
 #endif

--- a/src/signalk/signalk_put_request.h
+++ b/src/signalk/signalk_put_request.h
@@ -90,6 +90,11 @@ class SKPutRequestBase : public SKRequest, public Configurable {
   virtual String get_config_schema() override;
 
   /**
+   * Returns the Signal K path this object makes requests to
+   */
+  String get_sk_path() { return sk_path; }
+
+  /**
    * Returns TRUE if there is currently a PUT request pending
    * (i.e. this class has send a request, and it has not yet 
    * received a reply or timeout)


### PR DESCRIPTION
Fixes the strange timing problem when a PUT request is issued by a remote switch, but the the physical switch controller sends its current status before it answers the PUT request. This caused the remote switch to issue a second PUT request as it appeared the state had changed yet again.

This fix will also prevent future issues with the server being overwhelmed with requests as this only lets any one PUT request instance to make a single request at a time.