### PR TITLE
FIX: Many "sensor" classes should not inherit from Sensor

### DIFF
--- a/src/sensors/ads1x15.cpp
+++ b/src/sensors/ads1x15.cpp
@@ -3,8 +3,7 @@
 #include "sensesp.h"
 
 template <class T_Ada_1x15>
-ADS1x15<T_Ada_1x15>::ADS1x15(uint8_t addr, adsGain_t gain)
-    : Sensor(), gain_{gain} {
+ADS1x15<T_Ada_1x15>::ADS1x15(uint8_t addr, adsGain_t gain) : gain_{gain} {
   ads_ = new T_Ada_1x15(addr);
   ads_->begin();
   ads_->setGain(gain_);

--- a/src/sensors/ads1x15.h
+++ b/src/sensors/ads1x15.h
@@ -21,10 +21,9 @@
  *   See https://github.com/adafruit/Adafruit_ADS1X15/blob/master/Adafruit_ADS1015.h
  * */
 template <class T_Ada_1x15>
-class ADS1x15 : public Sensor {
+class ADS1x15 {
  public:
   ADS1x15(uint8_t addr = 0x48, adsGain_t gain = GAIN_TWOTHIRDS);
-  void enable() override final {}
   T_Ada_1x15* ads_;
   adsGain_t gain_;
 };

--- a/src/sensors/bme280.cpp
+++ b/src/sensors/bme280.cpp
@@ -5,8 +5,7 @@
 
 // BME280 represents an ADAfruit (or compatible) BME280 temperature / pressure /
 // humidity sensor.
-BME280::BME280(uint8_t addr)
-    : Sensor(), addr_{addr} {
+BME280::BME280(uint8_t addr) : addr_{addr} {
   adafruit_bme280_ = new Adafruit_BME280();
   check_status();
 }

--- a/src/sensors/bme280.h
+++ b/src/sensors/bme280.h
@@ -24,7 +24,7 @@
  * @param addr The memory address where the sensor can be read. Default is 0x77. Some
  * sensors use, or can use, different addresses - check your datasheet.
  **/
-class BME280 : public Sensor {
+class BME280 {
  public:
   BME280(uint8_t addr = 0x77);
   Adafruit_BME280* adafruit_bme280_;

--- a/src/sensors/bmp280.cpp
+++ b/src/sensors/bmp280.cpp
@@ -6,8 +6,7 @@
 
 // BMP280 represents an ADAfruit (or compatible) BMP280 temperature & pressure
 // sensor.
-BMP280::BMP280(uint8_t addr, Adafruit_BMP280* sensor)
-    : Sensor() {
+BMP280::BMP280(uint8_t addr, Adafruit_BMP280* sensor) {
   if (sensor == NULL) {
     sensor = new Adafruit_BMP280();
   }

--- a/src/sensors/bmp280.h
+++ b/src/sensors/bmp280.h
@@ -37,7 +37,7 @@
     auto* bmp280 = new BMP280(0x76, bmp_280_sensor);
 
 */
-class BMP280 : public Sensor {
+class BMP280 {
  public:
   BMP280(uint8_t addr = 0x77, Adafruit_BMP280* sensor = NULL);
   Adafruit_BMP280* adafruit_bmp280_;

--- a/src/sensors/orientation_9dof_input.cpp
+++ b/src/sensors/orientation_9dof_input.cpp
@@ -4,10 +4,7 @@
 
 #include "sensesp.h"
 
-Orientation9DOF::Orientation9DOF(uint8_t pin_i2c_sda, uint8_t pin_i2c_scl,
-                                 String config_path)
-    : Sensor(config_path) {
-  load_configuration();
+Orientation9DOF::Orientation9DOF(uint8_t pin_i2c_sda, uint8_t pin_i2c_scl) {
   sensor_fxos_fxas_ = new SensorNXP_FXOS8700_FXAS21002();
   if (!sensor_fxos_fxas_->connect(pin_i2c_sda, pin_i2c_scl)) {
     debugE(

--- a/src/sensors/orientation_9dof_input.h
+++ b/src/sensors/orientation_9dof_input.h
@@ -26,10 +26,9 @@
  * 
  *  @param pin_i2c_scl The pin you're using for I2c SCL.
 **/
-class Orientation9DOF : public Sensor {
+class Orientation9DOF {
  public:
-  Orientation9DOF(uint8_t pin_i2c_sda, uint8_t pin_i2c_scl,
-                  String config_path = "");
+  Orientation9DOF(uint8_t pin_i2c_sda, uint8_t pin_i2c_scl);
   void stream_raw_values(void);  // used when calibrating
   // pointer to physical sensor
   SensorNXP_FXOS8700_FXAS21002 *sensor_fxos_fxas_;

--- a/src/sensors/sht31.cpp
+++ b/src/sensors/sht31.cpp
@@ -6,8 +6,7 @@
 
 // SHT31 represents an ADAfruit (or compatible) SHT31 temperature & humidity
 // sensor.
-SHT31::SHT31(uint8_t addr)
-    : Sensor() {
+SHT31::SHT31(uint8_t addr) {
   adafruit_sht31_ = new Adafruit_SHT31();
   if (!adafruit_sht31_->begin(addr)) {
     debugE("Could not find a valid SHT31 sensor: check address and wiring");

--- a/src/sensors/sht31.h
+++ b/src/sensors/sht31.h
@@ -20,7 +20,7 @@
  * addresses are available for some SHT31 chips. See the datasheet.
 **/
 
-class SHT31 : public Sensor {
+class SHT31 {
  public:
   SHT31(uint8_t addr = 0x44);
   Adafruit_SHT31* adafruit_sht31_;


### PR DESCRIPTION
This goes back to the first sensor code that I wrote. I mistakenly made the class that represents the physical sensor inherit from `Sensor`. It doesn't need to, because it doesn't have anything that's configurable, and it doesn't actually emit anything.
- ADS1x15
- BME280
- BMP280
- SHT31
- 9DOF