### PR TITLE
Support WiFi AP mode

### DIFF
--- a/src/sensesp/controllers/system_status_controller.cpp
+++ b/src/sensesp/controllers/system_status_controller.cpp
@@ -14,6 +14,7 @@ void SystemStatusController::set_input(WiFiState new_value,
       this->update_state(SystemStatus::kWifiDisconnected);
       break;
     case WiFiState::kWifiConnectedToAP:
+    case WiFiState::kWifiAPModeActivated:
       this->update_state(SystemStatus::kWSDisconnected);
       break;
     case WiFiState::kWifiManagerActivated:

--- a/src/sensesp/net/http_server.cpp
+++ b/src/sensesp/net/http_server.cpp
@@ -146,14 +146,14 @@ HTTPServer::HTTPServer() : Startable(50) {
 
 void HTTPServer::start() {
   // only start the server if WiFi is connected
-  if (WiFi.status() == WL_CONNECTED) {
+  if (WiFi.status() == WL_CONNECTED || WiFi.getMode() == WIFI_MODE_AP) {
     server->begin();
     debugI("HTTP server started");
   } else {
     debugW("HTTP server not started, WiFi not connected");
   }
   WiFi.onEvent([this](WiFiEvent_t event, WiFiEventInfo_t info) {
-    if (event == ARDUINO_EVENT_WIFI_STA_GOT_IP) {
+    if (event == ARDUINO_EVENT_WIFI_STA_GOT_IP || event == ARDUINO_EVENT_WIFI_AP_START) {
       server->begin();
       debugI("HTTP server started");
     }

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -186,15 +186,15 @@ void Networking::setup_wifi_manager() {
   wifi_manager->setDebugOutput(false);
 #endif
   AsyncWiFiManagerParameter custom_hostname("hostname", "Device hostname",
-                                            hostname.c_str(), 20);
+                                            hostname.c_str(), 64);
   wifi_manager->addParameter(&custom_hostname);
 
   AsyncWiFiManagerParameter custom_ap_ssid(
-      "ap_ssid", "Custom Access Point SSID", ap_ssid.c_str(), 20);
+      "ap_ssid", "Custom Access Point SSID", ap_ssid.c_str(), 33);
   wifi_manager->addParameter(&custom_ap_ssid);
 
   AsyncWiFiManagerParameter custom_ap_password(
-      "ap_password", "Custom Access Point Password", ap_password.c_str(), 20);
+      "ap_password", "Custom Access Point Password", ap_password.c_str(), 64);
   wifi_manager->addParameter(&custom_ap_password);
 
   wifi_manager->setTryConnectDuringConfigPortal(false);

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -82,14 +82,25 @@ void Networking::activate_wifi_manager() {
 }
 
 void Networking::setup_wifi_callbacks() {
+
+
   WiFi.onEvent([this](WiFiEvent_t event,
                       WiFiEventInfo_t info) { this->wifi_station_connected(); },
                WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
+  WiFi.onEvent([this](WiFiEvent_t event,
+                      WiFiEventInfo_t info) { this->wifi_ap_enabled(); },
+               WiFiEvent_t::ARDUINO_EVENT_WIFI_AP_START);
   WiFi.onEvent(
       [this](WiFiEvent_t event, WiFiEventInfo_t info) {
-        this->wifi_station_disconnected();
+        this->wifi_disconnected();
       },
       WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+    WiFi.onEvent(
+      [this](WiFiEvent_t event, WiFiEventInfo_t info) {
+        this->wifi_disconnected();
+      },
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_AP_STOP);
+
 }
 
 /**
@@ -102,20 +113,27 @@ void Networking::setup_saved_ssid() {
   String hostname = SensESPBaseApp::get_hostname();
   WiFi.setHostname(hostname.c_str());
 
-  auto reconnect_cb = [this]() {
-    if (WiFi.status() != WL_CONNECTED) {
-      debugI("Connecting to wifi SSID %s.", ap_ssid.c_str());
-      WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
-    }
-  };
+  if (ap_mode_ == false) {
+    // set up WiFi in regular STA (client) mode
+    auto reconnect_cb = [this]() {
+      if (WiFi.status() != WL_CONNECTED) {
+        debugI("Connecting to wifi SSID %s.", ap_ssid.c_str());
+        WiFi.begin(ap_ssid.c_str(), ap_password.c_str());
+      }
+    };
 
-  // Perform an initial connection without a delay.
-  reconnect_cb();
+    // Perform an initial connection without a delay.
+    reconnect_cb();
 
-  // Launch a separate onRepeat reaction to (re-)establish WiFi connection.
-  // Connecting is attempted only every 20 s to allow the previous connection
-  // attempt to complete even if the network is slow.
-  ReactESP::app->onRepeat(20000, reconnect_cb);
+    // Launch a separate onRepeat reaction to (re-)establish WiFi connection.
+    // Connecting is attempted only every 20 s to allow the previous connection
+    // attempt to complete even if the network is slow.
+    ReactESP::app->onRepeat(20000, reconnect_cb);
+  } else {
+    // Set up WiFi in AP mode. In this case, we don't need a reconnect loop.
+    debugI("Setting up a WiFi access point...");
+    WiFi.softAP(ap_ssid.c_str(), ap_password.c_str());
+  }
 }
 
 /**
@@ -131,10 +149,16 @@ void Networking::wifi_station_connected() {
   this->emit(WiFiState::kWifiConnectedToAP);
 }
 
+void Networking::wifi_ap_enabled() {
+  debugI("WiFi Access Point enabled, SSID: %s", WiFi.SSID().c_str());
+  debugI("IP address of Device: %s", WiFi.softAPIP().toString().c_str());
+  this->emit(WiFiState::kWifiAPModeActivated);
+}
+
 /**
  * This method gets called when WiFi is disconnected from the AP.
  */
-void Networking::wifi_station_disconnected() {
+void Networking::wifi_disconnected() {
   debugI("Disconnected from wifi.");
   this->emit(WiFiState::kWifiDisconnected);
 }
@@ -161,9 +185,18 @@ void Networking::setup_wifi_manager() {
 #ifdef SERIAL_DEBUG_DISABLED
   wifi_manager->setDebugOutput(false);
 #endif
-  AsyncWiFiManagerParameter custom_hostname(
-      "hostname", "Set ESP32 device custom hostname", hostname.c_str(), 20);
+  AsyncWiFiManagerParameter custom_hostname("hostname", "Device hostname",
+                                            hostname.c_str(), 20);
   wifi_manager->addParameter(&custom_hostname);
+
+  AsyncWiFiManagerParameter custom_ap_ssid(
+      "ap_ssid", "Custom Access Point SSID", ap_ssid.c_str(), 20);
+  wifi_manager->addParameter(&custom_ap_ssid);
+
+  AsyncWiFiManagerParameter custom_ap_password(
+      "ap_password", "Custom Access Point Password", ap_password.c_str(), 20);
+  wifi_manager->addParameter(&custom_ap_password);
+
   wifi_manager->setTryConnectDuringConfigPortal(false);
 
   // Create a unique SSID for configuring each SensESP Device
@@ -181,24 +214,38 @@ void Networking::setup_wifi_manager() {
 
   wifi_manager->startConfigPortal(pconfig_ssid, wifi_manager_password_);
 
-  // WiFiManager attempts to connect to the new SSID, but that doesn't seem to
-  // work reliably. Instead, we'll just attempt to connect manually.
+  String configured_custom_ap_ssid = custom_ap_ssid.getValue();
+  String configured_custom_ap_password = custom_ap_password.getValue();
 
   bool connected = false;
-  this->ap_ssid = wifi_manager->getConfiguredSTASSID();
-  this->ap_password = wifi_manager->getConfiguredSTAPassword();
 
-  // attempt to connect with the new SSID and password
-  if (this->ap_ssid != "" && this->ap_password != "") {
-    debugD("Attempting to connect to acquired SSID %s and password",
-           this->ap_ssid.c_str());
-    WiFi.begin(this->ap_ssid.c_str(), this->ap_password.c_str());
-    for (int i = 0; i < 20; i++) {
-      if (WiFi.status() == WL_CONNECTED) {
-        connected = true;
-        break;
+  if (configured_custom_ap_ssid != "" && configured_custom_ap_password != "") {
+    // AP mode is desired
+    ap_ssid = configured_custom_ap_ssid;
+    ap_password = configured_custom_ap_password;
+    ap_mode_ = true;
+
+    // always assume we can launch a soft AP
+    connected = true;
+  } else {
+    // WiFiManager attempts to connect to the new SSID, but that doesn't seem to
+    // work reliably. Instead, we'll just attempt to connect manually.
+
+    this->ap_ssid = wifi_manager->getConfiguredSTASSID();
+    this->ap_password = wifi_manager->getConfiguredSTAPassword();
+
+    // attempt to connect with the new SSID and password
+    if (this->ap_ssid != "" && this->ap_password != "") {
+      debugD("Attempting to connect to acquired SSID %s and password",
+             this->ap_ssid.c_str());
+      WiFi.begin(this->ap_ssid.c_str(), this->ap_password.c_str());
+      for (int i = 0; i < 20; i++) {
+        if (WiFi.status() == WL_CONNECTED) {
+          connected = true;
+          break;
+        }
+        delay(1000);
       }
-      delay(1000);
     }
   }
 
@@ -219,9 +266,10 @@ String Networking::get_config_schema() {
   static const char kSchema[] = R"###({
     "type": "object",
     "properties": {
+      "hostname": { "title": "Device hostname", "type": "string" },
       "ssid": { "title": "WiFi SSID", "type": "string" },
       "password": { "title": "WiFi password", "type": "string", "format": "password" },
-      "hostname": { "title": "Device hostname", "type": "string" }
+      "ap_mode": { "type": "string", "format": "radio", "title": "WiFi mode", "enum": ["Client", "Hotspot"] }
     }
   })###";
 
@@ -236,6 +284,7 @@ void Networking::get_configuration(JsonObject& root) {
   root["default_hostname"] = default_hostname;
   root["ssid"] = ap_ssid;
   root["password"] = ap_password;
+  root["ap_mode"] = ap_mode_ ? "Hotspot" : "Client";
 }
 
 bool Networking::set_configuration(const JsonObject& config) {
@@ -251,6 +300,10 @@ bool Networking::set_configuration(const JsonObject& config) {
   }
   ap_ssid = config["ssid"].as<String>();
   ap_password = config["password"].as<String>();
+
+  if (config.containsKey("ap_mode")) {
+    ap_mode_ = config["ap_mode"].as<String>() == "Hotspot";
+  }
 
   return true;
 }

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -33,15 +33,13 @@ class Networking : public Configurable,
   virtual bool set_configuration(const JsonObject& config) override final;
   virtual String get_config_schema() override;
 
-  void enable_wifi_manager(bool state) {
-    wifi_manager_enabled_ = state;
-  }
+  void enable_wifi_manager(bool state) { wifi_manager_enabled_ = state; }
 
   void activate_wifi_manager();
 
-  void set_wifi_manager_ap_ssid(String ssid) {
-    wifi_manager_ap_ssid_ = ssid;
-  }
+  void set_wifi_manager_ap_ssid(String ssid) { wifi_manager_ap_ssid_ = ssid; }
+
+  void set_ap_mode(bool state) { ap_mode_ = state; }
 
  protected:
   void setup_saved_ssid();
@@ -51,7 +49,8 @@ class Networking : public Configurable,
   // callbacks
 
   void wifi_station_connected();
-  void wifi_station_disconnected();
+  void wifi_ap_enabled();
+  void wifi_disconnected();
 
  private:
   AsyncWebServer* server;
@@ -61,6 +60,10 @@ class Networking : public Configurable,
   AsyncWiFiManager* wifi_manager = nullptr;
 
   bool wifi_manager_enabled_ = true;
+
+  // If true, the device will set up its own WiFi access point
+
+  bool ap_mode_ = false;
 
   // values provided by WiFiManager or saved from previous configuration
 
@@ -79,7 +82,6 @@ class Networking : public Configurable,
   String default_hostname = "";
 
   const char* wifi_manager_password_;
-
 };
 
 }  // namespace sensesp

--- a/src/sensesp/net/wifi_state.h
+++ b/src/sensesp/net/wifi_state.h
@@ -7,7 +7,8 @@ enum class WiFiState {
   kWifiNoAP = 0,
   kWifiDisconnected,
   kWifiConnectedToAP,
-  kWifiManagerActivated
+  kWifiManagerActivated,
+  kWifiAPModeActivated
 };
 
 // alias WiFiState for backward compatibility

--- a/src/sensesp/net/ws_client.cpp
+++ b/src/sensesp/net/ws_client.cpp
@@ -373,7 +373,7 @@ void WSClient::connect() {
     return;
   }
 
-  if (!WiFi.isConnected()) {
+  if (!WiFi.isConnected() && WiFi.getMode() != WIFI_MODE_AP) {
     debugI(
         "WiFi is disconnected. SignalK client connection will connect when "
         "WiFi is connected.");


### PR DESCRIPTION
There are use cases in which it's handy to have the device in a soft-AP mode (not connected to a router but allowing inbound WiFi clients instead). This PR provides support for that feature.