### PR TITLE
Use the new preferred naming for dependencies

### DIFF
--- a/library.json
+++ b/library.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": [
     {
+      "owner": "mairas",
       "name": "ReactESP",
       "version": "^2.0.0"
     },
@@ -34,14 +35,12 @@
       "platforms": "espressif8266"
     },
     {
-      "name": "DNSServer"
-    },
-    {
+      "owner": "me-no-dev",
       "name": "ESPAsyncTCP"
     },
     {
-      "name": "ESP Async WebServer",
-      "version": "https://github.com/me-no-dev/ESPAsyncWebServer"
+      "owner": "me-no-dev",
+      "name": "ESP Async WebServer"
     },
     {
       "name": "ESP8266WiFi",
@@ -52,17 +51,20 @@
       "platforms": "espressif8266"
     },
     {
+      "owner": "alanswx",
       "name": "ESPAsyncWiFiManager"
     },
     {
+      "owner": "bblanchon",
       "name": "ArduinoJson"
     },
     {
+      "owner": "links2004",
       "name": "WebSockets"
     },
     {
-      "name": "elapsedMillis",
-      "version": "https://github.com/pfeerick/elapsedMillis"
+      "owner": "pfeerick",
+      "name": "elapsedMillis"
     },
     {
       "name": "RemoteDebug",

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,15 +28,14 @@ monitor_speed = 115200
 lib_deps =
    mairas/ReactESP@^2.0.0
    ESP8266WebServer
-   DNSServer
-   ESPAsyncTCP
-   ESP Async Webserver
+   me-no-dev/ESPAsyncTCP
+   me-no-dev/ESP Async Webserver
    ESP8266WiFi
    ESP8266mDNS
-   ESPAsyncWifiManager
+   alanswx/ESPAsyncWifiManager
    bblanchon/ArduinoJson
-   WebSockets
-   https://github.com/pfeerick/elapsedMillis
+   links2004/WebSockets
+   pfeerick/elapsedMillis
    https://github.com/JoaoLopesF/RemoteDebug.git#0b5a9c1a49fd2ade0e3cadc3a3707781e819359a
 
 [espressif32_base]


### PR DESCRIPTION
Also removed DNSSserver because it's not actually used. Go figure.