### PR TITLE
Bump master branch version number to 1.0.4-alpha

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = SensESP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.0.3
+PROJECT_NUMBER         = 1.0.4-alpha
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/library.json
+++ b/library.json
@@ -114,7 +114,7 @@
       "version": "https://github.com/JoaoLopesF/RemoteDebug.git#0b5a9c1a49fd2ade0e3cadc3a3707781e819359a" 
     }
   ],
-  "version": "1.0.3",
+  "version": "1.0.4-alpha",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SensESP
-version=1.0.3
+version=1.0.4-alpha
 author=Matti Airas <mairas@iki.fi>
 maintainer=Matti Airas <mairas@iki.fi>
 sentence=Signal K sensor development library for ESP devices


### PR DESCRIPTION
To better differentiate between the stable releases and the development branch, this PR bumps the development branch version number to 1.0.4-alpha. This should not imply that the next release version is 1.0.4 -- it could be that, or 1.1.0, or 2.00, depending on the changes done during the development cycle.