### PR TITLE
Clarify which SensESP to use in platformio.ini

### DIFF
--- a/examples/platformio.ini
+++ b/examples/platformio.ini
@@ -16,7 +16,7 @@
 [platformio]
 ;set default_envs to whichever board(s) you use. Build/Run/etc processes those envs
 default_envs = 
-   ;esp32dev
+;   esp32dev
    d1_mini
 ;   esp-wrover-kit
 
@@ -26,7 +26,15 @@ framework = arduino
 lib_ldf_mode = deep
 monitor_speed = 115200
 lib_deps =
+; Comment out one of the following two paths that point to the
+; SensESP library code.
+
+; This one is the "Release" version - the branch called "latest".
   SignalK/SensESP
+
+; This one has all merged PR's, but is not yet an official "release" version.
+; It is the branch called "master"
+; https://github.com/SignalK/SensESP
 
 [espressif8266_base]
 ;this section has config items common to all ESP8266 boards

--- a/examples/platformio.ini
+++ b/examples/platformio.ini
@@ -33,7 +33,9 @@ lib_deps =
   SignalK/SensESP
 
 ; This one has all merged PR's, but is not yet an official "release" version.
-; It is the branch called "master"
+; It is the branch called "master". This version is unstable and under continuous
+; development and will break without warning. Use it only if you want to
+; participate in SensESP development or need to test some yet unreleased feature.
 ; https://github.com/SignalK/SensESP
 
 [espressif8266_base]


### PR DESCRIPTION
Add `https://github.com/SignalK/SensESP` to the `lib_deps = ` section of `examples/platformio.ini`, as an option to `SignalK/SensESP`, because the latter doesn't have any of the PR's merged since the last release.

This is the result of spending a lot of time helping figure out why new users are getting errors - because they're using new examples from `master`, with code from `latest` (the current "Relase" version).

Hopefully, this will cut down on support issues, or at least make it easier to tell someone how to solve the "using new examples" problem.