### PR TITLE
Fix the minimal_app example

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
           - examples/analog_input.cpp
           - examples/hysteresis.cpp
           - examples/lambda_transform.cpp
+          - examples/minimal_app.cpp
           - examples/relay_control.cpp
           - examples/rpm_counter.cpp
         target_device:

--- a/examples/minimal_app.cpp
+++ b/examples/minimal_app.cpp
@@ -40,7 +40,7 @@ void setup() {
   // the HTTP configuration interface
 
   auto* networking = new Networking(
-      "/system/net", "", "", sensesp_app->get_hostname(),
+      "/system/net", "", "", SensESPBaseApp::get_hostname(),
       "thisisfine");
   auto* http_server = new HTTPServer();
 


### PR DESCRIPTION
Accidentally broke the minimal_app example when adding the `get_hostname()` convenience method. Fixed that, and also added `examples/minimal_app.cpp` to the GitHub Actions run.