### PR TITLE
Hash the configuration file names

### DIFF
--- a/src/sensesp/net/http_server.cpp
+++ b/src/sensesp/net/http_server.cpp
@@ -3,9 +3,6 @@
 #include <FS.h>
 
 #include <functional>
-#ifdef ESP32
-#include "SPIFFS.h"
-#endif
 
 #include <ESPAsyncWebServer.h>
 
@@ -105,7 +102,7 @@ HTTPServer::HTTPServer() : Startable(50) {
     response->addHeader("Content-Encoding", "gzip");
     request->send(response);
   });
-  
+
   server->on("/css/bootstrap.min.css", HTTP_GET,
   [](AsyncWebServerRequest* request) {
     debugD("Serving gziped bootstrap.min.css");
@@ -234,7 +231,7 @@ void HTTPServer::handle_info(AsyncWebServerRequest* request) {
   for (auto it = configurables.begin(); it != configurables.end(); ++it) {
     config.add(it->first);
   }
-  
+
   serializeJson(json_doc, *response);
   request->send(response);
 }

--- a/src/sensesp/system/configurable.cpp
+++ b/src/sensesp/system/configurable.cpp
@@ -11,7 +11,7 @@ namespace sensesp {
 // reference around would unnecessarily reduce readability of the code.
 std::map<String, Configurable*> configurables;
 
-Configurable::Configurable(String config_path = "") : config_path{config_path} {
+Configurable::Configurable(String config_path = "") : config_path_{config_path} {
   if (config_path != "") {
     auto it = configurables.find(config_path);
     if (it != configurables.end()) {
@@ -34,45 +34,56 @@ bool Configurable::set_configuration(const JsonObject& config) {
 String Configurable::get_config_schema() { return "{}"; }
 
 void Configurable::load_configuration() {
-  if (config_path == "") {
+
+  if (config_path_ == "") {
     debugI("Not loading configuration: no config_path specified: %s",
-           config_path.c_str());
+           config_path_.c_str());
     return;
   }
-  String hash_path = String("/") + Base64Sha1(config_path);
+  String hash_path = String("/") + Base64Sha1(config_path_);
 
-  if (!SPIFFS.exists(hash_path)) {
-    debugI("Not loading configuration for path %s: file does not exist: %s",
-           config_path.c_str(), hash_path.c_str());
+  const String* filename;
+
+  if (SPIFFS.exists(hash_path)) {
+    filename = &hash_path;
+    debugD("Loading configuration for path %s from %s", config_path_.c_str(),
+           hash_path.c_str());
+  } else if (config_path_.length() < 32 && SPIFFS.exists(config_path_)) {
+    filename = &config_path_;
+    debugD("Loading configuration for path %s", config_path_.c_str());
+  } else {
+    debugI("Could not find configuration for path %s", config_path_.c_str());
     return;
   }
 
-  debugD("Loading configuration for path %s from file %s", config_path.c_str(),
-         hash_path.c_str());
-
-  File f = SPIFFS.open(hash_path, "r");
+  File f = SPIFFS.open(*filename, "r");
   DynamicJsonDocument jsonDoc(
       1024);  // TODO: set the size of ALL DynamicJsonDocuments throughout the
               // project
   auto error = deserializeJson(jsonDoc, f);
   if (error) {
     debugW("WARNING: Could not parse configuration for %s",
-           config_path.c_str());
+           config_path_.c_str());
     return;
   }  //
   if (!set_configuration(jsonDoc.as<JsonObject>())) {
-    debugW("WARNING: Could not set configuration for %s", config_path.c_str());
+    debugW("WARNING: Could not set configuration for %s", config_path_.c_str());
   }
   f.close();
 }
 
 void Configurable::save_configuration() {
-  if (config_path == "") {
+  if (config_path_ == "") {
     debugI("WARNING: Could not save configuration (config_path not set)");
   }
-  String hash_path = String("/") + Base64Sha1(config_path);
+  String hash_path = String("/") + Base64Sha1(config_path_);
 
-  debugD("Saving configuration path %s to file %s", config_path.c_str(),
+  if (config_path_.length() < 32 && SPIFFS.exists(config_path_)) {
+    debugD("Deleting legacy configuration file %s", config_path_.c_str());
+    SPIFFS.remove(config_path_);
+  }
+
+  debugD("Saving configuration path %s to file %s", config_path_.c_str(),
          hash_path.c_str());
 
   DynamicJsonDocument jsonDoc(1024);

--- a/src/sensesp/system/configurable.h
+++ b/src/sensesp/system/configurable.h
@@ -30,7 +30,7 @@ class Configurable {
    */
   Configurable(String config_path);
 
-  const String config_path;
+  const String config_path_;
 
   /**
    * Returns the current configuration data as a JsonObject. In

--- a/src/sensesp/system/filesystem.cpp
+++ b/src/sensesp/system/filesystem.cpp
@@ -1,5 +1,4 @@
 #include "SPIFFS.h"
-#define SPIFFS_BEGIN SPIFFS.begin(true)
 
 #include "filesystem.h"
 #include "sensesp.h"
@@ -7,7 +6,7 @@
 namespace sensesp {
 
 Filesystem::Filesystem() : Resettable(-100) {
-  if (!SPIFFS_BEGIN) {
+  if (!SPIFFS.begin(true)) {
     debugE("FATAL: Filesystem initialization failed.");
     ESP.restart();
   }

--- a/src/sensesp/system/hash.cpp
+++ b/src/sensesp/system/hash.cpp
@@ -1,0 +1,62 @@
+#include "hash.h"
+
+#include "mbedtls/md.h"
+
+extern "C" {
+#include "crypto/base64.h"
+}
+
+/**
+ * @brief SHA-1 hash function
+ *
+ * Calculate a SHA-1 hash of the given payload.
+ *
+ * @param payload_str
+ * @param hash_output A 20-character output array
+ * @return String
+ */
+void Sha1(String payload_str, uint8_t *hash_output) {
+  const char *payload = payload_str.c_str();
+
+  const int size = 20;
+
+  mbedtls_md_context_t ctx;
+  mbedtls_md_type_t md_type = MBEDTLS_MD_SHA1;
+
+  const size_t payload_length = strlen(payload);
+
+  mbedtls_md_init(&ctx);
+  mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(md_type), 0);
+  mbedtls_md_starts(&ctx);
+  mbedtls_md_update(&ctx, (const unsigned char *)payload, payload_length);
+  mbedtls_md_finish(&ctx, hash_output);
+  mbedtls_md_free(&ctx);
+}
+
+/**
+ * @brief A base64-encoded SHA-1 hash function
+ *
+ * For filesystem compatibility, the output string is further scrubbed
+ * to replace "/" with "_".
+ *
+ * @param payload_str
+ * @return String
+ */
+String Base64Sha1(String payload_str) {
+  uint8_t hash_output[20];
+
+  size_t output_length;
+
+  Sha1(payload_str, hash_output);
+
+  unsigned char *encoded =
+      base64_encode((const unsigned char *)hash_output, 20, &output_length);
+
+  String encoded_str((char *)encoded);
+
+  encoded_str.replace("/", "_");
+
+  free(encoded);
+
+  return encoded_str;
+}

--- a/src/sensesp/system/hash.h
+++ b/src/sensesp/system/hash.h
@@ -1,0 +1,10 @@
+#ifndef __SRC_SENSESP_SYSTEM_HASH_H__
+#define __SRC_SENSESP_SYSTEM_HASH_H__
+
+#include "sensesp.h"
+
+void Sha1(String payload_str);
+
+String Base64Sha1(String payload_str);
+
+#endif


### PR DESCRIPTION
SPIFFS has a maximum path length of 32 characters. To circumvent this, configuration file paths are hashed with SHA-1 and then base64 encoded.

~This change resets existing device configurations.~ There are checks in place to make it backwards-compatible.

Fixes #536.