### PR TITLE
Fix for ESP32 variants  ADC width compile error

### DIFF
--- a/src/sensesp/sensors/analog_reader.h
+++ b/src/sensesp/sensors/analog_reader.h
@@ -25,7 +25,8 @@ class ESP32AnalogReader : public BaseAnalogReader {
  private:
   int pin_;
   adc_atten_t attenuation_ = ADC_ATTEN_DB_11;
-  adc_bits_width_t bit_width_ = ADC_WIDTH_BIT_12;
+   // This should work with ESP32 and newer variants, ADCs are different
+  adc_bits_width_t  bit_width_ = (adc_bits_width_t)  ADC_WIDTH_BIT_DEFAULT;
   // maximum voltage readout for 3.3V VDDA when attenuation_ is set to 11 dB
   const float kVmax_ = 3300;
   int8_t adc_channel_;


### PR DESCRIPTION
After upgrading to **_v2.4.1_** of SensESP and **_v4.2.0_** of platformio/esspressif32 I could finally compile for my **_Adafruit QT Py  ESP32-S2_** with only 1 error: setting the ADC width. The ADCs have changed on the newer ESP32 variants, the **_S2_** can have 13 bits of resolution. This fix should now cover the ESP32 and its variants.  Hope you have a successful compile!