### PR TITLE
1-Wire error detection and library change

### DIFF
--- a/library.json
+++ b/library.json
@@ -56,11 +56,11 @@
       "name": "WebSockets"
     },
     {
-      "name": "OneWire",
-      "version": "paulstoffregen/OneWire"
+      "name": "OneWireNg"
     },
     {
-      "name": "DallasTemperature"
+      "name": "DallasTemperature",
+      "version": "https://github.com/pstolarz/Arduino-Temperature-Control-Library"
     },
     {
       "name": "ESPTrueRandom",

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,8 +36,8 @@ lib_deps =
    ESPAsyncWifiManager
    ArduinoJson
    WebSockets
-   OneWire
-   DallasTemperature
+   pstolarz/OneWireNg
+   https://github.com/pstolarz/Arduino-Temperature-Control-Library
    https://github.com/sivar2311/ESPTrueRandom
    https://github.com/pfeerick/elapsedMillis
    Wire

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,7 +41,7 @@ lib_deps =
    https://github.com/sivar2311/ESPTrueRandom
    https://github.com/pfeerick/elapsedMillis
    Wire
-   Adafruit ADS1X15 @ <2.0.0
+   Adafruit ADS1X15
    Adafruit AHRS
    Adafruit BME280 Library
    Adafruit BMP280 Library

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -1,7 +1,6 @@
 #include "onewire_temperature.h"
 
 #include <DallasTemperature.h>
-#include <OneWire.h>
 
 #include <algorithm>
 

--- a/src/sensors/onewire_temperature.cpp
+++ b/src/sensors/onewire_temperature.cpp
@@ -139,8 +139,17 @@ void OneWireTemperature::update() {
 }
 
 void OneWireTemperature::read_value() {
+  float tempC = dts_->sensors_->getTempC(address_.data());
+  // we're on purpose ignoring the "conversion not ready" value (+85°C)
+  // because the update method always waits for 750 ms before reading the value
+  if (tempC == DEVICE_DISCONNECTED_C) {
+    char ow_addr_str[24];
+    owda_to_string(ow_addr_str, address_);
+    debugW("Failed to read 1-Wire device %s", ow_addr_str);
+    return;
+  }
   // getTempC returns degrees Celsius but Signal K expects Kelvin
-  this->emit(dts_->sensors_->getTempC(address_.data()) + 273.15);
+  this->emit(tempC + 273.15);
 }
 
 void OneWireTemperature::get_configuration(JsonObject& root) {

--- a/src/sensors/onewire_temperature.h
+++ b/src/sensors/onewire_temperature.h
@@ -4,7 +4,6 @@
 #include <set>
 
 #include <DallasTemperature.h>
-#include <OneWire.h>
 
 #include "sensor.h"
 


### PR DESCRIPTION
DallasTemperature sensor implementation now correctly detects the read error codes. Under the hood, the 1-Wire library has been changed from the stale `PaulStoffregen/OneWire` to `pstolarz/OneWireNg`. This seems to fix all the read errors on ESP32 and works unchanged on ESP8266 too.
