### PR TITLE
Move hostname from Networking to SensESPApp

### DIFF
--- a/src/net/discovery.cpp
+++ b/src/net/discovery.cpp
@@ -10,7 +10,7 @@
 #endif
 
 void MDNSDiscovery::start() {
-  const char* hostname = sensesp_app->get_hostname().c_str();
+  const char* hostname = sensesp_app->get_hostname_observable()->get().c_str();
 
   // MDNS.begin(hostname) will crash if hostname is blank
   if ((hostname == NULL) || (hostname[0] == '\0')) {

--- a/src/net/http.cpp
+++ b/src/net/http.cpp
@@ -211,7 +211,8 @@ void HTTPServer::handle_info(AsyncWebServerRequest* request) {
 
   response->setCode(200);
   response->printf("Name: %s, build at %s %s\n",
-                   sensesp_app->get_hostname().c_str(), __DATE__, __TIME__);
+                   sensesp_app->get_hostname_observable()->get().c_str(),
+                   __DATE__, __TIME__);
 
   response->printf("MAC: %s\n", WiFi.macAddress().c_str());
   response->printf("WiFi signal: %d\n", WiFi.RSSI());

--- a/src/net/networking.h
+++ b/src/net/networking.h
@@ -30,7 +30,6 @@ class Networking : public Configurable, public Startable, public ValueProducer<W
  public:
   Networking(String config_path, String ssid, String password, String hostname);
   virtual void start() override;
-  ObservableValue<String>* get_hostname();
   virtual void get_configuration(JsonObject& doc) override final;
   virtual bool set_configuration(const JsonObject& config) override final;
   virtual String get_config_schema() override;
@@ -60,7 +59,6 @@ class Networking : public Configurable, public Startable, public ValueProducer<W
   WiFiEventHandler wifi_disconnected_event_handler_;
 #endif
 
-  ObservableValue<String>* hostname;
   String ap_ssid = "";
   String ap_password = "";
   String preset_ssid = "";

--- a/src/net/ws_client.cpp
+++ b/src/net/ws_client.cpp
@@ -367,7 +367,8 @@ void WSClient::send_access_request(const String server_address,
   // create a new access request
   DynamicJsonDocument doc(1024);
   doc["clientId"] = client_id_;
-  doc["description"] = String("SensESP device: ") + sensesp_app->get_hostname();
+  doc["description"] = String("SensESP device: ") +
+                       sensesp_app->get_hostname_observable()->get();
   doc["permissions"] = kRequestPermission;
   String json_req = "";
   serializeJson(doc, json_req);

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -44,7 +44,7 @@ class SensESPApp {
   void setup();
   void start();
   void reset();
-  String get_hostname();
+  ObservableValue<String>* get_hostname_observable();
 
   // getters for internal members
   SKDeltaQueue* get_sk_delta() { return this->sk_delta_queue_; }
@@ -82,12 +82,14 @@ class SensESPApp {
     return this;
   }
 
- private:
+ protected:
   String preset_hostname_ = "SensESP";
   String ssid_ = "";
   String wifi_password_ = "";
   String sk_server_address_ = "";
   uint16_t sk_server_port_ = 0;
+
+  ObservableValue<String>* hostname_;
 
   void initialize();
 

--- a/src/signalk/signalk_delta_queue.cpp
+++ b/src/signalk/signalk_delta_queue.cpp
@@ -3,10 +3,11 @@
 #include "Arduino.h"
 #include "ArduinoJson.h"
 #include "sensesp.h"
+#include "sensesp_app.h"
 #include "signalk/signalk_emitter.h"
 
-SKDeltaQueue::SKDeltaQueue(const String& hostname, unsigned int max_buffer_size)
-    : Startable{0}, hostname{hostname}, max_buffer_size{max_buffer_size}, meta_sent_{false} {}
+SKDeltaQueue::SKDeltaQueue(unsigned int max_buffer_size)
+    : Startable{0}, max_buffer_size{max_buffer_size}, meta_sent_{false} {}
 
 void SKDeltaQueue::start() {
   this->connect_emitters();
@@ -95,7 +96,7 @@ void SKDeltaQueue::get_delta(String& output) {
 
   JsonObject current = updates.createNestedObject();
   JsonObject source = current.createNestedObject("source");
-  source["label"] = hostname;
+  source["label"] = sensesp_app->get_hostname_observable()->get();
   JsonArray values = current.createNestedArray("values");
 
   while (!buffer.empty()) {

--- a/src/signalk/signalk_delta_queue.h
+++ b/src/signalk/signalk_delta_queue.h
@@ -16,11 +16,10 @@
  */
 class SKDeltaQueue : public Startable {
  public:
-  SKDeltaQueue(const String& hostname, unsigned int max_buffer_size = 20);
+  SKDeltaQueue(unsigned int max_buffer_size = 20);
   void append(const String val);
   bool data_available();
   void get_delta(String& output);
-  void set_hostname(String hostname) { this->hostname = hostname; }
 
   void connect_emitters();
 
@@ -31,7 +30,6 @@ class SKDeltaQueue : public Startable {
   virtual void start() override;
 
  private:
-  String hostname;
   unsigned int max_buffer_size;
   std::list<String> buffer;
   bool meta_sent_;


### PR DESCRIPTION
The device hostname is used not just in the networking sense but also as a unique device name. As such, it is better to store it in SensESPApp instead of Network. This also decouples Network from SensESPApp.