### PR TITLE
Set a default password for the WiFi Manager configuration access point

### DIFF
--- a/examples/minimal_app.cpp
+++ b/examples/minimal_app.cpp
@@ -40,7 +40,8 @@ void setup() {
   // the HTTP configuration interface
 
   auto* networking = new Networking(
-      "/system/net", "", "", sensesp_app->get_hostname_observable()->get());
+      "/system/net", "", "", sensesp_app->get_hostname_observable()->get(),
+      "thisisfine");
   auto* http_server = new HTTPServer();
 
   auto* digin1 = new DigitalInputCounter(input_pin1, INPUT, RISING, read_delay);

--- a/src/net/networking.cpp
+++ b/src/net/networking.cpp
@@ -19,8 +19,8 @@ bool should_save_config = false;
 void save_config_callback() { should_save_config = true; }
 
 Networking::Networking(String config_path, String ssid, String password,
-                       String hostname)
-    : Configurable{config_path}, Startable(80), Resettable(0) {
+                       String hostname, const char* wifi_manager_password)
+    : Configurable{config_path}, wifi_manager_password_{wifi_manager_password}, Startable(80), Resettable(0) {
   this->output = WifiState::kWifiNoAP;
 
   preset_ssid = ssid;
@@ -115,7 +115,7 @@ void Networking::setup_wifi_manager() {
   WiFi.setHostname(
       SensESPBaseApp::get()->get_hostname_observable()->get().c_str());
 
-  if (!wifi_manager->autoConnect(pconfig_ssid)) {
+  if (!wifi_manager->autoConnect(pconfig_ssid, wifi_manager_password_)) {
     debugE("Failed to connect to wifi and config timed out. Restarting...");
 
     this->emit(WifiState::kWifiDisconnected);

--- a/src/net/networking.h
+++ b/src/net/networking.h
@@ -30,7 +30,8 @@ class Networking : public Configurable,
                    public Resettable,
                    public ValueProducer<WifiState> {
  public:
-  Networking(String config_path, String ssid, String password, String hostname);
+  Networking(String config_path, String ssid, String password, String hostname,
+             const char* wifi_manager_password);
   virtual void start() override;
   virtual void reset() override;
 
@@ -60,6 +61,7 @@ class Networking : public Configurable,
   String preset_ssid = "";
   String preset_password = "";
   String preset_hostname = "";
+  const char* wifi_manager_password_;
 };
 
 }  // namespace sensesp

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -20,8 +20,10 @@ void SensESPApp::setup() {
   SensESPBaseApp::setup();
 
   // create the networking object
-  networking_ = new Networking("/system/networking", ssid_, wifi_password_,
-                               SensESPBaseApp::get()->get_hostname_observable()->get());
+  networking_ =
+      new Networking("/system/networking", ssid_, wifi_password_,
+                     SensESPBaseApp::get()->get_hostname_observable()->get(),
+                     wifi_manager_password_);
 
   if (ota_password_ != nullptr) {
     // create the OTA object

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -101,6 +101,7 @@ class SensESPApp : public SensESPBaseApp {
   String sk_server_address_ = "";
   uint16_t sk_server_port_ = 0;
   const char* ota_password_ = nullptr;
+  const char* wifi_manager_password_ = "thisisfine";
 
   ObservableValue<String>* hostname_;
 

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -95,6 +95,9 @@ class SensESPApp : public SensESPBaseApp {
   const SensESPApp* enable_ota(const char* password) {
     ota_password_ = password;
   }
+  const SensESPApp* set_wifi_manager_password(const char* password) {
+    wifi_manager_password_ = password;
+  }
 
   String ssid_ = "";
   String wifi_password_ = "";

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -174,6 +174,22 @@ class SensESPAppBuilder : public SensESPBaseAppBuilder {
     app_->enable_ota(password);
     return this;
   }
+
+  /**
+   * @brief Set the wifi manager password.
+   *
+   * Set the password for the WiFi configuration access point
+   * that is enabled after device reset if no wifi configuration
+   * is provided in the application code.
+   *
+   * @param password
+   * @return SensESPAppBuilder*
+   */
+  SensESPAppBuilder* set_wifi_manager_password(const char* password) {
+    app_->set_wifi_manager_password(password);
+    return this;
+  }
+
   /**
    * @brief Get the SensESPApp object.
    *


### PR DESCRIPTION
WiFi Manager configuration access point is started if the WiFi configuration is not hardcoded and the device is unable to connect to the WiFi. Previously, this AP didn't have a password, allowing anyone nearby to hijack the device.

This PR adds a default password ("thisisfine") for WiFiManager. A builder method for changing the default password has also been implemented.

Fixes #454.
