### PR TITLE
Fix: 1Wire read delay needs to be longer than the conversion delay

### DIFF
--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -124,6 +124,10 @@ OneWireTemperature::OneWireTemperature(DallasTemperatureSensors* dts,
 
 void OneWireTemperature::enable() {
   if (found_) {
+    // read_delay must be at least a little longer than conversion_delay
+    if (read_delay_ < conversion_delay_ + 50) {
+      read_delay_ = conversion_delay_ + 50;
+    }
     app.onRepeat(read_delay_, [this]() { this->update(); });
   }
 }
@@ -131,7 +135,7 @@ void OneWireTemperature::enable() {
 void OneWireTemperature::update() {
   dts_->sensors_->requestTemperaturesByAddress(address_.data());
   // temp converstion can take up to 750 ms, so wait before reading
-  app.onDelay(750, [this]() { this->read_value(); });
+  app.onDelay(conversion_delay_, [this]() { this->read_value(); });
 }
 
 void OneWireTemperature::read_value() {

--- a/src/sensors/onewire_temperature.h
+++ b/src/sensors/onewire_temperature.h
@@ -59,7 +59,8 @@ class DallasTemperatureSensors : public Sensor {
  * @param dts Pointer to an instance of a DallasTemperatureSensors class.
  * 
  * @param read_delay How often to read the temperature. It takes up to 750 ms for the data
- * to be read by the chip, so this parameter should not be less than 750. You should
+ * to be read by the chip, so this parameter can't be less than 800. If you make it less than
+ * 800, the program will force it to be 800. You should
  * probably make it 1000 (the default) or more, to be safe.
  * 
  * @param config_path The path to configure the sensor address in the Config UI.
@@ -75,6 +76,7 @@ class OneWireTemperature : public NumericSensor {
 
  private:
   DallasTemperatureSensors* dts_;
+  uint conversion_delay_ = 750;
   uint read_delay_;
   bool found_ = true;
   OWDevAddr address_ = {};


### PR DESCRIPTION
I took the easy way out (instead of trying to manage it with concurrent programming - after the warning by @mairas ).