### PR TITLE
ENH: SmartSwitchController double click to sync sk paths

### DIFF
--- a/src/controllers/smart_switch_controller.cpp
+++ b/src/controllers/smart_switch_controller.cpp
@@ -1,13 +1,18 @@
 #include "smart_switch_controller.h"
 #include "transforms/truth_text.h"
 
-SmartSwitchController::SmartSwitchController(bool auto_initialize, String config_path, std::set<SyncPath>* defaults) :
+SmartSwitchController::SmartSwitchController(bool auto_initialize, String config_path, const char* sk_sync_paths[]) :
    BooleanTransform(config_path),
    auto_initialize_{auto_initialize} {
 
-  if (defaults != NULL) {
-    sync_paths.clear();
-    sync_paths = *defaults;
+  if (sk_sync_paths != NULL) {
+      sync_paths.clear();
+      int i = 0;
+      while (strlen(sk_sync_paths[i]) > 0) {
+          SyncPath path(sk_sync_paths[i]);
+          sync_paths.insert(path);
+          i++;
+      } // while
   }
 
   load_configuration();

--- a/src/controllers/smart_switch_controller.cpp
+++ b/src/controllers/smart_switch_controller.cpp
@@ -1,6 +1,19 @@
 #include "smart_switch_controller.h"
 #include "transforms/truth_text.h"
 
+SmartSwitchController::SmartSwitchController(bool auto_initialize, String config_path, std::set<SyncPath>* defaults) :
+   BooleanTransform(config_path),
+   auto_initialize_{auto_initialize} {
+
+  if (defaults != NULL) {
+    sync_paths.clear();
+    sync_paths = *defaults;
+  }
+
+  load_configuration();
+}
+
+
 void SmartSwitchController::enable() {
     if (auto_initialize_) {
        this->emit(is_on);
@@ -29,7 +42,16 @@ void SmartSwitchController::set_input(ClickTypes new_value, uint8_t input_channe
     // All other click types toggle the current state...
     is_on = !is_on;
     this->emit(is_on);
+
+    if (new_value == ClickTypes::DoubleClick) {
+        // Sync any specified sync paths...
+        for (auto& path : sync_paths) {
+            debugD("Sync status to %s", path.sk_sync_path.c_str());
+            path.put_request->set_input(is_on);
+        }
+    }
 }
+
 
 void SmartSwitchController::set_input(String new_value, uint8_t input_channel) {
 
@@ -45,4 +67,47 @@ void SmartSwitchController::set_input(String new_value, uint8_t input_channel) {
 
     }
     this->emit(is_on);
+}
+
+
+void SmartSwitchController::get_configuration(JsonObject& root) {
+  JsonArray jPaths = root.createNestedArray("sync_paths");
+  for (auto& path : sync_paths) {
+    jPaths.add(path.sk_sync_path);
+  }
+}
+
+static const char SCHEMA[] PROGMEM = R"({
+    "type": "object",
+    "properties": {
+        "sync_paths": { "title": "Sync on double click",
+                        "type": "array",
+                        "items": { "type": "string"}
+        }
+    }
+  })";
+
+String SmartSwitchController::get_config_schema() { return FPSTR(SCHEMA); }
+
+bool SmartSwitchController::set_configuration(const JsonObject& config) {
+
+  JsonArray arr = config["sync_paths"];
+  if (arr.size() > 0) {
+    sync_paths.clear();
+    for (String sk_path : arr) {
+      SyncPath path(sk_path);
+      sync_paths.insert(path);
+    }
+  }
+
+  return true;
+}
+
+
+SmartSwitchController::SyncPath::SyncPath() {}
+
+SmartSwitchController::SyncPath::SyncPath(String sk_sync_path)
+    : sk_sync_path{sk_sync_path} {
+   debugD("DoubleClick will also sync %s", sk_sync_path.c_str());
+   this->put_request = new SKBooleanPutRequest(sk_sync_path, "", false);
 }

--- a/src/controllers/smart_switch_controller.h
+++ b/src/controllers/smart_switch_controller.h
@@ -1,31 +1,39 @@
 #ifndef _smart_switch_controller_h
 #define _smart_switch_controller_h
 
+#include "signalk/signalk_put_request.h"
 #include "system/valueconsumer.h"
 #include "transforms/click_type.h"
 
 /**
  * @brief A high level transform designed to control a digital output
  * (such as a relay) via manual button presses or programatic commands. 
+ * 
  * To accomplish this, the controller accepts inputs from a generic boolean
  * producer (usually a SignalK listener), as well as String and ClickType inputs.
  * The latter allows a physical button to control the load as well as
- * add special behaviors to the sensor application. In particular, an ultra
- * long press of the button will cause the MCU to reboot.
+ * add special behaviors to the sensor application. In particular, a double
+ * click can be configured to set the state of multiple signal k paths, and
+ * an ultra long press of the button will cause the MCU to reboot.
  * <p>A SmartSwitchController object behaves differently depending on the type of 
  * input it receives. If the input is a boolean or a "valid truth type" 
  * (which is a specialized type of boolean - see below), SmartSwitchController's 
  * output will be "on" if the input is "true", or "off" if the input is "false". 
  * If the input is a ClickType, or a String that's NOT a "valid truth type", 
  * SmartSwitchController's output will simply toggle the output back and forth 
- * between "on" and "off" with each input. The one exception to this is if
- * the input is a ClickType with the value ClickTypes::UltraLongSingleClick
- * which will reboot the MCU.
+ * between "on" and "off" with each input. There are two exceptions to this if
+ * the input is a ClickType:
+ * <ol>
+ *   <li>A value of ClickTypes::DoubleClick will toggle the output as well as
+ *       send PUT requests to syncrhonize zero or more paths that are configured to
+ *       do so</li>
+ *   <li>A value of ClickTypes::UltraLongSingleClick will reboot the MCU.</li>
+ * </ol>
  * <p>Incoming String values are evaluated to see if they represent a "valid truth type". 
  * Examples include "on", "ON", "off", "true", "false", "one", "1", "123" (or any other string
  * that represents a non-zero value), etc. Case is insensitive. Any 
  * incoming String that doesn't evaluate to a "valid truth type" will be treated as 
- * a "click", and will toggle the output btween "on" and "off". 
+ * a "single click", and will toggle the output btween "on" and "off". 
  * @see TextToTruth 
  * @see ClickType
  */
@@ -34,22 +42,46 @@ class SmartSwitchController : public BooleanTransform,
                               public ValueConsumer<String> {
 
      public:
+       class SyncPath {
+          public:
+            String sk_sync_path;
+            SKBooleanPutRequest* put_request;
+
+            SyncPath();
+            SyncPath(String sk_sync_path);
+
+            friend bool operator<(const SyncPath& lhs, const SyncPath& rhs) {
+              return lhs.sk_sync_path < rhs.sk_sync_path;
+            }
+       };
+
        /**
         * The constructor
         * @param auto_initialize If TRUE, the controller will emit an
         *  initial "off" status when enabled. This is generally the
         *  desired case unless this controller is mirroring the state
         *  of a remote load.
+        * @param config_path The path to save configuration data (blank for
+        *   no saving)
+        * @param defaults The default list of paths to synchronize status
+        *   when a double click is commanded by the user.
         */
-       SmartSwitchController(bool auto_initialize = true) : auto_initialize_{auto_initialize} {}
+       SmartSwitchController(bool auto_initialize = true, String config_path = "", std::set<SyncPath>* defaults = NULL);
        void enable() override;
        void set_input(bool new_value, uint8_t input_channel = 0) override;
        void set_input(String new_value, uint8_t input_channel = 0) override;
        void set_input(ClickTypes new_value, uint8_t input_channel = 0) override;
 
+
+       // For reading and writing the configuration of this transformation
+       virtual void get_configuration(JsonObject& doc) override;
+       virtual bool set_configuration(const JsonObject& config) override;
+       virtual String get_config_schema() override;
+
      protected:
        bool is_on = false;
        bool auto_initialize_;
+       std::set<SyncPath> sync_paths;
 };
 
 #endif

--- a/src/controllers/smart_switch_controller.h
+++ b/src/controllers/smart_switch_controller.h
@@ -25,7 +25,7 @@
  * the input is a ClickType:
  * <ol>
  *   <li>A value of ClickTypes::DoubleClick will toggle the output as well as
- *       send PUT requests to syncrhonize zero or more paths that are configured to
+ *       send PUT requests to synchronize zero or more paths that are configured to
  *       do so</li>
  *   <li>A value of ClickTypes::UltraLongSingleClick will reboot the MCU.</li>
  * </ol>
@@ -42,6 +42,34 @@ class SmartSwitchController : public BooleanTransform,
                               public ValueConsumer<String> {
 
      public:
+       /**
+        * The constructor
+        * @param auto_initialize If TRUE, the controller will emit an
+        *  initial "off" status when enabled. This is generally the
+        *  desired case unless this controller is mirroring the state
+        *  of a remote load.
+        * @param config_path The path to save configuration data (blank for
+        *   no saving)
+        * @param sk_sync_paths An optional array of Signal K paths that should
+        *   synchronize their status whenever a double click ClickType is received.
+        *   Each path listed will have a PUT request issued to set the status to
+        *   be the same as this SmartSwitchController each time a double click occurs.
+        *   This list, if specified, should have a zero length string as its last entry.
+        */
+       SmartSwitchController(bool auto_initialize = true, String config_path = "", const char* sk_sync_paths[] = NULL);
+       void enable() override;
+       void set_input(bool new_value, uint8_t input_channel = 0) override;
+       void set_input(String new_value, uint8_t input_channel = 0) override;
+       void set_input(ClickTypes new_value, uint8_t input_channel = 0) override;
+
+
+       // For reading and writing the configuration of this transformation
+       virtual void get_configuration(JsonObject& doc) override;
+       virtual bool set_configuration(const JsonObject& config) override;
+       virtual String get_config_schema() override;
+
+     public:
+       /// Used to store configuration internally.
        class SyncPath {
           public:
             String sk_sync_path;
@@ -54,29 +82,6 @@ class SmartSwitchController : public BooleanTransform,
               return lhs.sk_sync_path < rhs.sk_sync_path;
             }
        };
-
-       /**
-        * The constructor
-        * @param auto_initialize If TRUE, the controller will emit an
-        *  initial "off" status when enabled. This is generally the
-        *  desired case unless this controller is mirroring the state
-        *  of a remote load.
-        * @param config_path The path to save configuration data (blank for
-        *   no saving)
-        * @param defaults The default list of paths to synchronize status
-        *   when a double click is commanded by the user.
-        */
-       SmartSwitchController(bool auto_initialize = true, String config_path = "", std::set<SyncPath>* defaults = NULL);
-       void enable() override;
-       void set_input(bool new_value, uint8_t input_channel = 0) override;
-       void set_input(String new_value, uint8_t input_channel = 0) override;
-       void set_input(ClickTypes new_value, uint8_t input_channel = 0) override;
-
-
-       // For reading and writing the configuration of this transformation
-       virtual void get_configuration(JsonObject& doc) override;
-       virtual bool set_configuration(const JsonObject& config) override;
-       virtual String get_config_schema() override;
 
      protected:
        bool is_on = false;


### PR DESCRIPTION
This PR enhances SmartSwitchController to allow the "double click" button input to sync the light's status to one or more additional sk paths via an SKBooleanPutRequest().  For example, a "double click" on one of the boat's interior lights can cause ALL the interior lights to turn on.