### PR TITLE
Create a separate page for add-on libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,6 @@ Class documentation for SensESP is [here](http://signalk.org/SensESP/generated/d
 
 A Wiki page with more detailed information about using SensESP is [here](https://github.com/SignalK/SensESP/wiki).
 
-Libraries for some SensESP "add-ons" can be found [here](https://github.com/SensESP). Initially, there are a few external sensors in this list
-(such as the INA family of voltage and current sensors). Eventually, there may be add-ons to interface with other hardware or software.
-
-*NOTE:* If you have an existing project that fails to compile after 2020-10-22, add the following line to the `[env]` section of the `platformio.ini` file of your project:
-
-    lib_ldf_mode = deep
-
 ## Getting Started
 
 You must have a Signal K Server running on your network, or SensESP has nothing to connect to. The most common installation is the Signal K node server running on a Raspberry Pi. Installation instructions for that are [here](https://github.com/SignalK/signalk-server-node/blob/master/raspberry_pi_installation.md).
@@ -74,6 +67,13 @@ You can find the IP address of your device in the Serial Monitor, right after th
 
 Everything that is configurable on a "live" device will be in the menu that appears. As you'll see in the examples, this includes things like how often you want to read the sensor (usually represented as "read_delay"), how many samples you want in the MovingAverage() transform, what multiplier and offset you want in the Linear() transform, etc., etc. You can also rename the device from that menu, and restart the device, and even reset the device to factory settings (which erases the wifi credentials and the device name).
 
+## Add-on libraries
+
+Going forward, SensESP attempts to focus on providing the core "scaffolding" for building asynchronous and Signal K aware sensor devices. It will not include sensor classes for every possible piece of hardware but those can be provided by third parties and pulled in as dependencies as any other library. Thus, SensESP will hopefully become more like a network of affiliated projects.
+
+A list of SensESP add-on libraries can be found on a separate page: [SensESP add-ons and related projects](https://github.com/SensESP/blob/master/docs/Add-ons.md).
+
+
 ## Getting help
 
 Discussion about SensESP happens mostly in [Signalk-dev Slack](http://slack-invite.signalk.org/) on the #sensors channel. Don't hesitate to join and ask if you ever have problems with getting your project working!
@@ -81,9 +81,3 @@ Discussion about SensESP happens mostly in [Signalk-dev Slack](http://slack-invi
 ## Contributing
 
 Some guidelines about contributing to SensESP are given on the [SensESP wiki](https://github.com/SignalK/SensESP/wiki/Contributing-to-the-SensESP-Project). In particular, you should follow the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and try to keep the Git commits clean. The project maintainers are active on the [Signalk-dev Slack](http://slack-invite.signalk.org/) #sensors channel. It's recommended to provide a heads-up about your plans there first!
-
-## SensESP Class Diagram
-
-----------------------------
-
-![alt text](sens_esp_uml.png "UML for SensESP")

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ and ESP32. It can be used as a high-level toolkit for
 creating ESP-based hardware sensoring devices that interface with Signal K
 servers.
 
-SensESP is heavily inspired by [SigkSens](https://github.com/mxtommy/SigkSens)
-and prior work done by [@mxtommy](https://github.com/mxtommy).
-
 Class documentation for SensESP is [here](http://signalk.org/SensESP/generated/docs/annotated.html).
 
 A Wiki page with more detailed information about using SensESP is [here](https://github.com/SignalK/SensESP/wiki).

--- a/docs/Add-ons.md
+++ b/docs/Add-ons.md
@@ -1,0 +1,25 @@
+# List of SensESP add-ons and related projects
+
+This page lists different add-ons and other projects related to [SensESP](https://github.com/SignalK/SensESP).
+
+## Sensor libraries
+
+### Attitude
+
+- [NXP Sensor Fusion](https://github.com/BjarneBitscrambler/OrientationSensorFusion-ESP): Orientation sensing and sensor fusion using NXP FXOS8700 magnetometer/accelerometer and FXAS21002 gyroscope sensors
+
+### Current and power
+
+- [INA2xx](https://github.com/SensESP/INA2xx): Library for reading one or more of the INA2xx (INA219, INA226, INA3221) current and power sensors
+
+### Output and display libraries
+
+- [Status display for SSD1306-based OLED modules](https://github.com/mairas/SensESPStatusDisplay): An example for using small 128x32 and 128x64 pixel OLED modules as a system status display
+
+### Temperature and humidity
+
+- [DHTxx](https://github.com/SensESP/DHTxx): Library for reading low-cost DHTxx Temperature and Humidity Sensors including DHT11, DHT21, and DHT22.
+
+## Examples and related projects
+
+- [SH-ESP32-test-jig](https://github.com/hatlabs/SH-ESP32-test-jig): A test jig implementation for the [SH-ESP32](https://hatlabs.github.io/sh-esp32/). While not generally useful in itself, these two projects showcase NMEA 2000 communication and how to use SensESP constructs without having to instantiate a SensESPApp object.

--- a/docs/Add-ons.md
+++ b/docs/Add-ons.md
@@ -2,6 +2,8 @@
 
 This page lists different add-ons and other projects related to [SensESP](https://github.com/SignalK/SensESP).
 
+If you want to have your own project added to the list, [make a PR](https://github.com/SignalK/SensESP/pulls) or [create an issue](https://github.com/SignalK/SensESP/issues) for it.
+
 ## Sensor libraries
 
 ### Attitude


### PR DESCRIPTION
Add-on libraries are now listed on their own page with instructions on how to add your own.