### PR TITLE
Remove ina2xx link

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -101,8 +101,8 @@ last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https:/
 # Footer "Edit this page on GitHub" link text
 gh_edit_link: true # show or hide edit this page link
 gh_edit_link_text: "Edit this page on GitHub."
-gh_edit_repository: "https://github.com/SignalK/SensESP/ghpages" # the github URL for your repo
-gh_edit_branch: "master" # the branch that your docs is served from
+gh_edit_repository: "https://github.com/SignalK/SensESP/docs" # the github URL for your repo
+gh_edit_branch: "main" # the branch that your docs is served from
 # gh_edit_source: docs # the source that your files originate from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 

--- a/docs/pages/additional_resources/index.md
+++ b/docs/pages/additional_resources/index.md
@@ -26,7 +26,6 @@ If you want to have your own project added to the list, [create an issue](https:
 
 ### Current and Power
 
-- [INA2xx](https://github.com/SensESP/INA2xx): Library for reading one or more of the INA2xx (INA219, INA226, INA3221) current and power sensors
 - [ve.direct_mppt](https://github.com/SensESP/ve.direct_mppt): Library for reading one victron mppt unit via the ve.direct hardware interface into SignalK/SensESP
 
 ### Control and Display Libraries


### PR DESCRIPTION
A repo that never got published was linked in the "Additional resources" doc page. Removed now.