### PR TITLE
Fix the unbalanced namespace brackets when debugging is disabled

### DIFF
--- a/src/sensesp/system/local_debug.cpp
+++ b/src/sensesp/system/local_debug.cpp
@@ -1,8 +1,8 @@
-#ifndef DEBUG_DISABLED
-
 #include "local_debug.h"
 
 namespace sensesp {
+
+#ifndef DEBUG_DISABLED
 
 bool LocalDebug::begin(String hostname, uint8_t startingDebugLevel) {
   _lastDebugLevel = startingDebugLevel;
@@ -16,12 +16,6 @@ boolean LocalDebug::isActive(uint8_t debugLevel) {
 //   Serial.write(character);
 //   return 1;
 // }
-
-#else  // DEBUG_DISABLED
-
-// define empty debug macros
-
-#include "local_debug.h"
 
 #endif  // DEBUG_DISABLED
 

--- a/src/sensesp/system/local_debug.h
+++ b/src/sensesp/system/local_debug.h
@@ -1,12 +1,12 @@
 #ifndef _local_debug_H_
 #define _local_debug_H_
 
-#ifndef DEBUG_DISABLED
-
 #include "Arduino.h"
 #include "Print.h"
 
 namespace sensesp {
+
+#ifndef DEBUG_DISABLED
 
 #define rdebugA(fmt, ...)        \
   if (Debug.isActive(Debug.ANY)) \


### PR DESCRIPTION
As reported on Slack by RBO.