### PR TITLE
Add GNGLL parser, fix parsing of south and west coordinates

### DIFF
--- a/src/sensors/gps.cpp
+++ b/src/sensors/gps.cpp
@@ -9,6 +9,7 @@ GPSInput::GPSInput(Stream* rx_stream)
   rx_stream_ = rx_stream;
 
   nmea_parser_.add_sentence_parser(new GPGGASentenceParser(&nmea_data_));
+  nmea_parser_.add_sentence_parser(new GNGLLSentenceParser(&nmea_data_));
   nmea_parser_.add_sentence_parser(new GPGLLSentenceParser(&nmea_data_));
   nmea_parser_.add_sentence_parser(new GPRMCSentenceParser(&nmea_data_));
   nmea_parser_.add_sentence_parser(new PSTISentenceParser(&nmea_data_));

--- a/src/system/nmea_parser.cpp
+++ b/src/system/nmea_parser.cpp
@@ -87,7 +87,7 @@ bool parse_NS(double* value, char* s) {
     case 'N':
       break;
     case 'S':
-      *value *= 1;
+      *value *= -1;
       break;
     default:
       return false;
@@ -100,7 +100,7 @@ bool parse_EW(double* value, char* s) {
     case 'E':
       break;
     case 'W':
-      *value *= 1;
+      *value *= -1;
       break;
     default:
       return false;
@@ -252,6 +252,34 @@ void GPGGASentenceParser::parse(char* buffer, int term_offsets[],
   if (dgps_id_defined) {
     nmea_data->dgps_id.set(dgps_id);
   }
+}
+
+void GNGLLSentenceParser::parse(char* buffer, int term_offsets[],
+                                int num_terms) {
+  bool ok = true;
+
+  Position position;
+
+  // eg3. $GNGLL,5133.81,N,00042.25,W*75
+  //       1    5133.81   Current latitude
+  ok &= parse_latlon(&position.latitude, buffer + term_offsets[1]);
+  //       2    N         North/South
+  ok &= parse_NS(&position.latitude, buffer + term_offsets[2]);
+  //       3    00042.25  Current longitude
+  ok &= parse_latlon(&position.longitude, buffer + term_offsets[3]);
+  //       4    W         East/West
+  ok &= parse_EW(&position.longitude, buffer + term_offsets[4]);
+
+  report_success(ok, sentence());
+  if (!ok) {
+    return;
+  }
+
+  position.altitude = -99999;
+
+  // notify relevant observers
+
+  nmea_data->position.set(position);
 }
 
 void GPGLLSentenceParser::parse(char* buffer, int term_offsets[],

--- a/src/system/nmea_parser.h
+++ b/src/system/nmea_parser.h
@@ -66,6 +66,15 @@ class GPGGASentenceParser : public SentenceParser {
  private:
 };
 
+class GNGLLSentenceParser : public SentenceParser {
+ public:
+  GNGLLSentenceParser(NMEAData* nmea_data) : SentenceParser{nmea_data} {}
+  void parse(char* buffer, int term_offsets[], int num_terms) override final;
+  const char* sentence() { return "GNGLL"; }
+
+ private:
+};
+
 class GPGLLSentenceParser : public SentenceParser {
  public:
   GPGLLSentenceParser(NMEAData* nmea_data) : SentenceParser{nmea_data} {}


### PR DESCRIPTION
GNGLL sentences are emitted when the fix comes from a combination of GPS
and GLONASS. Before this, the fix would be ignored.

SensESP's NMEA parser incorrectly treats southerly latitudes and
westerly longitudes as positive degrees, this change also fixes that.