### PR TITLE
Announce only activated services on mDNS

### DIFF
--- a/src/sensesp/net/discovery.cpp
+++ b/src/sensesp/net/discovery.cpp
@@ -21,8 +21,6 @@ void MDNSDiscovery::start() {
     debugI("mDNS responder started for hostname '%s'", hostname.c_str());
   }
   mdns_instance_name_set(hostname.c_str());  // mDNS hostname for ESP32
-  MDNS.addService("http", "tcp", 80);
-  MDNS.addService("signalk-sensesp", "tcp", 80);
 }
 
 }  // namespace sensesp

--- a/src/sensesp/net/discovery.h
+++ b/src/sensesp/net/discovery.h
@@ -7,7 +7,7 @@ namespace sensesp {
 
 class MDNSDiscovery : public Startable {
  public:
-  MDNSDiscovery() : Startable(0) {}
+  MDNSDiscovery() : Startable(79) {}
   virtual void start() override;
 };
 

--- a/src/sensesp/net/ws_client.cpp
+++ b/src/sensesp/net/ws_client.cpp
@@ -103,6 +103,7 @@ WSClient::WSClient(String config_path, SKDeltaQueue* sk_delta_queue,
 void WSClient::start() {
   xTaskCreate(ExecuteWebSocketTask, "WSClient", ws_client_task_stack_size, this,
               1, NULL);
+  MDNS.addService("signalk-sensesp", "tcp", 80);
 }
 
 void WSClient::connect_loop() {


### PR DESCRIPTION
SensESP announces some networked services over mDNS. In particular, it announces the websocket client service over `signalk-sensesp` and the HTTP configuration interface over `http`.

Previously, mDNS services were announced unconditionally whenever `MDNSDiscovery` was instantiated. Now, the main class only starts the facilities and sets the hostname discovery. The individual services are announced only in the particular service's startup code.