### PR TITLE
Non blocking wifi

### DIFF
--- a/src/controllers/system_status_controller.cpp
+++ b/src/controllers/system_status_controller.cpp
@@ -6,16 +6,16 @@ void SystemStatusController::set_input(WifiState new_value,
   // this would be a simple array dereferencing
   switch (new_value) {
     case WifiState::kWifiNoAP:
-      this->emit(SystemStatus::kWifiNoAP);
+      this->update_state(SystemStatus::kWifiNoAP);
       break;
     case WifiState::kWifiDisconnected:
-      this->emit(SystemStatus::kWifiDisconnected);
+      this->update_state(SystemStatus::kWifiDisconnected);
       break;
     case WifiState::kWifiConnectedToAP:
-      this->emit(SystemStatus::kWSDisconnected);
+      this->update_state(SystemStatus::kWSDisconnected);
       break;
     case WifiState::kWifiManagerActivated:
-      this->emit(SystemStatus::kWifiManagerActivated);
+      this->update_state(SystemStatus::kWifiManagerActivated);
       break;
   }
 }
@@ -24,16 +24,21 @@ void SystemStatusController::set_input(WSConnectionState new_value,
                                        uint8_t input_channel) {
   switch (new_value) {
     case WSConnectionState::kWSDisconnected:
-      this->emit(SystemStatus::kWSDisconnected);
+      if (current_state_ != SystemStatus::kWifiDisconnected &&
+          current_state_ != SystemStatus::kWifiNoAP &&
+          current_state_ != SystemStatus::kWifiManagerActivated) {
+        // Wifi disconnection states override the higher level protocol state
+        this->update_state(SystemStatus::kWSDisconnected);
+      }
       break;
     case WSConnectionState::kWSConnecting:
-      this->emit(SystemStatus::kWSConnecting);
+      this->update_state(SystemStatus::kWSConnecting);
       break;
     case WSConnectionState::kWSAuthorizing:
-      this->emit(SystemStatus::kWSAuthorizing);
+      this->update_state(SystemStatus::kWSAuthorizing);
       break;
     case WSConnectionState::kWSConnected:
-      this->emit(SystemStatus::kWSConnected);
+      this->update_state(SystemStatus::kWSConnected);
       break;
   }
 }

--- a/src/controllers/system_status_controller.h
+++ b/src/controllers/system_status_controller.h
@@ -36,6 +36,13 @@ class SystemStatusController : public ValueConsumer<WifiState>,
   /// (WSClient object state updates)
   virtual void set_input(WSConnectionState new_value,
                          uint8_t input_channel = 0) override;
+ protected:
+  void update_state(const SystemStatus new_state) {
+    current_state_ = new_state;
+    this->emit(new_state);
+  }
+ private:
+  SystemStatus current_state_ = SystemStatus::kWifiNoAP;
 };
 
 #endif

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -83,6 +83,7 @@ void Networking::wifi_station_connected() {
 }
 
 void Networking::wifi_station_disconnected() {
+  debugI("Disconnected from wifi.");
   this->emit(WifiState::kWifiDisconnected);
 }
 

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -163,21 +163,13 @@ String Networking::get_config_schema() {
   // Config UI. If preset_hostname is not "SensESP", then it was set in
   // main.cpp, so it should be read-only.
   bool hostname_preset = preset_hostname != "SensESP";
-  bool wifi_preset = preset_ssid != "";
   return String(FPSTR(SCHEMA_PREFIX)) +
          get_property_row("hostname", "ESP device hostname", hostname_preset) +
-         "," +
-         get_property_row("ap_ssid", "Wifi Access Point SSID", wifi_preset) +
-         "," +
-         get_property_row("ap_password", "Wifi Access Point Password",
-                          wifi_preset) +
          "}}";
 }
 
 void Networking::get_configuration(JsonObject& root) {
   root["hostname"] = this->hostname->get();
-  root["ap_ssid"] = this->ap_ssid;
-  root["ap_password"] = this->ap_password;
 }
 
 bool Networking::set_configuration(const JsonObject& config) {
@@ -189,11 +181,6 @@ bool Networking::set_configuration(const JsonObject& config) {
     this->hostname->set(config["hostname"].as<String>());
   }
 
-  if (preset_ssid == "") {
-    debugW("Using saved SSID and password");
-    this->ap_ssid = config["ap_ssid"].as<String>();
-    this->ap_password = config["ap_password"].as<String>();
-  }
   return true;
 }
 

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -189,5 +189,8 @@ void Networking::reset_settings() {
   ap_password = preset_password;
 
   save_configuration();
-  wifi_manager->resetSettings();
+  WiFi.disconnect(true);
+  // On ESP32, disconnect does not erase previous credentials. Let's connect
+  // to a bogus network instead
+  WiFi.begin("0", "0");
 }

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -71,8 +71,6 @@ void Networking::setup_saved_ssid() {
   this->emit(WifiState::kWifiDisconnected);
   setup_wifi_callbacks();
   WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
-  
-  uint32_t timer_start = millis();
 
   debugI("Connecting to wifi %s.", ap_ssid.c_str());
 }

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -83,14 +83,7 @@ void Networking::wifi_station_connected() {
 }
 
 void Networking::wifi_station_disconnected() {
-  // if connection is lost, simply restart
-  debugD("Wifi disconnected");
-
-  // Might be futile to notify about a disconnection if it results in
-  // a reboot anyway
   this->emit(WifiState::kWifiDisconnected);
-
-  //ESP.restart();
 }
 
 void Networking::setup_wifi_manager() {

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -49,12 +49,14 @@ void Networking::setup() {
 
 void Networking::setup_wifi_callbacks() {
 #if defined(ESP8266)
-  WiFi.onStationModeConnected([this](const WiFiEventStationModeConnected& event) { 
-    this->wifi_station_connected();
-  });
-  WiFi.onStationModeDisconnected([this](const WiFiEventStationModeDisconnected& event) { 
-    this->wifi_station_disconnected();
-  });
+  got_ip_event_handler_ =
+      WiFi.onStationModeGotIP([this](const WiFiEventStationModeGotIP& event) {
+        this->wifi_station_connected();
+      });
+  wifi_disconnected_event_handler_ = WiFi.onStationModeDisconnected(
+      [this](const WiFiEventStationModeDisconnected& event) {
+        this->wifi_station_disconnected();
+      });
 #elif defined(ESP32)
   WiFi.onEvent([this](WiFiEvent_t event, WiFiEventInfo_t info) {
     this->wifi_station_connected();

--- a/src/net/networking.h
+++ b/src/net/networking.h
@@ -3,6 +3,10 @@
 
 #include "Arduino.h"
 
+#ifdef ESP8266
+#include <ESP8266WiFi.h>
+#endif
+
 // Local WebServer used to serve the configuration portal
 #include <ESPAsyncWebServer.h>
 #include <ESPAsyncWiFiManager.h>
@@ -19,7 +23,7 @@ enum class WifiState {
 };
 
 /**
- * @brief Manages the ESP's connection to the Wifi network. 
+ * @brief Manages the ESP's connection to the Wifi network.
  */
 class Networking : public Configurable, public ValueProducer<WifiState> {
  public:
@@ -48,6 +52,13 @@ class Networking : public Configurable, public ValueProducer<WifiState> {
   // respective methods to save some runtime memory
   DNSServer* dns;
   AsyncWiFiManager* wifi_manager;
+
+#ifdef ESP8266
+  // event handlers must be saved to keep the handlers activated
+  WiFiEventHandler got_ip_event_handler_;
+  WiFiEventHandler wifi_disconnected_event_handler_;
+#endif
+
   ObservableValue<String>* hostname;
   String ap_ssid = "";
   String ap_password = "";

--- a/src/net/networking.h
+++ b/src/net/networking.h
@@ -33,9 +33,14 @@ class Networking : public Configurable, public ValueProducer<WifiState> {
   void reset_settings();
 
  protected:
-  void check_connection();
   void setup_saved_ssid();
+  void setup_wifi_callbacks();
   void setup_wifi_manager();
+
+  // callbacks
+
+  void wifi_station_connected();
+  void wifi_station_disconnected();
 
  private:
   AsyncWebServer* server;


### PR DESCRIPTION
This PR implements quite a few changes in the networking code. WiFi connection logic is no longer blocking: we don't need to wait for the wifi to get connected before entering the main loop. This allows easier simultaneous NMEA 2000 and other protocol use.

The wifi disconnection watchdog that reboots the device after disconnection is now a LambdaConsumer of SystemStatus in SensESPApp instead of being hard-coded in the Networking class. Sure, the behavior is arguably still hard-coded but will be easier to modify in the future. This requires PR #365 to work.

Wifi state changes are now captured and propagated using event handlers. Due to underlying API differences, the implementation is platform-specific (different for ESP8266 and ESP32).

Wifi settings were not reset properly at least on ESP32. Now they're nuked to invalid values on reset to force the device to forget the old values.

Wifi settings are no longer saved on SPIFFS by SensESP. The settings are in any case saved to flash memory by WifiManager, so having them in multiple places just made things more difficult.