### PR TITLE
Allow setting of custom WiFiManager access point SSIDs

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -41,6 +41,7 @@ build_unflags = -Werror=reorder
 board_build.partitions = min_spiffs.csv
 monitor_filters = esp32_exception_decoder
 extra_scripts = extra_script.py
+check_skip_packages = true
 
 [env:esp32dev]
 extends = espressif32_base

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -157,8 +157,12 @@ void Networking::setup_wifi_manager() {
   wifi_manager->setTryConnectDuringConfigPortal(false);
 
   // Create a unique SSID for configuring each SensESP Device
-  String config_ssid = SensESPBaseApp::get_hostname();
-  config_ssid = "Configure " + config_ssid;
+  String config_ssid;
+  if (wifi_manager_ap_ssid_ != "") {
+    config_ssid = wifi_manager_ap_ssid_;
+  } else {
+    config_ssid = "Configure " + hostname;
+  }
   const char* pconfig_ssid = config_ssid.c_str();
 
   this->emit(WiFiState::kWifiManagerActivated);

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -38,6 +38,11 @@ class Networking : public Configurable,
   }
 
   void activate_wifi_manager();
+
+  void set_wifi_manager_ap_ssid(String ssid) {
+    wifi_manager_ap_ssid_ = ssid;
+  }
+
  protected:
   void setup_saved_ssid();
   void setup_wifi_callbacks();
@@ -59,6 +64,7 @@ class Networking : public Configurable,
 
   String ap_ssid = "";
   String ap_password = "";
+  String wifi_manager_ap_ssid_ = "";
 
   /// hardcoded values provided as constructor parameters
   String preset_ssid = "";

--- a/src/sensesp/system/led_blinker.cpp
+++ b/src/sensesp/system/led_blinker.cpp
@@ -2,7 +2,6 @@
 #include "led_blinker.h"
 
 #include "sensesp.h"
-#include "sensesp/net/networking.h"
 #include "sensesp_app.h"
 
 namespace sensesp {

--- a/src/sensesp/system/led_blinker.h
+++ b/src/sensesp/system/led_blinker.h
@@ -3,7 +3,6 @@
 
 #include <ReactESP.h>
 
-#include "sensesp/net/networking.h"
 #include "sensesp/net/ws_client.h"
 #include "startable.h"
 


### PR DESCRIPTION
In some cases it's quite useful if the WiFiManager AP name can be set independently of the device hostname. This PR adds a simple setter method for defining a custom AP name.