### PR TITLE
Limit the platform to espressif32 only

### DIFF
--- a/library.json
+++ b/library.json
@@ -62,5 +62,5 @@
   ],
   "version": "2.4.1-alpha",
   "frameworks": "arduino",
-  "platforms": "*"
+  "platforms": ["espressif32"]
 }


### PR DESCRIPTION
Shouldn't make much difference in practice, but makes the metadata better match reality.