### PR TITLE
Allow compilation when DEBUG_DISABLED defined

### DIFF
--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -29,9 +29,11 @@ void SetupSerialDebug(uint32_t baudrate) {
 
   // A small delay and one debugI() are required so that
   // the serial output displays everything
+#ifndef DEBUG_DISABLED
   delay(100);
   Debug.setSerialEnabled(true);
   delay(100);
+#endif 
   debugI("\nSerial debug enabled");
 }
 

--- a/src/sensors/system_info.cpp
+++ b/src/sensors/system_info.cpp
@@ -1,6 +1,11 @@
 #include "system_info.h"
 
 #include "Arduino.h"
+#if defined(ESP8266)
+  #include <ESP8266WiFi.h>
+#elif defined(ESP32)
+  #include <WiFi.h>
+#endif
 #include "sensesp.h"
 
 void SystemHz::tick() { tick_count_++; }


### PR DESCRIPTION
Basically, we are unable to turn off the debug*() informative prints due to two small compilation errors. Corrected by including one #ifndef guard and one #include statement.  See #358 for details.

This resolves #358. 