### PR TITLE
Don't pin down the ReactESP version number

### DIFF
--- a/library.json
+++ b/library.json
@@ -22,8 +22,7 @@
   ],
   "dependencies": [
     {
-      "name": "ReactESP",
-      "version": "^0.2.2"
+      "name": "ReactESP"
     },
     {
       "name": "ESP8266WebServer",


### PR DESCRIPTION
I hadn't noticed that ReactESP version number was actually pinned down in library.json. This PR removes the version restriction.