### PR TITLE
WiFi.localIP() returns broadcast address 255.255.255.255 when using workaround

### DIFF
--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -73,7 +73,7 @@ void Networking::setup_saved_ssid() {
 
   // this is a workaround for setting the DHCP hostname, suggested in
   // https://github.com/espressif/arduino-esp32/issues/2537
-  WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+  // WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
 #ifdef ESP32
   WiFi.setHostname(hostname->get().c_str());
 #elif defined(ESP8266)
@@ -124,7 +124,7 @@ void Networking::setup_wifi_manager() {
 
   // this is a workaround for setting the DHCP hostname, suggested in
   // https://github.com/espressif/arduino-esp32/issues/2537
-  WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
+  // WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);
 #ifdef ESP32
   WiFi.setHostname(hostname->get().c_str());
 #elif defined(ESP8266)


### PR DESCRIPTION
When using this workaround, WiFi.localIP() returns 255.255.255.255 after a successful wifi connect and the signal k server can't be found with mdns.  
I tested that for the ESP8266 v2 with platform version Espressif 8266 v2.6.3

see here: https://github.com/espressif/arduino-esp32/issues/4732