### PR TITLE
Curve interpolator UI improvements

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -179,7 +179,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = src/
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/src/sensesp/transforms/curveinterpolator.cpp
+++ b/src/sensesp/transforms/curveinterpolator.cpp
@@ -21,15 +21,12 @@ CurveInterpolator::Sample::Sample(JsonObject& obj)
  * @param output_title Display name for the output sample values
  */
 CurveInterpolator::CurveInterpolator(std::set<Sample>* defaults,
-                                     String config_path, String input_title,
-                                     String output_title)
-    : FloatTransform(config_path),
-      input_title_{input_title},
-      output_title_{output_title} {
+                                     String config_path)
+    : FloatTransform(config_path) {
   // Load default values if no configuration present...
   if (defaults != NULL) {
-    samples.clear();
-    samples = *defaults;
+    samples_.clear();
+    samples_ = *defaults;
   }
 
   load_configuration();
@@ -39,9 +36,9 @@ void CurveInterpolator::set_input(float input, uint8_t inputChannel) {
   float x0 = 0.0;
   float y0 = 0.0;
 
-  std::set<Sample>::iterator it = samples.begin();
+  std::set<Sample>::iterator it = samples_.begin();
 
-  while (it != samples.end()) {
+  while (it != samples_.end()) {
     auto& sample = *it;
 
     if (input > sample.input) {
@@ -54,7 +51,7 @@ void CurveInterpolator::set_input(float input, uint8_t inputChannel) {
     it++;
   }
 
-  if (it != samples.end()) {
+  if (it != samples_.end()) {
     // We found our range. "input" is between
     // minInput and it->input. CurveInterpolator the result
     Sample max = *it;
@@ -72,9 +69,9 @@ void CurveInterpolator::set_input(float input, uint8_t inputChannel) {
 }
 
 void CurveInterpolator::get_configuration(JsonObject& root) {
-  JsonArray jSamples = root.createNestedArray("samples");
-  for (auto& sample : samples) {
-    auto entry = jSamples.createNestedObject();
+  JsonArray json_samples = root.createNestedArray("samples");
+  for (auto& sample : samples_) {
+    auto entry = json_samples.createNestedObject();
     entry["input"] = sample.input;
     entry["output"] = sample.output;
   }
@@ -117,22 +114,22 @@ bool CurveInterpolator::set_configuration(const JsonObject& config) {
 
   JsonArray arr = config["samples"];
   if (arr.size() > 0) {
-    samples.clear();
+    samples_.clear();
     for (auto jentry : arr) {
-      auto jObject = jentry.as<JsonObject>();
-      Sample sample(jObject);
-      samples.insert(sample);
+      auto json_object = jentry.as<JsonObject>();
+      Sample sample(json_object);
+      samples_.insert(sample);
     }
   }
 
   return true;
 }
 
-void CurveInterpolator::clear_samples() { samples.clear(); }
+void CurveInterpolator::clear_samples() { samples_.clear(); }
 
 void CurveInterpolator::add_sample(const Sample& sample) {
-  Sample* pSampleCopy = new Sample(sample);
-  samples.insert(*pSampleCopy);
+  Sample* sample_copy = new Sample(sample);
+  samples_.insert(*sample_copy);
 }
 
 }  // namespace sensesp

--- a/src/sensesp/transforms/curveinterpolator.h
+++ b/src/sensesp/transforms/curveinterpolator.h
@@ -6,10 +6,28 @@
 namespace sensesp {
 
 /**
- * @brief Uses a collection of input/output samples that approximate
- * a non-linear curve and outputs a value on that curve.
- * The output is the linear interpolation between the two
- * sample points that the input falls between. It is used primarily for
+ * @brief Implement a piecewise linear interpolation transform.
+ *
+ * Piecewise linear functions are defined by a collection of x,y pairs, in which
+ * the x values are monotonically increasing. The y values are the corresponding
+ * values of the function at the x values. The interpolator will linearly
+ * interpolate between the y values to produce a value for any x value.
+ *
+ * As a practical example, consider the following samples:
+ *
+ * - 0, 0
+ * - 1, 0
+ * - 2, 1
+ * - 3, 1
+ *
+ * At different input values, the following happens:
+ *
+ * - At x = 0, the interpolator will return 0.
+ * - At x = 0.5, the interpolator will still return 0 because both adjacent samples have y = 0.
+ * - At x = 1.4, the adjacent outputs are 0 and 1, so the interpolator will return 0.4.
+ * - At x = 2.5, the interpolator will return 1.0 because the adjacent outputs are both 1.
+ *
+ * It can be used e.g. for
  * non-linear analog gauges such as temperature gauges and oil pressure gauges,
  * which get their input from analog sensors that are variable resistors.
  */

--- a/src/sensesp/transforms/curveinterpolator.h
+++ b/src/sensesp/transforms/curveinterpolator.h
@@ -31,7 +31,9 @@ class CurveInterpolator : public FloatTransform {
   };
 
  public:
-  CurveInterpolator(std::set<Sample>* defaults = NULL, String config_path = "");
+  CurveInterpolator(std::set<Sample>* defaults = NULL, String config_path = "",
+                    String input_title = "input",
+                    String output_title = "output");
 
   // Set and retrieve the transformed value
   void set_input(float input, uint8_t input_channel = 0) override;
@@ -48,6 +50,8 @@ class CurveInterpolator : public FloatTransform {
 
  protected:
   std::set<Sample> samples;
+  String input_title_;
+  String output_title_;
 };
 
 }  // namespace sensesp

--- a/src/sensesp/transforms/curveinterpolator.h
+++ b/src/sensesp/transforms/curveinterpolator.h
@@ -31,12 +31,20 @@ class CurveInterpolator : public FloatTransform {
   };
 
  public:
-  CurveInterpolator(std::set<Sample>* defaults = NULL, String config_path = "",
-                    String input_title = "input",
-                    String output_title = "output");
+  CurveInterpolator(std::set<Sample>* defaults = NULL, String config_path = "");
 
   // Set and retrieve the transformed value
   void set_input(float input, uint8_t input_channel = 0) override;
+
+  // Web UI configuration methods
+  CurveInterpolator* set_input_title(String input_title) {
+    input_title_ = input_title;
+    return this;
+  }
+  CurveInterpolator* set_output_title(String output_title) {
+    output_title_ = output_title;
+    return this;
+  }
 
   // For reading and writing the configuration of this transformation
   virtual void get_configuration(JsonObject& doc) override;
@@ -48,10 +56,12 @@ class CurveInterpolator : public FloatTransform {
 
   void add_sample(const Sample& new_sample);
 
+  const std::set<Sample>& get_samples() const { return samples_; }
+
  protected:
-  std::set<Sample> samples;
-  String input_title_;
-  String output_title_;
+  std::set<Sample> samples_;
+  String input_title_ = "Input";
+  String output_title_ = "Output";
 };
 
 }  // namespace sensesp


### PR DESCRIPTION
`CurveInterpolator` web UI was a bit clunky to use. I changed the editor into table format and added options to provide display names for the input and output sample values. With these tweaks, this is how it looks like:

<img width="500" alt="Screenshot 2022-02-01 at 16 10 45" src="https://user-images.githubusercontent.com/407010/151984333-1272fa82-4088-4419-a149-6195d7312845.png">

