### PR TITLE
Added option to disable RepeatReport repeating

### DIFF
--- a/src/transforms/repeat_report.cpp
+++ b/src/transforms/repeat_report.cpp
@@ -10,7 +10,7 @@ template <typename T>
 void RepeatReport<T>::enable() {
   SymmetricTransform<T>::enable();
   app.onRepeat(10, [this]() {
-    if (last_update_interval_ > max_silence_interval_) {
+    if (max_silence_interval_ > 0 && last_update_interval_ > max_silence_interval_) {
       this->last_update_interval_ = 0;
       this->notify();
     }

--- a/src/transforms/repeat_report.h
+++ b/src/transforms/repeat_report.h
@@ -12,7 +12,8 @@
  * again.
  * 
  * @param max_silence_interval Maximum time, in ms, before the previous value
- * is emitted again. Default is 15000 (15 seconds).
+ * is emitted again. Default is 15000 (15 seconds). Setting the interval to 
+ * zero disables the repeating.
  * 
  * @param config_path Path to configure this transform in the Config UI.
  */


### PR DESCRIPTION
Now, if you set the "repeat interval" to zero via the configuration UI, the auto-repeating of the value is disabled.