### PR TITLE
ADS1115 output should be signed

### DIFF
--- a/src/sensors/ads1x15.h
+++ b/src/sensors/ads1x15.h
@@ -67,7 +67,7 @@ class ADS1x15RawValue : public NumericSensor {
   T_ads_1x15* ads1x15_;
   ADS1x15Channel_t channel_;
   uint read_delay_;
-  uint16_t raw_value_ = 0;
+  int16_t raw_value_ = 0;
 
  private:
   virtual void get_configuration(JsonObject& doc) override;


### PR DESCRIPTION
One-character bugfixes are the best.

I didn't have suitable hardware at hand so I didn't actually test the change. Let's summon @RBerliner for that!

Fixes #473.