### PR TITLE
Use an IP address for all server addresses in /examples

### DIFF
--- a/examples/hysteresis.cpp
+++ b/examples/hysteresis.cpp
@@ -10,7 +10,7 @@ ReactESP app([]() {
   SetupSerialDebug(115200);
 
   sensesp_app = new SensESPApp("sensesp-hysteresis-example", "My WiFi SSID",
-                               "my_wifi_password", "skserver.lan", 80);
+                               "my_wifi_password", "192.168.10.3", 80);
 
   const char* sk_path = "environment.indoor.illuminance";
   const char* analog_in_config_path = "/indoor_illuminance/analog_in";

--- a/examples/lambda_transform.cpp
+++ b/examples/lambda_transform.cpp
@@ -13,7 +13,7 @@ ReactESP app([]() {
   // an equivalent alternative to using the SensESPAppBuilder class.
 
   sensesp_app = new SensESPApp("sensesp-illum-example", "My WiFi SSID",
-                               "my_wifi_password", "skdev.lan", 80);
+                               "my_wifi_password", "192.168.1.13", 80);
 
   // To find valid Signal K Paths that fits your need you look at this link:
   // https://signalk.org/specification/1.4.0/doc/vesselsBranch.html

--- a/examples/smart_switch/remote_switch_example.cpp
+++ b/examples/smart_switch/remote_switch_example.cpp
@@ -48,7 +48,7 @@ ReactESP app([]() {
 
   // Create the global SensESPApp() object.
   sensesp_app = builder.set_hostname("sk-lights-vswitch")
-                    ->set_sk_server("sk-server.local", 3000)
+                    ->set_sk_server("10.10.1.5", 3000)
                     ->set_wifi("YOUR_WIFI_SSID", "YOUR_WIFI_PASSWORD")
                     ->set_standard_sensors(StandardSensors::NONE)
                     ->get_app();

--- a/examples/smart_switch/smart_switch_example.cpp
+++ b/examples/smart_switch/smart_switch_example.cpp
@@ -51,7 +51,7 @@ ReactESP app([]() {
 
   // Create the global SensESPApp() object.
   sensesp_app = builder.set_hostname("sk-engine-lights")
-                    ->set_sk_server("sk-server.local", 3000)
+                    ->set_sk_server("192.168.10.3", 3000)
                     ->set_wifi("YOUR_WIFI_SSID", "YOUR_WIFI_PASSWORD")
                     ->set_standard_sensors(StandardSensors::NONE)
                     ->get_app();

--- a/examples/temperature_sender.cpp
+++ b/examples/temperature_sender.cpp
@@ -62,18 +62,15 @@ ReactESP app([]() {
   SetupSerialDebug(115200);
 #endif
 
-  // Create the global SensESPApp() object. If you add the line ->set_wifi("your
-  // ssid", "your password") you can specify the wifi parameters in the builder.
-  // If you do not do that, the SensESP device wifi configuration hotspot will
-  // appear and you can use a web browser pointed to 192.168.4.1 to configure
-  // the wifi parameters. You can use NONE, UPTIME, FREQUENCY, FREE_MEMORY,
-  // WIFI_SIGNAL or ALL instead if IP_ADDRESS in set_standard_sensors().
+  // Create the global SensESPApp() object by first creating a
+  // SensESPAppBuilder object, then setting some hard-coded
+  // program attributes, and then calling get_app().
 
   // Create a builder object
   SensESPAppBuilder builder;
 
   sensesp_app = builder.set_hostname("your device name")
-                    ->set_sk_server("your server address", 80)
+                    ->set_sk_server("192.168.1.5", 80)
                     ->get_app();
 
   // The "Signal K path" identifies the output of this sensor to the Signal K


### PR DESCRIPTION
Recently had a new user who didn't recognize `sk-server.local` as an alias for the SK Server's IP address, and I spent a couple hours helping him track it down. I'm assuming most users will recognize an IP address as something they need to change, like their wifi SSID and password.