### PR TITLE
Fix SKOutputPosition emitting "null"

### DIFF
--- a/src/signalk/signalk_position.cpp
+++ b/src/signalk/signalk_position.cpp
@@ -5,14 +5,13 @@ template <>
 String SKOutput<Position>::as_signalk() {
   DynamicJsonDocument jsonDoc(1024);
   String json;
-  JsonObject root = jsonDoc.as<JsonObject>();
-  root["path"] = this->get_sk_path();
-  JsonObject value = root.createNestedObject("value");
+  jsonDoc["path"] = this->get_sk_path();
+  JsonObject value = jsonDoc.createNestedObject("value");
   value["latitude"] = output.latitude;
   value["longitude"] = output.longitude;
   if (output.altitude > -10000) {
     value["altitude"] = output.altitude;
   }
-  serializeJson(root, json);
+  serializeJson(jsonDoc, json);
   return json;
 }


### PR DESCRIPTION
Previously, SKOutputPosition seemed to be emitting the string "null".
This patch fixes it, at least for me. Maybe I was doing something wrong before. :)