### PR TITLE
Collect UIOutput objects to SensESPApp

### DIFF
--- a/src/sensesp/net/http_server.cpp
+++ b/src/sensesp/net/http_server.cpp
@@ -223,7 +223,9 @@ void HTTPServer::handle_info(AsyncWebServerRequest* request) {
   auto pages = json_doc.createNestedArray("Pages");
   auto config = json_doc.createNestedArray("Config");
 
-  for(auto property = ui_outputs.begin(); property != ui_outputs.end(); ++property)
+  auto ui_outputs = UIOutputBase::get_ui_outputs();
+
+  for(auto property = ui_outputs->begin(); property != ui_outputs->end(); ++property)
   {
     property->second->set_json(properties);
   }

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -12,7 +12,6 @@
 #include "sensesp/system/resettable.h"
 #include "sensesp/system/startable.h"
 #include "sensesp/system/valueproducer.h"
-#include "sensesp/system/ui_output.h"
 
 namespace sensesp {
 

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -63,9 +63,7 @@ class Networking : public Configurable,
   String preset_password = "";
   String preset_hostname = "";
   const char* wifi_manager_password_;
-  UILambdaOutput<String>* ssid_ = new UILambdaOutput<String>("SSID", [this]() { return this->ap_ssid; });
-  UIOutput<String>* mac_ = new UIOutput<String>("MAC", WiFi.macAddress());
-  UILambdaOutput<int8_t>* rssi_ = new UILambdaOutput<int8_t>("WiFi Signal Strength", [this]() { return WiFi.RSSI(); });
+
 };
 
 }  // namespace sensesp

--- a/src/sensesp/net/ws_client.h
+++ b/src/sensesp/net/ws_client.h
@@ -55,6 +55,8 @@ class WSClient : public Configurable,
     return delta_count_producer_;
   };
 
+  String get_connection_status();
+
   /////////////////////////////////////////////////////////
   // WSClient task methods
 
@@ -123,18 +125,7 @@ class WSClient : public Configurable,
   /////////////////////////////////////////////////////////
   // main task methods
 
-  UILambdaOutput<String>* sk_server_property_ = new UILambdaOutput<String>(
-      "SK address", [this]() { return this->server_address_; });
-  UILambdaOutput<uint16_t>* sk_server_port_property_ =
-      new UILambdaOutput<uint16_t>("SK server port",
-                                   [this]() { return this->server_port_; });
-  UILambdaOutput<String>* sk_server_connection_ = new UILambdaOutput<String>(
-      "SK connection status",
-      [this]() { return this->get_connection_status(); });
-
   void process_received_updates();
-
-  String get_connection_status();
 
   /////////////////////////////////////////////////////////
   // WSClient task methods

--- a/src/sensesp/net/ws_client.h
+++ b/src/sensesp/net/ws_client.h
@@ -11,7 +11,6 @@
 #include "sensesp/system/observablevalue.h"
 #include "sensesp/system/startable.h"
 #include "sensesp/system/task_queue_producer.h"
-#include "sensesp/system/ui_output.h"
 #include "sensesp/system/valueproducer.h"
 
 namespace sensesp {

--- a/src/sensesp/system/ui_output.cpp
+++ b/src/sensesp/system/ui_output.cpp
@@ -1,10 +1,12 @@
 #include "ui_output.h"
+
 namespace sensesp {
-std::map<String, UIOutputBase*> ui_outputs;
+
+std::map<String, UIOutputBase*> UIOutputBase::ui_outputs_;
 
 UIOutputBase::UIOutputBase(String name) {
   name_ = name;
 
-  ui_outputs[name] = this;
+  ui_outputs_[name] = this;
 }
 }  // namespace sensesp

--- a/src/sensesp/system/ui_output.h
+++ b/src/sensesp/system/ui_output.h
@@ -15,12 +15,17 @@ namespace sensesp {
 class UIOutputBase : virtual public Observable {
  protected:
   String name_;
+  static std::map<String, UIOutputBase*> ui_outputs_;
 
  public:
   UIOutputBase(String name);
   String& get_name() { return name_; }
 
   virtual void set_json(const JsonObject& obj) {}
+
+  static const std::map<String, UIOutputBase*>* get_ui_outputs() {
+    return &ui_outputs_;
+  }
 };
 
 template <typename T>

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -23,7 +23,6 @@
 #include "sensesp/system/ui_output.h"
 #include "sensesp_base_app.h"
 
-
 namespace sensesp {
 
 /**
@@ -67,10 +66,7 @@ class SensESPApp : public SensESPBaseApp {
    *
    */
   SensESPApp() : SensESPBaseApp() {
-    ui_build_info_ = new UIOutput<String>("Build at", __DATE__ " " __TIME__);
-    ui_sensesp_version_ = new UIOutput<String>("SenseESP version", kSensESPVersion);
-    ui_hostname_ = new UIOutput<String>("Name");
-    hostname_->connect_to(ui_hostname_);
+    hostname_->connect_to(hostname_ui_output_);
   }
 
   // setters for all constructor arguments
@@ -128,9 +124,26 @@ class SensESPApp : public SensESPBaseApp {
   SKDeltaQueue* sk_delta_queue_;
   WSClient* ws_client_;
 
-  UIOutput<String>* ui_build_info_;
-  UIOutput<String>* ui_sensesp_version_;
-  UIOutput<String>* ui_hostname_;
+  UIOutput<String>* build_info_ui_output_ =
+      new UIOutput<String>("Built at", __DATE__ " " __TIME__);
+  UIOutput<String>* sensesp_version_ui_output_ =
+      new UIOutput<String>("SenseESP version", kSensESPVersion);
+  UIOutput<String>* hostname_ui_output_ = new UIOutput<String>("Name");
+  UIOutput<String>* mac_address_ui_output_ =
+      new UIOutput<String>("MAC", WiFi.macAddress());
+  UILambdaOutput<String>* wifi_ssid_ui_output_ =
+      new UILambdaOutput<String>("SSID", [this]() { return WiFi.SSID(); });
+  UILambdaOutput<int8_t>* wifi_rssi_ui_output_ = new UILambdaOutput<int8_t>(
+      "WiFi signal strength", [this]() { return WiFi.RSSI(); });
+  UILambdaOutput<String>* sk_server_address_ui_output_ = new UILambdaOutput<String>(
+      "SK address", [this]() { return ws_client_->get_server_address(); });
+  UILambdaOutput<uint16_t>* sk_server_port_ui_output_ =
+      new UILambdaOutput<uint16_t>(
+          "SK server port", [this]() { return ws_client_->get_server_port(); });
+  UILambdaOutput<String>* sk_server_connection_ui_output_ =
+      new UILambdaOutput<String>("SK connection status", [this]() {
+        return ws_client_->get_connection_status();
+      });
 
   friend class HTTPServer;
   friend class SensESPAppBuilder;


### PR DESCRIPTION
UIOutput objects were scattered around unrelated classes. They're now all collected to `SensESPApp`.

Additionally, the `ui_outputs` instance map was a global variable. That was changed into a static member variable of UIOutputBase.

Fixes #555.