### PR TITLE
Re-add Position and ENUVector structs

### DIFF
--- a/src/sensesp/signalk/signalk_position.cpp
+++ b/src/sensesp/signalk/signalk_position.cpp
@@ -1,0 +1,30 @@
+
+#include "signalk_position.h"
+
+namespace sensesp {
+
+/**
+ * @brief Template specialization for SKOutputPosition::as_signalk()
+ *
+ * This specialization allows `Position` objects to be output as Signal K
+ * deltas.
+ *
+ * @tparam
+ * @return String
+ */
+template <>
+String SKOutput<Position>::as_signalk() {
+  DynamicJsonDocument json_doc(1024);
+  String json;
+  json_doc["path"] = this->get_sk_path();
+  JsonObject value = json_doc.createNestedObject("value");
+  value["latitude"] = output.latitude;
+  value["longitude"] = output.longitude;
+  if (output.altitude != kPositionInvalidAltitude) {
+    value["altitude"] = output.altitude;
+  }
+  serializeJson(json_doc, json);
+  return json;
+}
+
+}  // namespace sensesp

--- a/src/sensesp/signalk/signalk_position.h
+++ b/src/sensesp/signalk/signalk_position.h
@@ -1,0 +1,19 @@
+#ifndef _signalk_position_H_
+#define _signalk_position_H_
+
+#include <set>
+
+#include "sensesp/signalk/signalk_output.h"
+
+#include "sensesp/types/position.h"
+
+namespace sensesp {
+
+template <>
+String SKOutput<Position>::as_signalk();
+
+typedef SKOutput<Position> SKOutputPosition;
+
+}
+
+#endif

--- a/src/sensesp/signalk/signalk_time.cpp
+++ b/src/sensesp/signalk/signalk_time.cpp
@@ -11,16 +11,14 @@ SKOutputTime::SKOutputTime(String sk_path, String config_path)
 String SKOutputTime::as_signalk() {
   DynamicJsonDocument json_doc(1024);
   String json;
-  JsonObject root = json_doc.as<JsonObject>();
-  root["path"] = this->sk_path;
-  root["value"] = output;
-  serializeJson(root, json);
+  json_doc["path"] = this->sk_path;
+  json_doc["value"] = output;
+  serializeJson(json_doc, json);
   return json;
 }
 
 void SKOutputTime::get_configuration(JsonObject& root) {
   root["sk_path"] = sk_path;
-  root["value"] = output;
 }
 
 static const char SCHEMA[] PROGMEM = R"({

--- a/src/sensesp/types/position.h
+++ b/src/sensesp/types/position.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <limits>
+
+namespace sensesp {
+
+/// Value used to indicate an invalid or missing altitude
+constexpr float kPositionInvalidAltitude = std::numeric_limits<float>::lowest();
+
+/**
+ * @brief Position data container.
+ * 
+ * Position data as latitudes and longitudes, in decimal degrees, and altitude,
+ * in meters.
+ * 
+ */
+struct Position {
+  double latitude;
+  double longitude;
+  float altitude = kPositionInvalidAltitude;
+};
+
+/**
+ * @brief Container for local tangent plane coordinates.
+ * 
+ * East-North-Up coordinates, in reference to the local tangent plane.
+ * Static locations are in meters, velocities in m/s.
+ * 
+ */
+struct ENUVector {
+  float east;
+  float north;
+  float up = kPositionInvalidAltitude;
+};
+
+}


### PR DESCRIPTION
I'm working on bringing the NMEA 0183 parser back to life. While the parser probably has no business in SensESP core, the data types could well be defined in SensESP itself to have a uniform representation of position and ENU vectors.