### PR TITLE
DigitalInputCounter fix

### DIFF
--- a/src/sensesp/sensors/digital_input.h
+++ b/src/sensesp/sensors/digital_input.h
@@ -90,6 +90,7 @@ class DigitalInputCounter : public DigitalInput, public SensorT<int> {
                       unsigned int read_delay, String config_path = "")
       : DigitalInput{pin, pin_mode},
         SensorT<int>(config_path),
+        interrupt_type_{interrupt_type},
         read_delay_{read_delay} {
     load_configuration();
   }


### PR DESCRIPTION
The interrupt type was never set correctly because a crucial line had fallen off the constructor. Took quite some time to find that...