### PR TITLE
Prevent Configure <hostname> AP from showing

### DIFF
--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -87,6 +87,7 @@ void Networking::wifi_station_connected() {
            WiFi.RSSI());
     debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
     this->emit(WifiState::kWifiConnectedToAP);
+    WiFi.mode(WIFI_STA); // so "Configure <hostname>" AP won't appear
 }
 
 void Networking::wifi_station_disconnected() {

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -87,7 +87,9 @@ void Networking::wifi_station_connected() {
            WiFi.RSSI());
     debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
     this->emit(WifiState::kWifiConnectedToAP);
+#if defined(ESP8266)
     WiFi.mode(WIFI_STA); // so "Configure <hostname>" AP won't appear
+#endif        
 }
 
 void Networking::wifi_station_disconnected() {


### PR DESCRIPTION
After wifi is configured, the "Configure <hostname>" AP would still appear in a list of available AP's. This solves that.