### PR TITLE
Define PWMRANGE for ESP8266

### DIFF
--- a/src/system/pwm_output.cpp
+++ b/src/system/pwm_output.cpp
@@ -12,6 +12,10 @@
 #define PWMRANGE 4095
 #endif
 
+#ifdef ESP8266
+#define PWMRANGE 1023
+#endif
+
 std::map<uint8_t, int8_t> PWMOutput::channel_to_pin_;
 
 PWMOutput::PWMOutput(int pin, int pwm_channel) {


### PR DESCRIPTION
Necessary due to a change in ESP8266/Arduino code. See SensESP Issue #424.