### PR TITLE
Change min interval for sending deltas to 5 ms from 100 ms

### DIFF
--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -71,7 +71,7 @@ WSClient::WSClient(String config_path, SKDelta* sk_delta, String server_address,
 void WSClient::enable() {
   app.onDelay(0, [this]() { this->connect(); });
   app.onRepeat(20, [this]() { this->loop(); });
-  app.onRepeat(100, [this]() { this->send_delta(); });
+  app.onRepeat(5, [this]() { this->send_delta(); });
   app.onRepeat(10000, [this]() { this->connect_loop(); });
 }
 


### PR DESCRIPTION
Current minimum interval between SK delta messages is 100 ms. This change improves the maximum possible rate of deltas by decreasing the interval between calls to `send_delata()` to 5ms.

This  resolves #369 