### PR TITLE
AnalogInput: update docs for this and related classes

### DIFF
--- a/src/sensors/analog_input.h
+++ b/src/sensors/analog_input.h
@@ -27,7 +27,9 @@
    * 'output_scale' is 1024, which means output will be from 0 to 1023. If you
    * want your output to be on a different scale, use this parameter to indicate
    * the X in the `0 to X` scale. For example, if you want your output to be
-   * expressed as a percentage (0 to 100), make this parameter be 100.
+   * expressed as a percentage (0 to 100), make this parameter be 100. If you want
+   * your output to be the original voltage read by the AnalogIn pin, make this
+   * parameter be the maximum voltage that can go into the pin (probably 3.3).
    */
  class AnalogInput : public NumericSensor {
  public:

--- a/src/sensors/analog_input.h
+++ b/src/sensors/analog_input.h
@@ -29,7 +29,11 @@
    * the X in the `0 to X` scale. For example, if you want your output to be
    * expressed as a percentage (0 to 100), make this parameter be 100. If you want
    * your output to be the original voltage read by the AnalogIn pin, make this
-   * parameter be the maximum voltage that can go into the pin (probably 3.3).
+   * parameter be the maximum voltage that can go into the pin (probably 3.3). If
+   * you want your output to be the original voltage that was intput into a
+   * physical voltage divider circuit before being read by the AnalogIn pin,
+   * make this parameter be the maximum voltage that you would send into the
+   * voltage divider circuit.
    */
  class AnalogInput : public NumericSensor {
  public:

--- a/src/transforms/analogvoltage.h
+++ b/src/transforms/analogvoltage.h
@@ -10,12 +10,17 @@
 #endif
 
 /**
- * @brief A transform that takes the output of the built-in
- * analog-to-digital converter on the ESP and outputs the voltage that went into
- * it.
+ * @brief A transform that takes the output of an
+ * analog-to-digital converter and outputs the voltage that went into
+ * it. (This can be the built-in ADC on the ESP, or it can be an external
+ * ADC like the ADS1015/1115.)
  * 
  * It can also be used like the Linear transport since it has a multiplier
  * and an offset.
+ * 
+ * If you don't need to use the mulitplier or offset, you probably don't need
+ * this transform, because the AnalogInput sensor now has the ability to output
+ * the original voltage that came into it, using its `output_scale` parameter.
  * 
  * @param max_voltage is the maximum voltage allowable on the Analog
  * Input pin of the microcontroller, which is 3.3V on most ESP's, but only 1.0V

--- a/src/transforms/voltage_multiplier.h
+++ b/src/transforms/voltage_multiplier.h
@@ -4,7 +4,11 @@
 #include "transforms/transform.h"
 
 /**
- * @brief A transform that does the opposite of what a physical voltage divider circuit
+ * @brief OBSOLETE: Since you can now apply an "output_scale" to the
+ * AnalogInput sensor, you don't need this transform anymore. See the
+ * description of "output_scale" in analog_input.h.
+ * 
+ * A transform that does the opposite of what a physical voltage divider circuit
  * does: convert the voltage that comes out of a voltage divider back
  * into the original voltage that went into the voltage divider.
  *

--- a/src/transforms/voltagedivider.h
+++ b/src/transforms/voltagedivider.h
@@ -9,7 +9,7 @@
  * 
  * Vout = (Vin x R2) / (R1 + R2) is the voltage divider formula. We know:
  * - Vout - that's the input to this transform, probably coming from an AnalogVoltage
- *          transform.
+ *          transform, or directly from an AnalogInput sensor.
  * - Vin - that's one of the paramaters to this transform. It's a fixed voltage that
  *         you know from your physical voltage divider circuit.
  * - R2 - also a parameter to this transform, and also from your physical voltage divider.
@@ -46,7 +46,7 @@ class VoltageDividerR1 : public SymmetricTransform<float> {
  * 
  * Vout = (Vin x R2) / (R1 + R2) is the voltage divider formula. We know:
  * - Vout - that's the input to this transform, probably coming from an AnalogVoltage
- *          transform.
+ *          transform, or directly from an AnalogInput sensor.
  * - Vin - that's one of the paramaters to this transform. It's a fixed voltage that
  *         you know from your physical voltage divider circuit.
  * - R1 - also a parameter to this transform, and also from your physical voltage divider.


### PR DESCRIPTION
Make it clear that AnalogVoltage is probably not needed in most cases.