### PR TITLE
Make OTA authentication mandatory

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -47,7 +47,14 @@ extends = espressif32_base
 board = esp32dev
 build_flags =
    -D LED_BUILTIN=2
-   ; Uncomment te following to disable debug output altogether
+   ; Uncomment the following to disable debug output altogether
    ;-D DEBUG_DISABLED
    ; Uncomment the following to enable the remote debug telnet interface on port 23
    ;-D REMOTE_DEBUG
+; Uncomment the following to use the OTA interface for flashing.
+; "mydevice" must correspond to the device hostname.
+; "mypassword" must correspond to the device OTA password.
+;upload_protocol = espota
+;upload_port = mydevice.local
+;upload_flags =
+;   --auth=mypassword

--- a/src/net/ota.cpp
+++ b/src/net/ota.cpp
@@ -7,15 +7,8 @@
 
 namespace sensesp {
 
-// Password for Over-the-air (OTA) updates
-#ifndef OTA_PASSWORD
-//#define OTA_PASSWORD "bonvoyage"
-#endif
-
 void OTA::start() {
-#ifdef OTA_PASSWORD
-  ArduinoOTA.setPassword((const char *)OTA_PASSWORD);
-#endif
+  ArduinoOTA.setPassword(password_);
   ArduinoOTA.onStart([]() { debugW("Starting OTA"); });
   ArduinoOTA.onEnd([]() { debugW("OTA End"); });
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {

--- a/src/net/ota.h
+++ b/src/net/ota.h
@@ -7,10 +7,16 @@ namespace sensesp {
 
 class OTA : public Startable {
  public:
-  OTA() : Startable{0} {}
+  /**
+   * @brief Construct a new OTA (Over-the-air update) object
+   *
+   * @param password A password to be used for the OTA update.
+   */
+  OTA(const char* password) : Startable{0}, password_{password} {}
   virtual void start() override;
 
  private:
+  const char* password_;
   static void handle_ota();
 };
 

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -23,8 +23,10 @@ void SensESPApp::setup() {
   networking_ = new Networking("/system/networking", ssid_, wifi_password_,
                                SensESPBaseApp::get()->get_hostname_observable()->get());
 
-  // create the OTA object
-  ota_ = new OTA();
+  if (ota_password_ != nullptr) {
+    // create the OTA object
+    ota_ = new OTA(ota_password_);
+  }
 
   // create the HTTP server
   this->http_server_ = new HTTPServer();

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -92,12 +92,15 @@ class SensESPApp : public SensESPBaseApp {
     this->system_status_led_ = system_status_led;
     return this;
   }
+  const SensESPApp* enable_ota(const char* password) {
+    ota_password_ = password;
+  }
 
- protected:
   String ssid_ = "";
   String wifi_password_ = "";
   String sk_server_address_ = "";
   uint16_t sk_server_port_ = 0;
+  const char* ota_password_ = nullptr;
 
   ObservableValue<String>* hostname_;
 

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -25,21 +25,62 @@ class SensESPAppBuilder : public SensESPBaseAppBuilder {
   SensESPApp* app_;
 
  public:
+  /**
+   * @brief Construct a new SensESPApp Builder object.
+   *
+   * SensESPAppBuilder is used to instantiate a SensESPApp
+   * object with non-trivial configuration.
+   */
   SensESPAppBuilder() { app_ = SensESPApp::get(); }
+  /**
+   * @brief Set the Wi-Fi network SSID and password.
+   *
+   * If not set, WiFiManager is used to create an access point for configuring
+   * the settings.
+   *
+   * @param ssid
+   * @param password
+   * @return SensESPAppBuilder*
+   */
   SensESPAppBuilder* set_wifi(String ssid, String password) {
     app_->set_ssid(ssid);
     app_->set_wifi_password(password);
     return this;
   }
+  /**
+   * @brief Set the Signal K server address and port.
+   *
+   * If not set, mDNS is used to discover the Signal K server.
+   *
+   * @param address
+   * @param port
+   * @return SensESPAppBuilder*
+   */
   SensESPAppBuilder* set_sk_server(String address, uint16_t port) {
     app_->set_sk_server_address(address);
     app_->set_sk_server_port(port);
     return this;
   }
+  /**
+   * @brief Set the device hostname.
+   *
+   * If not set, the device hostname is set to "SensESP".
+   *
+   * @param hostname
+   * @return SensESPAppBuilder*
+   */
   SensESPAppBuilder* set_hostname(String hostname) override final {
     app_->set_hostname(hostname);
     return this;
   }
+  /**
+   * @brief Set the system status led object.
+   *
+   * This allows custom status LED patterns to be used.
+   *
+   * @param system_status_led
+   * @return SensESPAppBuilder*
+   */
   SensESPAppBuilder* set_system_status_led(SystemStatusLed* system_status_led) {
     app_->set_system_status_led(system_status_led);
     return this;
@@ -48,28 +89,73 @@ class SensESPAppBuilder : public SensESPBaseAppBuilder {
     WSClient::test_auth_on_each_connect_ = val;
     return this;
   }
-  SensESPAppBuilder* enable_system_hz_sensor(String prefix=kDefaultSystemInfoSensorPrefix) {
+  /**
+   * @brief Enable the System Hz sensor.
+   *
+   * The System Hz sensor is a built-in sensor that measures how many
+   * times the system loop is executed per second.
+   *
+   * @param prefix
+   * @return SensESPAppBuilder*
+   */
+  SensESPAppBuilder* enable_system_hz_sensor(
+      String prefix = kDefaultSystemInfoSensorPrefix) {
     connect_system_info_sensor(new SystemHz(), prefix, "systemHz");
     return this;
   }
-  SensESPAppBuilder* enable_free_mem_sensor(String prefix=kDefaultSystemInfoSensorPrefix) {
+  /**
+   * @brief Enable the free memory sensor.
+   *
+   * @param prefix
+   * @return SensESPAppBuilder*
+   */
+  SensESPAppBuilder* enable_free_mem_sensor(
+      String prefix = kDefaultSystemInfoSensorPrefix) {
     connect_system_info_sensor(new FreeMem(), prefix, "freeMemory");
     return this;
   }
-  SensESPAppBuilder* enable_uptime_sensor(String prefix=kDefaultSystemInfoSensorPrefix) {
+  /**
+   * @brief Report the system uptime in seconds since the last reboot.
+   *
+   * @param prefix
+   * @return SensESPAppBuilder*
+   */
+  SensESPAppBuilder* enable_uptime_sensor(
+      String prefix = kDefaultSystemInfoSensorPrefix) {
     connect_system_info_sensor(new Uptime(), prefix, "uptime");
     return this;
   }
-  SensESPAppBuilder* enable_ip_address_sensor(String prefix=kDefaultSystemInfoSensorPrefix) {
+  /**
+   * @brief Report the IP address of the device.
+   *
+   * @param prefix
+   * @return SensESPAppBuilder*
+   */
+  SensESPAppBuilder* enable_ip_address_sensor(
+      String prefix = kDefaultSystemInfoSensorPrefix) {
     connect_system_info_sensor(new IPAddrDev(), prefix, "ipAddress");
     return this;
   }
-  SensESPAppBuilder* enable_wifi_signal_sensor(String prefix=kDefaultSystemInfoSensorPrefix) {
+  /**
+   * @brief Report the Wi-Fi signal strength.
+   *
+   * @param prefix
+   * @return SensESPAppBuilder*
+   */
+  SensESPAppBuilder* enable_wifi_signal_sensor(
+      String prefix = kDefaultSystemInfoSensorPrefix) {
     connect_system_info_sensor(new WiFiSignal(), prefix, "wifiSignalLevel");
     return this;
   }
 
-  SensESPAppBuilder* enable_system_info_sensors(String prefix=kDefaultSystemInfoSensorPrefix) {
+  /**
+   * @brief Enable all built-in system info sensors.
+   *
+   * @param prefix
+   * @return SensESPAppBuilder*
+   */
+  SensESPAppBuilder* enable_system_info_sensors(
+      String prefix = kDefaultSystemInfoSensorPrefix) {
     this->enable_system_hz_sensor(prefix);
     this->enable_free_mem_sensor(prefix);
     this->enable_uptime_sensor(prefix);
@@ -88,6 +174,13 @@ class SensESPAppBuilder : public SensESPBaseAppBuilder {
     app_->enable_ota(password);
     return this;
   }
+  /**
+   * @brief Get the SensESPApp object.
+   *
+   * Return a SensESPApp object that has been setup.
+   *
+   * @return SensESPApp*
+   */
   SensESPApp* get_app() override final {
     app_->setup();
     return app_;

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -78,6 +78,16 @@ class SensESPAppBuilder : public SensESPBaseAppBuilder {
     return this;
   }
 
+  /**
+   * @brief Enable over-the-air updates for the device.
+   *
+   * @param password OTA authentication password.
+   * @return SensESPAppBuilder*
+   */
+  SensESPAppBuilder* enable_ota(const char* password) {
+    app_->enable_ota(password);
+    return this;
+  }
   SensESPApp* get_app() override final {
     app_->setup();
     return app_;


### PR DESCRIPTION
Over-the-air updates are now enabled only if a password has been provided. This improves safety (a lot) and saves memory if OTA is not needed.

Fixes #453.