### PR TITLE
Hostname handling fixes

### DIFF
--- a/src/net/discovery.cpp
+++ b/src/net/discovery.cpp
@@ -8,20 +8,19 @@
 namespace sensesp {
 
 void MDNSDiscovery::start() {
-  const char* hostname =
-      SensESPBaseApp::get_hostname().c_str();
+  String hostname = SensESPBaseApp::get_hostname();
 
   // MDNS.begin(hostname) will crash if hostname is blank
-  if ((hostname == NULL) || (hostname[0] == '\0')) {
+  if ((hostname == "")) {
     debugE("hostname has not been set - mDNS can't start");
     return;
   }
-  if (!MDNS.begin(hostname)) {  // Start the mDNS responder for hostname.local
+  if (!MDNS.begin(hostname.c_str())) {  // Start the mDNS responder for hostname.local
     debugW("Error setting up mDNS responder");
   } else {
     debugI("mDNS responder started at %s", hostname);
   }
-  mdns_instance_name_set(hostname);  // mDNS hostname for ESP32
+  mdns_instance_name_set(hostname.c_str());  // mDNS hostname for ESP32
   MDNS.addService("http", "tcp", 80);
   MDNS.addService("signalk-sensesp", "tcp", 80);
 }

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -15,6 +15,13 @@ SensESPApp* SensESPApp::get() {
   return (SensESPApp*)instance_;
 }
 
+/**
+ * @brief Perform initialization of SensESPApp once builder configuration is
+ * done.
+ *
+ * This should be only called from the builder!
+ *
+ */
 void SensESPApp::setup() {
   // call the parent setup()
   SensESPBaseApp::setup();
@@ -22,8 +29,7 @@ void SensESPApp::setup() {
   // create the networking object
   networking_ =
       new Networking("/system/networking", ssid_, wifi_password_,
-                     SensESPBaseApp::get_hostname(),
-                     wifi_manager_password_);
+                     SensESPBaseApp::get_hostname(), wifi_manager_password_);
 
   if (ota_password_ != nullptr) {
     // create the OTA object

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -45,7 +45,6 @@ class SensESPApp : public SensESPBaseApp {
    */
   static SensESPApp* get();
 
-  void setup();
   ObservableValue<String>* get_hostname_observable();
 
   // getters for internal members
@@ -98,6 +97,10 @@ class SensESPApp : public SensESPBaseApp {
   const SensESPApp* set_wifi_manager_password(const char* password) {
     wifi_manager_password_ = password;
   }
+
+  void setup();
+
+
 
   String ssid_ = "";
   String wifi_password_ = "";

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -109,8 +109,6 @@ class SensESPApp : public SensESPBaseApp {
   const char* ota_password_ = nullptr;
   const char* wifi_manager_password_ = "thisisfine";
 
-  ObservableValue<String>* hostname_;
-
   Filesystem* filesystem_;
   DebugOutput* debug_output_;
   MDNSDiscovery* mdns_discovery_;

--- a/src/sensesp_base_app.cpp
+++ b/src/sensesp_base_app.cpp
@@ -29,6 +29,13 @@ SensESPBaseApp::SensESPBaseApp() {
  */
 SensESPBaseApp* SensESPBaseApp::get() { return instance_; }
 
+/**
+ * @brief Perform initialization of SensESPBaseApp once builder configuration is
+ * done.
+ *
+ * This should be only called from the builder!
+ *
+ */
 void SensESPBaseApp::setup() {
   // initialize the filesystem
   filesystem_ = new Filesystem();

--- a/src/sensesp_base_app.h
+++ b/src/sensesp_base_app.h
@@ -32,12 +32,6 @@ class SensESPBaseApp {
   static SensESPBaseApp* get();
 
   /**
-   * @brief Initialize the app
-   *
-   */
-  virtual void setup();
-
-  /**
    * @brief Start the app (activate all the subcomponents)
    *
    */
@@ -67,6 +61,8 @@ class SensESPBaseApp {
    * refactored into a singleton.
    */
   SensESPBaseApp();
+
+  virtual void setup();
 
   static SensESPBaseApp* instance_;
 


### PR DESCRIPTION
Some changes in hostname handling resulted in the MDNSDiscovery class not receiving the correct hostname, preventing the mDNS client from starting. Fixed now.