### PR TITLE
Fix duplication of CurveInterpolator samples

### DIFF
--- a/src/transforms/curveinterpolator.cpp
+++ b/src/transforms/curveinterpolator.cpp
@@ -64,7 +64,6 @@ void CurveInterpolator::get_configuration(JsonObject& root) {
     auto entry = jSamples.createNestedObject();
     entry["input"] = sample.input;
     entry["output"] = sample.output;
-    jSamples.add(entry);
   }
 }
 


### PR DESCRIPTION
Entering and saving samples in the CurveInterpolator transform's web interface causes duplicates of the entered values to appear if the web interface is opened subsequent to the first save.  See issue #375 for details.

Fix consists of removing extraneous call to `jSamples.add(entry);`
