### PR TITLE
Implement a RepeatSensor template class

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
           - examples/minimal_app.cpp
           - examples/relay_control.cpp
           - examples/rpm_counter.cpp
+          - examples/async_repeat_sensor.cpp
+          - examples/repeat_sensor_analog_input.cpp
         target_device:
           - esp32dev
     steps:

--- a/examples/async_repeat_sensor.cpp
+++ b/examples/async_repeat_sensor.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file async_repeat_sensor.cpp
+ * @brief Example of an asynchronous RepeatSensor that reads a digital input.
+ *
+ * RepeatSensor is a helper class that can be used to wrap any generic Arduino
+ * sensor library into a SensESP sensor. This file demonstrates its use with
+ * the built-in GPIO digital input, but in an asynchronous manner.
+ *
+ */
+
+#include "sensesp_app_builder.h"
+#include "signalk/signalk_output.h"
+#include "transforms/linear.h"
+
+using namespace sensesp;
+
+reactesp::ReactESP app;
+
+// The setup function performs one-time application initialization.
+void setup() {
+// Some initialization boilerplate when in debug mode...
+#ifndef SERIAL_DEBUG_DISABLED
+  SetupSerialDebug(115200);
+#endif
+
+  // Create the global SensESPApp() object.
+  SensESPAppBuilder builder;
+  sensesp_app = builder.get_app();
+
+  const uint8_t kDigitalInputPin = 15;
+
+  // Do here any sensor initialization you need. For a more complex sensor,
+  // this might include initializing the hardware, setting the I2C pins, etc.
+  pinMode(kDigitalInputPin, INPUT_PULLUP);
+
+  // GPIO pin that we'll be using for the analog input.
+
+  // define an asynchronous callback function that reads a digital input pin
+  // after a delay of 1000 ms.
+  auto analog_read_callback = [](RepeatSensor<bool>* sensor) {
+    debugI("Pretend to trigger an asynchronous measurement operation here.");
+    app.onDelay(
+        1000, [sensor]() { sensor->emit(digitalRead(kDigitalInputPin)); });
+  };
+
+  // Let's read the sensor every 2000 ms.
+  unsigned int read_interval = 2000;
+
+  // Create a RepeatSensor with float output that reads the analog input.
+  auto* digital =
+      new RepeatSensor<bool>(read_interval, analog_read_callback);
+
+  // The "Signal K path" identifies this sensor to the Signal K server. Leaving
+  // this blank would indicate this particular sensor (or transform) does not
+  // broadcast Signal K data.
+  // To find valid Signal K Paths that fits your need you look at this link:
+  // https://signalk.org/specification/1.4.0/doc/vesselsBranch.html
+  const char* sk_path = "environment.bool.pin15";
+
+  // Connect the output of the analog input to the Linear transform,
+  // and then output the results to the Signal K server. As part of
+  // that output, send some metadata to indicate that the "units"
+  // to be used to display this value is "ratio". Also specify that
+  // the display name for this value, to be used by any Signal K
+  // consumer that displays it, is "Indoor light".
+  digital->connect_to(
+      new SKOutputFloat(sk_path, ""));
+
+  // Start the SensESP application running
+  sensesp_app->start();
+}
+
+// The loop function is called in an endless loop during program execution.
+// It simply calls `app.tick()` which will then execute all reactions as needed.
+void loop() { app.tick(); }

--- a/examples/repeat_sensor_analog_input.cpp
+++ b/examples/repeat_sensor_analog_input.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file repeat_sensor_analog_input.cpp
+ * @brief Example of a RepeatSensor that reads an analog input.
+ *
+ * RepeatSensor is a helper class that can be used to wrap any generic Arduino
+ * sensor library into a SensESP sensor. This file demonstrates its use with
+ * the built-in analog input sensor.
+ *
+ * Note that for analog input, it's actually better to use the AnalogInput
+ * sensor class as demonstrated by the analog_input.cpp example file. The
+ * AnalogInput class compensates for the ESP32 ADC nonlinearities. The approach
+ * presented here, however, can be used with any sensor library compatible with
+ * arduino-esp32.
+ *
+ */
+
+#include "sensesp_app_builder.h"
+#include "signalk/signalk_output.h"
+#include "transforms/linear.h"
+
+using namespace sensesp;
+
+reactesp::ReactESP app;
+
+// GPIO pin that we'll be using for the analog input.
+const uint8_t kAnalogInputPin = 36;
+
+// define a callback function that reads the analog input
+float analog_read_callback() { return analogRead(kAnalogInputPin) / 4096.0; }
+
+// The setup function performs one-time application initialization.
+void setup() {
+// Some initialization boilerplate when in debug mode...
+#ifndef SERIAL_DEBUG_DISABLED
+  SetupSerialDebug(115200);
+#endif
+
+  // Create the global SensESPApp() object.
+  SensESPAppBuilder builder;
+  sensesp_app = builder.get_app();
+
+  // Do here any sensor initialization you need. For a more complex sensor,
+  // this might include initializing the hardware, setting the I2C pins, etc.
+  // In this case, we'll just set the analog input attenuation to 2.5 dB,
+  // corresponding to maximum input voltage of 1.1 V.
+  analogSetAttenuation(ADC_2_5db);
+
+  // Let's read the sensor every 100 ms.
+  unsigned int read_interval = 100;
+
+  // Create a RepeatSensor with float output that reads the analog input.
+  auto* analog_input =
+      new RepeatSensor<float>(read_interval, analog_read_callback);
+
+  // The "Signal K path" identifies this sensor to the Signal K server. Leaving
+  // this blank would indicate this particular sensor (or transform) does not
+  // broadcast Signal K data.
+  // To find valid Signal K Paths that fits your need you look at this link:
+  // https://signalk.org/specification/1.4.0/doc/vesselsBranch.html
+  const char* sk_path = "environment.indoor.illuminance";
+
+  // Connect the output of the analog input to the Linear transform,
+  // and then output the results to the Signal K server. As part of
+  // that output, send some metadata to indicate that the "units"
+  // to be used to display this value is "ratio". Also specify that
+  // the display name for this value, to be used by any Signal K
+  // consumer that displays it, is "Indoor light".
+  analog_input->connect_to(
+      new SKOutputFloat(sk_path, "", new SKMetadata("ratio", "Indoor light")));
+
+  // Start the SensESP application running
+  sensesp_app->start();
+}
+
+// The loop function is called in an endless loop during program execution.
+// It simply calls `app.tick()` which will then execute all reactions as needed.
+void loop() { app.tick(); }

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -51,6 +51,35 @@ typedef SensorT<float> FloatSensor;
 typedef SensorT<int> IntSensor;
 typedef SensorT<String> StringSensor;
 
+template <class T>
+class RepeatSensor : public SensorT<T> {
+ public:
+  /**
+   * @brief Construct a new RepeatSensor object.
+   *
+   * RepeatSensor is a sensor that calls a callback function at given intervals
+   * and produces the value returned by the callback function. It can be used
+   * to wrap any generic Arduino sensor library into a SensESP sensor.
+   *
+   * @param repeat_interval_ms The repeating interval, in milliseconds.
+   * @param callback A callback function that returns the value the sensor will produce.
+   * @tparam T The type of the value returned by the callback function.
+   */
+  RepeatSensor<T>(unsigned int repeat_interval_ms, std::function<T()> callback)
+      : SensorT<T>(""),
+        repeat_interval_ms_(repeat_interval_ms),
+        callback_(callback) {}
+  void start() override final {
+    ReactESP::app->onRepeat(repeat_interval_ms_, [this]() {
+      this->emit(this->callback_());
+    });
+  }
+
+ protected:
+  unsigned int repeat_interval_ms_;
+  std::function<T()> callback_;
+};
+
 }  // namespace sensesp
 
 #endif

--- a/src/sensors/sensor.h
+++ b/src/sensors/sensor.h
@@ -62,22 +62,48 @@ class RepeatSensor : public SensorT<T> {
    * to wrap any generic Arduino sensor library into a SensESP sensor.
    *
    * @param repeat_interval_ms The repeating interval, in milliseconds.
-   * @param callback A callback function that returns the value the sensor will produce.
+   * @param callback A callback function that returns the value the sensor will
+   * produce.
    * @tparam T The type of the value returned by the callback function.
    */
   RepeatSensor<T>(unsigned int repeat_interval_ms, std::function<T()> callback)
       : SensorT<T>(""),
         repeat_interval_ms_(repeat_interval_ms),
-        callback_(callback) {}
+        returning_callback_(callback) {}
+
+  /**
+   * @brief Construct a new RepeatSensor object (supporting asynchronous
+   * callbacks).
+   *
+   * RepeatSensor is a sensor that calls a callback function at given intervals
+   * and produces the value returned by the callback function. It can be used
+   * to wrap any generic Arduino sensor library into a SensESP sensor.
+   *
+   * @param repeat_interval_ms The repeating interval, in milliseconds.
+   * @param callback A callback function that requires RepeatSensor<T>::emit()
+   *   to be called when output becomes available.
+   * @tparam T The type of the value returned by the callback function.
+   */
+  RepeatSensor<T>(unsigned int repeat_interval_ms,
+                  std::function<void(RepeatSensor<T>*)> callback)
+      : SensorT<T>(""),
+        repeat_interval_ms_(repeat_interval_ms),
+        emitting_callback_(callback) {}
+
   void start() override final {
-    ReactESP::app->onRepeat(repeat_interval_ms_, [this]() {
-      this->emit(this->callback_());
-    });
+    if (emitting_callback_ != nullptr) {
+      ReactESP::app->onRepeat(repeat_interval_ms_,
+                              [this]() { emitting_callback_(this); });
+    } else {
+      ReactESP::app->onRepeat(repeat_interval_ms_,
+                              [this]() { this->emit(this->returning_callback_()); });
+    }
   }
 
  protected:
   unsigned int repeat_interval_ms_;
-  std::function<T()> callback_;
+  std::function<T()> returning_callback_ = nullptr;
+  std::function<void(RepeatSensor<T>*)> emitting_callback_ = nullptr;
 };
 
 }  // namespace sensesp


### PR DESCRIPTION
RepeatSensor can be used to interface any generic arduino-esp32 compatible sensor library with SensESP. You initialize an upstream sensor interface object and set it up in `setup()`. Next, you define a callback function which will read and return a new value from the sensor interface. Finally, you instantiate `RepeatingSensor` and define the return type, repeat interval, and provide the callback function. The created `RepeatingSensor` object is a normal producer that can be connected to transforms and output objects as usual.