### PR TITLE
Fixes required by platformio/platformio-espressif32 v.4.1.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,7 @@ lib_deps =
 
 [espressif32_base]
 ;this section has config items common to all ESP32 boards
-platform = espressif32
+platform = espressif32 @ ^4.1.0
 build_unflags = -Werror=reorder
 board_build.partitions = min_spiffs.csv
 monitor_filters = esp32_exception_decoder

--- a/src/sensesp/net/debug_output.h
+++ b/src/sensesp/net/debug_output.h
@@ -1,6 +1,8 @@
 #ifndef _remote_debug_H_
 #define _remote_debug_H_
 
+#include <cstdint>
+
 #include "sensesp/system/startable.h"
 
 namespace sensesp {

--- a/src/sensesp/net/http_server.cpp
+++ b/src/sensesp/net/http_server.cpp
@@ -148,7 +148,7 @@ void HTTPServer::start() {
     debugW("HTTP server not started, WiFi not connected");
   }
   WiFi.onEvent([this](WiFiEvent_t event, WiFiEventInfo_t info) {
-    if (event == SYSTEM_EVENT_STA_GOT_IP) {
+    if (event == ARDUINO_EVENT_WIFI_STA_GOT_IP) {
       server->begin();
       debugI("HTTP server started");
     }

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -84,12 +84,12 @@ void Networking::activate_wifi_manager() {
 void Networking::setup_wifi_callbacks() {
   WiFi.onEvent([this](WiFiEvent_t event,
                       WiFiEventInfo_t info) { this->wifi_station_connected(); },
-               WiFiEvent_t::SYSTEM_EVENT_STA_GOT_IP);
+               WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
   WiFi.onEvent(
       [this](WiFiEvent_t event, WiFiEventInfo_t info) {
         this->wifi_station_disconnected();
       },
-      WiFiEvent_t::SYSTEM_EVENT_STA_DISCONNECTED);
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
 }
 
 /**

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -42,6 +42,16 @@ Networking::Networking(String config_path, String ssid, String password,
     default_hostname = preset_hostname;
   }
 
+  if (ap_ssid == "" && preset_ssid != "") {
+    // there is no saved config and preset config is available
+    ap_ssid = preset_ssid;
+  }
+
+  if (ap_password == "" && preset_password != "") {
+    // there is no saved config and preset config is available
+    ap_password = preset_password;
+  }
+
   server = new AsyncWebServer(80);
   dns = new DNSServer();
 }

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -62,11 +62,14 @@ class Networking : public Configurable,
 
   bool wifi_manager_enabled_ = true;
 
+  // values provided by WiFiManager or saved from previous configuration
+
   String ap_ssid = "";
   String ap_password = "";
-  String wifi_manager_ap_ssid_ = "";
 
-  /// hardcoded values provided as constructor parameters
+  // hardcoded values provided as constructor parameters
+
+  String wifi_manager_ap_ssid_ = "";
   String preset_ssid = "";
   String preset_password = "";
   String preset_hostname = "";

--- a/src/sensesp/system/configurable.cpp
+++ b/src/sensesp/system/configurable.cpp
@@ -46,9 +46,17 @@ void Configurable::load_configuration() {
 
   if (SPIFFS.exists(hash_path)) {
     filename = &hash_path;
-    debugD("Loading configuration for path %s from %s", config_path_.c_str(),
+    debugD("Loading configuration for path '%s' from '%s'", config_path_.c_str(),
+           hash_path.c_str());
+  } else if (SPIFFS.exists(hash_path + "\n")) {
+    // Up to SensESP v2.4.0, the config path hash had an accidental newline
+    // appended to it.
+    hash_path += "\n";
+    filename = &hash_path;
+    debugD("Loading configuration for path '%s' from '%s'", config_path_.c_str(),
            hash_path.c_str());
   } else if (config_path_.length() < 32 && SPIFFS.exists(config_path_)) {
+    // Prior to SensESP v2.1.0, the config path was a plain filename.
     filename = &config_path_;
     debugD("Loading configuration for path %s", config_path_.c_str());
   } else {

--- a/src/sensesp/system/hash.cpp
+++ b/src/sensesp/system/hash.cpp
@@ -1,10 +1,11 @@
 #include "hash.h"
 
 #include "mbedtls/md.h"
+#include "mbedtls/base64.h"
 
-extern "C" {
-#include "crypto/base64.h"
-}
+#include "sensesp/net/debug_output.h"
+
+using namespace sensesp;
 
 /**
  * @brief SHA-1 hash function
@@ -45,18 +46,22 @@ void Sha1(String payload_str, uint8_t *hash_output) {
 String Base64Sha1(String payload_str) {
   uint8_t hash_output[20];
 
+  uint8_t encoded[32];
+
   size_t output_length;
 
   Sha1(payload_str, hash_output);
 
-  unsigned char *encoded =
-      base64_encode((const unsigned char *)hash_output, 20, &output_length);
+  int retval = mbedtls_base64_encode(encoded, sizeof(encoded), &output_length, hash_output, 20);
+
+  if (retval != 0) {
+    debugE("Base64 encoding failed");
+    return "";
+  }
 
   String encoded_str((char *)encoded);
 
   encoded_str.replace("/", "_");
-
-  free(encoded);
 
   return encoded_str;
 }

--- a/src/sensesp/system/local_debug.cpp
+++ b/src/sensesp/system/local_debug.cpp
@@ -6,6 +6,7 @@ namespace sensesp {
 
 bool LocalDebug::begin(String hostname, uint8_t startingDebugLevel) {
   lastDebugLevel_ = startingDebugLevel;
+  return true;
 }
 
 boolean LocalDebug::isActive(uint8_t debugLevel) {

--- a/src/sensesp/system/local_debug.cpp
+++ b/src/sensesp/system/local_debug.cpp
@@ -5,11 +5,11 @@ namespace sensesp {
 #ifndef DEBUG_DISABLED
 
 bool LocalDebug::begin(String hostname, uint8_t startingDebugLevel) {
-  _lastDebugLevel = startingDebugLevel;
+  lastDebugLevel_ = startingDebugLevel;
 }
 
 boolean LocalDebug::isActive(uint8_t debugLevel) {
-  return (debugLevel >= _lastDebugLevel);
+  return (debugLevel >= lastDebugLevel_);
 }
 
 // size_t LocalDebug::write(uint8_t character) {

--- a/src/sensesp/system/local_debug.h
+++ b/src/sensesp/system/local_debug.h
@@ -73,7 +73,7 @@ class LocalDebug {
       6;  // Used for show always messages, for any current debug level
 
  private:
-  uint8_t _lastDebugLevel = DEBUG;
+  uint8_t lastDebugLevel_ = DEBUG;
 };
 
 #else  // DEBUG_DISABLED

--- a/src/sensesp/system/task_queue_producer.h
+++ b/src/sensesp/system/task_queue_producer.h
@@ -23,7 +23,6 @@ class TaskQueueProducer : public ObservableValue<T> {
   TaskQueueProducer(const T& value, int queue_size = 1,
                     unsigned int poll_rate = 990)
       : ObservableValue<T>(value), queue_size_{queue_size} {
-    debugD("In TaskQueueProducer constructor");
     queue_ = xQueueCreate(queue_size, sizeof(T));
     if (queue_ == NULL) {
       debugE("Failed to create queue");


### PR DESCRIPTION
PlatformIO's espressif32 framework got updated from 3.5.0 to 4.1.0. The major change was that the Arduino ESP32 core got updated from 1.0.6 to 2.0.2. The change broke some APIs and exposed some bugs in SensESP. This PR fixes those.