### PR TITLE
Fix SK access token validity checking

### DIFF
--- a/src/sensesp/net/discovery.cpp
+++ b/src/sensesp/net/discovery.cpp
@@ -18,7 +18,7 @@ void MDNSDiscovery::start() {
   if (!MDNS.begin(hostname.c_str())) {  // Start the mDNS responder for hostname.local
     debugW("Error setting up mDNS responder");
   } else {
-    debugI("mDNS responder started at %s", hostname);
+    debugI("mDNS responder started for hostname '%s'", hostname.c_str());
   }
   mdns_instance_name_set(hostname.c_str());  // mDNS hostname for ESP32
   MDNS.addService("http", "tcp", 80);

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -80,6 +80,8 @@ void Networking::wifi_station_connected() {
   debugI("Connected to wifi, SSID: %s (signal: %d)", WiFi.SSID().c_str(),
          WiFi.RSSI());
   debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
+  debugI("Default route: %s", WiFi.gatewayIP().toString().c_str());
+  debugI("DNS server: %s", WiFi.dnsIP().toString().c_str());
   this->emit(WifiState::kWifiConnectedToAP);
 }
 

--- a/src/sensesp/net/ws_client.cpp
+++ b/src/sensesp/net/ws_client.cpp
@@ -367,9 +367,6 @@ bool WSClient::get_mdns_service(String& server_address, uint16_t& server_port) {
 }
 
 void WSClient::connect() {
-  debugI("WSClient websocket connect attempt (state=%d)",
-         get_connection_state());
-
   if (get_connection_state() != WSConnectionState::kWSDisconnected) {
     return;
   }

--- a/src/sensesp/net/ws_client.cpp
+++ b/src/sensesp/net/ws_client.cpp
@@ -479,10 +479,13 @@ void WSClient::send_access_request(const String server_address,
   String json_req = "";
   serializeJson(doc, json_req);
 
+  debugD("Access request: %s", json_req.c_str());
+
   HTTPClient http;
 
   String url = String("http://") + server_address + ":" + server_port +
                "/signalk/v1/access/requests";
+  debugD("Access request url: %s", url.c_str());
   http.begin(wifi_client_, url);
   http.addHeader("Content-Type", "application/json");
   int httpCode = http.POST(json_req);

--- a/src/sensesp/net/ws_client.cpp
+++ b/src/sensesp/net/ws_client.cpp
@@ -425,10 +425,11 @@ void WSClient::test_token(const String server_address,
   HTTPClient http;
 
   String url =
-      String("http://") + server_address + ":" + server_port + "/signalk/";
+      String("http://") + server_address + ":" + server_port + "/signalk/v1/stream";
   debugD("Testing token with url %s", url.c_str());
   http.begin(wifi_client_, url);
-  String full_token = String("JWT ") + auth_token_;
+  String full_token = String("Bearer ") + auth_token_;
+  debugD("Authorization: %s", full_token.c_str());
   http.addHeader("Authorization", full_token.c_str());
   int httpCode = http.GET();
   if (httpCode > 0) {
@@ -441,8 +442,9 @@ void WSClient::test_token(const String server_address,
     } else {
       debugD("Returned payload is empty");
     }
-    if (httpCode == 200) {
-      // our token is valid, go ahead and connect
+    if (httpCode == 426) {
+      // HTTP status 426 is "Upgrade Required", which is the expected
+      // response for a websocket connection.
       debugD("Attempting to connect to Signal K Websocket...");
       server_detected_ = true;
       token_test_success_ = true;
@@ -588,7 +590,7 @@ void WSClient::connect_ws(const String host, const uint16_t port) {
   set_connection_state(WSConnectionState::kWSConnecting);
   this->client_.begin(host, port, path);
   this->client_.onEvent(webSocketClientEvent);
-  String full_token = String("JWT ") + auth_token_;
+  String full_token = String("Bearer ") + auth_token_;
   this->client_.setAuthorization(full_token.c_str());
 }
 


### PR DESCRIPTION
The previous SK server endpoint for testing the SK access token validity didn't work, resulting in the device no longer being able to connect to the server if the access token was invalidated on the server.

The validity checking endpoint at the server is not implemented, but I found out that the websocket stream endpoint works for this purpose, at least somewhat.

Some related SK server issues:

- SignalK/signalk-server#1396
- SignalK/signalk-server#1397

Fixes #552.