### PR TITLE
Fix the has_children property value

### DIFF
--- a/docs/pages/additional_resources/index.md
+++ b/docs/pages/additional_resources/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Additional Resources
 nav_order: 120
-has_children: true
+has_children: false
 ---
 
 # Additional Resources


### PR DESCRIPTION
The additional_resources page has no children, so changed the has_children property to false.