### PR TITLE
WiFi connection logic improvements

### DIFF
--- a/library.json
+++ b/library.json
@@ -40,7 +40,8 @@
     },
     {
       "owner": "alanswx",
-      "name": "ESPAsyncWiFiManager"
+      "name": "ESPAsyncWiFiManager",
+      "version": "^0.31"
     },
     {
       "owner": "bblanchon",

--- a/src/sensesp/controllers/system_status_controller.cpp
+++ b/src/sensesp/controllers/system_status_controller.cpp
@@ -2,21 +2,21 @@
 
 namespace sensesp {
 
-void SystemStatusController::set_input(WifiState new_value,
+void SystemStatusController::set_input(WiFiState new_value,
                                        uint8_t input_channel) {
   // FIXME: If pointers to member functions would be held in an array,
   // this would be a simple array dereferencing
   switch (new_value) {
-    case WifiState::kWifiNoAP:
+    case WiFiState::kWifiNoAP:
       this->update_state(SystemStatus::kWifiNoAP);
       break;
-    case WifiState::kWifiDisconnected:
+    case WiFiState::kWifiDisconnected:
       this->update_state(SystemStatus::kWifiDisconnected);
       break;
-    case WifiState::kWifiConnectedToAP:
+    case WiFiState::kWifiConnectedToAP:
       this->update_state(SystemStatus::kWSDisconnected);
       break;
-    case WifiState::kWifiManagerActivated:
+    case WiFiState::kWifiManagerActivated:
       this->update_state(SystemStatus::kWifiManagerActivated);
       break;
   }

--- a/src/sensesp/controllers/system_status_controller.h
+++ b/src/sensesp/controllers/system_status_controller.h
@@ -24,15 +24,15 @@ enum class SystemStatus {
  * set_wifi_* and set_ws_* methods to take the relevant action when such
  * an event occurs.
  */
-class SystemStatusController : public ValueConsumer<WifiState>,
+class SystemStatusController : public ValueConsumer<WiFiState>,
                                public ValueConsumer<WSConnectionState>,
                                public ValueProducer<SystemStatus> {
  public:
   SystemStatusController() {}
 
-  /// ValueConsumer interface for ValueConsumer<WifiState> (Networking object
+  /// ValueConsumer interface for ValueConsumer<WiFiState> (Networking object
   /// state updates)
-  virtual void set_input(WifiState new_value,
+  virtual void set_input(WiFiState new_value,
                          uint8_t input_channel = 0) override;
   /// ValueConsumer interface for ValueConsumer<WSConnectionState>
   /// (WSClient object state updates)

--- a/src/sensesp/net/http_server.cpp
+++ b/src/sensesp/net/http_server.cpp
@@ -136,6 +136,24 @@ HTTPServer::HTTPServer() : Startable(50) {
   server->on("/info", HTTP_GET, std::bind(&HTTPServer::handle_info, this, _1));
 }
 
+
+
+void HTTPServer::start() {
+  // only start the server if WiFi is connected
+  if (WiFi.status() == WL_CONNECTED) {
+    server->begin();
+    debugI("HTTP server started");
+  } else {
+    debugW("HTTP server not started, WiFi not connected");
+  }
+  WiFi.onEvent([this](WiFiEvent_t event, WiFiEventInfo_t info) {
+    if (event == SYSTEM_EVENT_STA_GOT_IP) {
+      server->begin();
+      debugI("HTTP server started");
+    }
+  });
+}
+
 void HTTPServer::handle_not_found(AsyncWebServerRequest* request) {
   debugD("NOT_FOUND: ");
   if (request->method() == HTTP_GET) {

--- a/src/sensesp/net/http_server.h
+++ b/src/sensesp/net/http_server.h
@@ -16,7 +16,7 @@ class HTTPServer : public Startable {
  public:
   HTTPServer();
   ~HTTPServer() { delete server; }
-  virtual void start() override { server->begin(); }
+  virtual void start() override;
   void handle_not_found(AsyncWebServerRequest* request);
   void handle_config(AsyncWebServerRequest* request);
   void handle_device_reset(AsyncWebServerRequest* request);

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -44,7 +44,6 @@ Networking::Networking(String config_path, String ssid, String password,
   }
   server = new AsyncWebServer(80);
   dns = new DNSServer();
-  wifi_manager = new AsyncWiFiManager(server, dns);
 }
 
 void Networking::start() {
@@ -113,6 +112,9 @@ void Networking::wifi_station_disconnected() {
  * start the WiFi Manager.
  */
 void Networking::setup_wifi_manager() {
+
+  wifi_manager = new AsyncWiFiManager(server, dns);
+
   should_save_config = false;
 
   String hostname = SensESPBaseApp::get_hostname();

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -55,6 +55,10 @@ void Networking::start() {
   }
   // otherwise, fall through and WiFi will remain disconnected
 }
+
+void Networking::activate_wifi_manager() {
+  debugD("Activating WiFiManager");
+  if (WiFi.status() != WL_CONNECTED) {
     setup_wifi_manager();
   }
 }

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -47,7 +47,8 @@ void Networking::start() {
   if (ap_ssid != "" && ap_password != "") {
     debugI("Using hard-coded SSID %s and password", ap_ssid.c_str());
     setup_saved_ssid();
-  } else if (ap_ssid == "" && WiFi.status() != WL_CONNECTED && wifi_manager_enabled_) {
+  } else if (ap_ssid == "" && WiFi.status() != WL_CONNECTED &&
+             wifi_manager_enabled_) {
     debugI("Starting WiFiManager");
     setup_wifi_manager();
   }
@@ -127,7 +128,6 @@ void Networking::wifi_station_disconnected() {
  * start the WiFi Manager.
  */
 void Networking::setup_wifi_manager() {
-
   wifi_manager = new AsyncWiFiManager(server, dns);
 
   String hostname = SensESPBaseApp::get_hostname();
@@ -167,7 +167,8 @@ void Networking::setup_wifi_manager() {
 
   // attempt to connect with the new SSID and password
   if (this->ap_ssid != "" && this->ap_password != "") {
-    debugD("Attempting to connect to acquired SSID %s and password", this->ap_ssid.c_str());
+    debugD("Attempting to connect to acquired SSID %s and password",
+           this->ap_ssid.c_str());
     WiFi.begin(this->ap_ssid.c_str(), this->ap_password.c_str());
     for (int i = 0; i < 20; i++) {
       if (WiFi.status() == WL_CONNECTED) {
@@ -191,34 +192,17 @@ void Networking::setup_wifi_manager() {
   ESP.restart();
 }
 
-static const char SCHEMA_PREFIX[] PROGMEM = R"({
-"type": "object",
-"properties": {
-)";
-
-String get_property_row(String key, String title, bool readonly) {
-  String readonly_title = "";
-  String readonly_property = "";
-
-  if (readonly) {
-    readonly_title = " (readonly)";
-    readonly_property = ",\"readOnly\":true";
-  }
-
-  return "\"" + key + "\":{\"title\":\"" + title + readonly_title + "\"," +
-         "\"type\":\"string\"" + readonly_property + "}";
-}
-
 String Networking::get_config_schema() {
-  String schema;
-  // If hostname is not set by SensESPAppBuilder::set_hostname() in main.cpp,
-  // then preset_hostname will be "SensESP", and should not be read-only in the
-  // Config UI. If preset_hostname is not "SensESP", then it was set in
-  // main.cpp, so it should be read-only.
-  bool hostname_preset = preset_hostname != "SensESP";
-  return String(FPSTR(SCHEMA_PREFIX)) +
-         get_property_row("hostname", "ESP device hostname", hostname_preset) +
-         "}}";
+  static const char kSchema[] = R"###({
+    "type": "object",
+    "properties": {
+      "ssid": { "title": "WiFi SSID", "type": "string" },
+      "password": { "title": "WiFi password", "type": "string", "format": "password" },
+      "hostname": { "title": "Device hostname", "type": "string" }
+    }
+  })###";
+
+  return String(kSchema);
 }
 
 // FIXME: hostname should be saved in SensESPApp

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -16,6 +16,11 @@ namespace sensesp {
 
 bool should_save_config = false;
 
+/**
+ * @brief Callback used by WiFiManager to indicate that the configuration
+ * should be saved.
+ *
+ */
 void save_config_callback() { should_save_config = true; }
 
 Networking::Networking(String config_path, String ssid, String password,
@@ -63,6 +68,9 @@ void Networking::setup_wifi_callbacks() {
       WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
 }
 
+/**
+ * @brief Start WiFi using preset SSID and password.
+ */
 void Networking::setup_saved_ssid() {
   this->emit(WifiState::kWifiDisconnected);
   setup_wifi_callbacks();
@@ -76,6 +84,10 @@ void Networking::setup_saved_ssid() {
   debugI("Connecting to wifi %s.", ap_ssid.c_str());
 }
 
+/**
+ * This method gets called when WiFi is connected to the AP and has
+ * received an IP address.
+ */
 void Networking::wifi_station_connected() {
   debugI("Connected to wifi, SSID: %s (signal: %d)", WiFi.SSID().c_str(),
          WiFi.RSSI());
@@ -85,11 +97,21 @@ void Networking::wifi_station_connected() {
   this->emit(WifiState::kWifiConnectedToAP);
 }
 
+/**
+ * This method gets called when WiFi is disconnected from the AP.
+ */
 void Networking::wifi_station_disconnected() {
   debugI("Disconnected from wifi.");
   this->emit(WifiState::kWifiDisconnected);
 }
 
+/**
+ * @brief Start WiFi using WiFi Manager.
+ *
+ * If the setup process has been completed before, this method will start
+ * the WiFi connection using the saved SSID and password. Otherwise, it will
+ * start the WiFi Manager.
+ */
 void Networking::setup_wifi_manager() {
   should_save_config = false;
 

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -29,7 +29,7 @@ Networking::Networking(String config_path, String ssid, String password,
       wifi_manager_password_{wifi_manager_password},
       Startable(80),
       Resettable(0) {
-  this->output = WifiState::kWifiNoAP;
+  this->output = WiFiState::kWifiNoAP;
 
   preset_ssid = ssid;
   preset_password = password;
@@ -78,7 +78,7 @@ void Networking::setup_wifi_callbacks() {
  * @brief Start WiFi using preset SSID and password.
  */
 void Networking::setup_saved_ssid() {
-  this->emit(WifiState::kWifiDisconnected);
+  this->emit(WiFiState::kWifiDisconnected);
   setup_wifi_callbacks();
 
   const char* hostname = SensESPBaseApp::get_hostname().c_str();
@@ -100,7 +100,7 @@ void Networking::wifi_station_connected() {
   debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
   debugI("Default route: %s", WiFi.gatewayIP().toString().c_str());
   debugI("DNS server: %s", WiFi.dnsIP().toString().c_str());
-  this->emit(WifiState::kWifiConnectedToAP);
+  this->emit(WiFiState::kWifiConnectedToAP);
 }
 
 /**
@@ -108,7 +108,7 @@ void Networking::wifi_station_connected() {
  */
 void Networking::wifi_station_disconnected() {
   debugI("Disconnected from wifi.");
-  this->emit(WifiState::kWifiDisconnected);
+  this->emit(WiFiState::kWifiDisconnected);
 }
 
 /**
@@ -145,21 +145,21 @@ void Networking::setup_wifi_manager() {
   config_ssid = "Configure " + config_ssid;
   const char* pconfig_ssid = config_ssid.c_str();
 
-  this->emit(WifiState::kWifiManagerActivated);
+  this->emit(WiFiState::kWifiManagerActivated);
 
   WiFi.setHostname(SensESPBaseApp::get_hostname().c_str());
 
   if (!wifi_manager->autoConnect(pconfig_ssid, wifi_manager_password_)) {
     debugE("Failed to connect to wifi and config timed out. Restarting...");
 
-    this->emit(WifiState::kWifiDisconnected);
+    this->emit(WiFiState::kWifiDisconnected);
 
     ESP.restart();
   }
 
   debugI("Connected to wifi,");
   debugI("IP address of Device: %s", WiFi.localIP().toString().c_str());
-  this->emit(WifiState::kWifiConnectedToAP);
+  this->emit(WiFiState::kWifiConnectedToAP);
 
   if (should_save_config) {
     String new_hostname = custom_hostname.getValue();

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -50,8 +50,11 @@ void Networking::start() {
   debugD("Enabling Networking object");
   if (ap_ssid != "" && ap_password != "") {
     setup_saved_ssid();
+  } else if (ap_ssid == "" && WiFi.status() != WL_CONNECTED && wifi_manager_enabled_) {
+    setup_wifi_manager();
   }
-  if (ap_ssid == "" && WiFi.status() != WL_CONNECTED) {
+  // otherwise, fall through and WiFi will remain disconnected
+}
     setup_wifi_manager();
   }
 }

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -54,7 +54,7 @@ class Networking : public Configurable,
   // FIXME: DNSServer and AsyncWiFiManager could be instantiated in
   // respective methods to save some runtime memory
   DNSServer* dns;
-  AsyncWiFiManager* wifi_manager;
+  AsyncWiFiManager* wifi_manager = nullptr;
 
   String ap_ssid = "";
   String ap_password = "";

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -59,9 +59,16 @@ class Networking : public Configurable,
 
   String ap_ssid = "";
   String ap_password = "";
+
+  /// hardcoded values provided as constructor parameters
   String preset_ssid = "";
   String preset_password = "";
   String preset_hostname = "";
+
+  // original value of hardcoded hostname; used to detect changes
+  // in the hardcoded value
+  String default_hostname = "";
+
   const char* wifi_manager_password_;
 
 };

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -7,6 +7,7 @@
 #include <ESPAsyncWebServer.h>
 #include <ESPAsyncWiFiManager.h>
 
+#include "sensesp/net/wifi_state.h"
 #include "sensesp/system/configurable.h"
 #include "sensesp/system/observablevalue.h"
 #include "sensesp/system/resettable.h"
@@ -14,13 +15,6 @@
 #include "sensesp/system/valueproducer.h"
 
 namespace sensesp {
-
-enum class WifiState {
-  kWifiNoAP = 0,
-  kWifiDisconnected,
-  kWifiConnectedToAP,
-  kWifiManagerActivated
-};
 
 /**
  * @brief Manages the ESP's connection to the Wifi network.

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -42,6 +42,8 @@ class Networking : public Configurable,
   void enable_wifi_manager(bool state) {
     wifi_manager_enabled_ = state;
   }
+
+  void activate_wifi_manager();
  protected:
   void setup_saved_ssid();
   void setup_wifi_callbacks();

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -22,7 +22,7 @@ namespace sensesp {
 class Networking : public Configurable,
                    public Startable,
                    public Resettable,
-                   public ValueProducer<WifiState> {
+                   public ValueProducer<WiFiState> {
  public:
   Networking(String config_path, String ssid, String password, String hostname,
              const char* wifi_manager_password);

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -39,6 +39,9 @@ class Networking : public Configurable,
   virtual bool set_configuration(const JsonObject& config) override final;
   virtual String get_config_schema() override;
 
+  void enable_wifi_manager(bool state) {
+    wifi_manager_enabled_ = state;
+  }
  protected:
   void setup_saved_ssid();
   void setup_wifi_callbacks();
@@ -55,6 +58,8 @@ class Networking : public Configurable,
   // respective methods to save some runtime memory
   DNSServer* dns;
   AsyncWiFiManager* wifi_manager = nullptr;
+
+  bool wifi_manager_enabled_ = true;
 
   String ap_ssid = "";
   String ap_password = "";

--- a/src/sensesp/net/wifi_state.h
+++ b/src/sensesp/net/wifi_state.h
@@ -3,12 +3,15 @@
 
 namespace sensesp {
 
-enum class WifiState {
+enum class WiFiState {
   kWifiNoAP = 0,
   kWifiDisconnected,
   kWifiConnectedToAP,
   kWifiManagerActivated
 };
+
+// alias WiFiState for backward compatibility
+using WifiState = WiFiState;
 
 }  // namespace sensesp
 

--- a/src/sensesp/net/wifi_state.h
+++ b/src/sensesp/net/wifi_state.h
@@ -1,0 +1,15 @@
+#ifndef SENSESP_NET_WIFI_STATE_H_
+#define SENSESP_NET_WIFI_STATE_H_
+
+namespace sensesp {
+
+enum class WifiState {
+  kWifiNoAP = 0,
+  kWifiDisconnected,
+  kWifiConnectedToAP,
+  kWifiManagerActivated
+};
+
+}  // namespace sensesp
+
+#endif  // SENSESP_NET_WIFI_STATE_H_

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -28,7 +28,7 @@ void SensESPApp::setup() {
 
   // create the networking object
   networking_ =
-      new Networking("/system/networking", ssid_, wifi_password_,
+      new Networking("/System/WiFi Settings", ssid_, wifi_password_,
                      SensESPBaseApp::get_hostname(), wifi_manager_password_);
 
   if (ota_password_ != nullptr) {
@@ -43,7 +43,7 @@ void SensESPApp::setup() {
   sk_delta_queue_ = new SKDeltaQueue();
 
   // create the websocket client
-  this->ws_client_ = new WSClient("/system/sk", sk_delta_queue_,
+  this->ws_client_ = new WSClient("/System/Signal K Settings", sk_delta_queue_,
                                   sk_server_address_, sk_server_port_);
 
   // connect the system status controller


### PR DESCRIPTION
SensESP WiFi connection logic was a bit fragile and unnecessarily complex. Different connecting code was used depending on whether the WiFI AP was hard-coded or configured via WiFi Manager, and also reconnecting in case of lost WiFi was unreliable. This PR attempts to address those issues.

Major changes:
- WiFi Manager configuration portal is only enabled if no previous configuration has been saved. Once SSID and password have been entered and verified to work, they will be used ever after (or at least until the device is reset).
- If the WiFi AP is not available or the connection is lost, the device will keep attempting to reconnect until a connection has been established. WiFi Manager never gets launched, and these reconnection attempts are non-blocking (so the device is still operating normally, albeit without network).
- WiFi Manager operates still in a blocking fashion, but since it's never launched during normal operation, this is less harmful than before.
