### PR TITLE
Updated the Tutorial index page

### DIFF
--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -2,7 +2,6 @@
 layout: default
 title: Tutorials
 nav_order: 42
-has_children: true
 ---
 
 # Tutorials

--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -47,11 +47,3 @@ This Tutorial shows how to read more than one value from the same physical senso
 ## Reading Multiple Values from Multiple Sensors
 
 This Tutorial combines everything in the previous Tutorials, showing you how to read multiple values from multiple sensors in the same SensESP project. [Click here to see it](multiple_sensors).
-
-## BAS: other tutorials to write
-
-Transforms
-Lambda transform
-Metadata
-Relay control (the example could use some more explanation)
-Using SensESP for something other than sending data to SK (need a good example)

--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -11,10 +11,15 @@ This page lists the tutorials available on the SensESP website.
 The tutorials are down-to-earth guides that teach you how to achieve specific goals with SensESP.
 They can vary a lot in scope and complexity, and often also discuss not just SensESP itself but also how to integrate SensESP with external hardware and software components.
 
+The following labels are used to categorize the tutorials:
 
-Each of the Tutorials is briefly described below.
+| Label | Description |
+| :---: | :--- |
+| &#x1f4cc; | Essential: Concepts important for all levels of users
+| &#x1F424; | Newbie: Slow-paced tutorials suitable for people with little programming experience |
+| &#x1F47D; | Advanced: Intermediate or advanced content that highlight quirks or interesting techniques |
 
-## Minimal Example of Sending Data to Signal K
+## &#x1F424; Minimal Example of Sending Data to Signal K
 
 This should be the very first Tutorial you go through as a new SensESP user. It will introduce you to the basic structure of every SensESP project, and explain all of the "boilerplate" code that's in every project. Subsequent tutorials won't do this, so you need to start with this one.
 
@@ -22,28 +27,28 @@ It demonstrates how to send a single bit of data (the status of GPIO13) to a Sig
 
 [Click here to see the Tutorial](minimal_sk).
 
-## Sending Data from Two Sensors to Signal K
+## &#x1F424; Sending Data from Two Sensors to Signal K
 
 This Tutorial shows how to read more than one physical sensor in a single SensESP project. [Click here to see it](minimal_sk_two_sensors).
 
-## Reading a SensESP-specific External Sensor
+## &#x1F424; Reading a SensESP-specific External Sensor
 
 Many sensors that you might want to use are read with a library specific to that sensor. Many of these can be read with a very generic approach, illustrated in the [next tutorial](bmp280). But some require a little more code to get them to work easily with SensESP, so they use an additional "helper" library, several of which you can find [here](https://github.com/SensESP).
 
 This Tutorial shows how to use one of these, the very popular 1-Wire temperature sensor. [Click here to see it](one_wire).
 
-## Reading a "Generic" External Sensor, Part 1
+## &#x1f4cc; Reading a "Generic" External Sensor, Part 1
 
 There are literally hundreds of sensors that can be used by Arduino-compatible microprocessors like the ESP32. The vast majority of them are read following the same pattern: initiate the hardware, do any required configuration, then call a specific function to read a specific value. SensESP interfaces with these types of sensors very easily, as illustrated in this Tutorial, which shows how to read temperature and barometric pressure with an Adafruit-compatible BMP280. [Click here to see it](bmp280).
 
-## Reading a "Generic" External Sensor - Part 2
+## &#x1f4cc; Reading a "Generic" External Sensor - Part 2
 
 This Tutorial builds on Part 1, explaining how to use that approach for almost any Arduino-compatible sensor. [Click here to see it](bmp280_part_2).
 
-## Reading a "Generic" External Sensor - Part 3
+## &#x1F424; Reading a "Generic" External Sensor - Part 3
 
 This Tutorial shows how to read more than one value from the same physical sensor. [Click here to see it](ina219_2_values).
 
-## Reading Multiple Values from Multiple Sensors
+## &#x1F424; Reading Multiple Values from Multiple Sensors
 
 This Tutorial combines everything in the previous Tutorials, showing you how to read multiple values from multiple sensors in the same SensESP project. [Click here to see it](multiple_sensors).

--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -19,36 +19,38 @@ The following labels are used to categorize the tutorials:
 | &#x1F424; | Newbie: Slow-paced tutorials suitable for people with little programming experience |
 | &#x1F47D; | Advanced: Intermediate or advanced content that highlight quirks or interesting techniques |
 
-## &#x1F424; Minimal Example of Sending Data to Signal K
+## Interfacing with Software Libraries and Hardware
 
-This should be the very first Tutorial you go through as a new SensESP user. It will introduce you to the basic structure of every SensESP project, and explain all of the "boilerplate" code that's in every project. Subsequent tutorials won't do this, so you need to start with this one.
+### &#x1f4cc; [Using External Sensor Libraries: BMP280](bmp280)
+
+There are literally hundreds of sensor libraries that are compatible with the ESP32 and the Arduino Framework. The vast majority of them are read following the same pattern: initiate the hardware, do any required configuration, then call a specific function to read a specific value. SensESP interfaces with these types of sensors very easily, as illustrated in this Tutorial, which shows how to read temperature and barometric pressure with an Adafruit-compatible BMP280.
+
+### &#x1f4cc; [Using Any External Sensor Libraries](bmp280_part_2)
+
+This tutorial illustrates how to integrate an arbitrary Arduino Framework compatible sensor library with SensESP.
+
+### &#x1F424; [Using a SensESP-specific External Sensor Library](one_wire)
+
+Many sensors that you might want to use are read with a library specific to that sensor. Many of these can be read with a very generic approach, illustrated in the [BMP280 Tutorial](bmp280). But some require a little more code to get them to work easily with SensESP, so they use an additional "helper" library, several of which you can find [here](https://github.com/SensESP).
+
+This Tutorial shows how to use one of these, the very popular 1-Wire temperature sensor.
+
+### &#x1F424; [Reading Multiple Values from an External Sensor Library](ina219_2_values)
+
+This tutorial shows how to read more than one value from the same sensor library.
+
+### &#x1F424; [Reading Multiple Values from Multiple Sensors Libraries](multiple_sensors)
+
+This tutorial shows you how to read multiple values from multiple sensors in the same SensESP project.
+
+## Signal K
+
+### &#x1F424; [Sending Data to Signal K](minimal_sk)
+
+This tutorial will introduce you to the basic structure of a typical SensESP project, and explain all of the "boilerplate" code that's in every project.
 
 It demonstrates how to send a single bit of data (the status of GPIO13) to a Signal K Server, so you can try it out with only an ESP32 and a jumper wire.
 
-[Click here to see the Tutorial](minimal_sk).
+### &#x1F424; [Sending Data from Two Sensors to Signal K](minimal_sk_2sensors)
 
-## &#x1F424; Sending Data from Two Sensors to Signal K
-
-This Tutorial shows how to read more than one physical sensor in a single SensESP project. [Click here to see it](minimal_sk_two_sensors).
-
-## &#x1F424; Reading a SensESP-specific External Sensor
-
-Many sensors that you might want to use are read with a library specific to that sensor. Many of these can be read with a very generic approach, illustrated in the [next tutorial](bmp280). But some require a little more code to get them to work easily with SensESP, so they use an additional "helper" library, several of which you can find [here](https://github.com/SensESP).
-
-This Tutorial shows how to use one of these, the very popular 1-Wire temperature sensor. [Click here to see it](one_wire).
-
-## &#x1f4cc; Reading a "Generic" External Sensor, Part 1
-
-There are literally hundreds of sensors that can be used by Arduino-compatible microprocessors like the ESP32. The vast majority of them are read following the same pattern: initiate the hardware, do any required configuration, then call a specific function to read a specific value. SensESP interfaces with these types of sensors very easily, as illustrated in this Tutorial, which shows how to read temperature and barometric pressure with an Adafruit-compatible BMP280. [Click here to see it](bmp280).
-
-## &#x1f4cc; Reading a "Generic" External Sensor - Part 2
-
-This Tutorial builds on Part 1, explaining how to use that approach for almost any Arduino-compatible sensor. [Click here to see it](bmp280_part_2).
-
-## &#x1F424; Reading a "Generic" External Sensor - Part 3
-
-This Tutorial shows how to read more than one value from the same physical sensor. [Click here to see it](ina219_2_values).
-
-## &#x1F424; Reading Multiple Values from Multiple Sensors
-
-This Tutorial combines everything in the previous Tutorials, showing you how to read multiple values from multiple sensors in the same SensESP project. [Click here to see it](multiple_sensors).
+This Tutorial shows how to read more than one physical sensor in a single SensESP project.

--- a/docs/pages/tutorials/index.md
+++ b/docs/pages/tutorials/index.md
@@ -7,9 +7,10 @@ has_children: true
 
 # Tutorials
 
-If you're new to SensESP, and you like learning through tutorials, this is the page for you! We've made a tutorial for every important concept we can think of to help you learn in a step-by-step manner. Each one will teach you something new, but in a way that builds on one or more other tutorials.
+This page lists the tutorials available on the SensESP website.
+The tutorials are down-to-earth guides that teach you how to achieve specific goals with SensESP.
+They can vary a lot in scope and complexity, and often also discuss not just SensESP itself but also how to integrate SensESP with external hardware and software components.
 
-In most cases, there is a `main.cpp` file in the SensESP examples, or in a special GitHub repository, that corresponds with the tutorial, so you can see exactly the code that the tutorial is talking about, and can easily build it, upload it to your ESP, and try it out.
 
 Each of the Tutorials is briefly described below.
 


### PR DESCRIPTION
The tutorial index page should work as a generic index page for tutorials written by different contributors. For example, I intend to write some essential tutorials myself. Also, the index should provide some useful categorization of the content according to the topic and expected audience. It should not expect any linear ordering of the content: it should be possible to reorder the categories and content within the categories, even alphabetically or by date, if need be. Or by some other editorial priority order.

Thinking a bit more about it, the index page should not expect a linear order of the content at the top level. However, if you'd prefer keeping the beginner tutorials ordered in the index, we could have a "### Beginner Tutorial Series" (or whatever) to group all those tutorials and then list them at one lower `####` heading level. Or, they could have a separate sub-index page, but that would be awkward to use. However, I'd really love to be able to refer directly to the external sensor tutorials, too, and I think the tutorials would be generally more valuable if the reader could just pick the content that they need.

Given these considerations, I rewrote the introduction, added labeling using emojis (the Just the Docs labels were clunky to use and produced ugly results), and added two top-level categories for now ("Interfacing" and "Signal K"). I also tried to give the tutorials more descriptive titles and modified some of the descriptions. I also reordered the tutorials and pulled the ones that I thought would have the widest audience to the top.

All of these changes are free game: categorization (if and how), labeling (if and how), ordering, title updates, description updates. But I really think the tutorial index should be usable for more material than just the newbie tutorial series.