### PR TITLE
Changed samples from private to protected

### DIFF
--- a/src/transforms/curveinterpolator.h
+++ b/src/transforms/curveinterpolator.h
@@ -56,7 +56,7 @@ class CurveInterpolator : public NumericTransform {
     add_sample(new_sample);
   }
 
- private:
+ protected:
   std::set<Sample> samples;
 };
 


### PR DESCRIPTION
Not 100% sure if this is ok architecture wise: In order to override get_input in a subclass, I also need to be able to access samples since I still need to iterate over the samples in the implementation in my subclass. Please let me know if there is a more elegant way of doing this!