### PR TITLE
Remove the delta size estimate debugging message

### DIFF
--- a/src/signalk/signalk_delta.cpp
+++ b/src/signalk/signalk_delta.cpp
@@ -66,8 +66,6 @@ void SKDelta::get_delta(String& output) {
 
   unsigned int doc_size_estimate = get_doc_size_estimate();
 
-  debugD("doc size estimate: %d", doc_size_estimate);
-
   if (!meta_sent_) {
     doc_size_estimate += JSON_OBJECT_SIZE(1) + get_metadata_size_estimate();
   }


### PR DESCRIPTION
When working with the Json doc size estimates, it seems I left behind an unnecessary and spammy debugging message.