### PR TITLE
Add LocalDebug to the sensesp namespace

### DIFF
--- a/src/sensesp/system/local_debug.cpp
+++ b/src/sensesp/system/local_debug.cpp
@@ -2,6 +2,8 @@
 
 #include "local_debug.h"
 
+namespace sensesp {
+
 bool LocalDebug::begin(String hostname, uint8_t startingDebugLevel) {
   _lastDebugLevel = startingDebugLevel;
 }
@@ -10,10 +12,10 @@ boolean LocalDebug::isActive(uint8_t debugLevel) {
   return (debugLevel >= _lastDebugLevel);
 }
 
-//size_t LocalDebug::write(uint8_t character) {
-//  Serial.write(character);
-//  return 1;
-//}
+// size_t LocalDebug::write(uint8_t character) {
+//   Serial.write(character);
+//   return 1;
+// }
 
 #else  // DEBUG_DISABLED
 
@@ -22,3 +24,5 @@ boolean LocalDebug::isActive(uint8_t debugLevel) {
 #include "local_debug.h"
 
 #endif  // DEBUG_DISABLED
+
+}  // namespace sensesp

--- a/src/sensesp/system/local_debug.h
+++ b/src/sensesp/system/local_debug.h
@@ -6,6 +6,8 @@
 #include "Arduino.h"
 #include "Print.h"
 
+namespace sensesp {
+
 #define rdebugA(fmt, ...)        \
   if (Debug.isActive(Debug.ANY)) \
   Serial.printf("(%s)(C%d) " fmt, __func__, xPortGetCoreID(), ##__VA_ARGS__)
@@ -85,5 +87,7 @@ class LocalDebug {
 #define debugE(...)
 
 #endif
+
+}  // namespace sensesp
 
 #endif


### PR DESCRIPTION
A minor stylistic fix: `LocalDebug` wasn't wrapped in the `sensesp` namespace, which caused it to be displayed separately of the other items in the Doxygen docs. And maybe it should've been there, in the first place.