### PR TITLE
Store auto-discovered SignalK server address & port

### DIFF
--- a/src/sensesp/net/ws_client.cpp
+++ b/src/sensesp/net/ws_client.cpp
@@ -392,6 +392,9 @@ void WSClient::connect() {
     } else {
       debugI("Signal K server has been found at address %s:%d by mDNS.",
              server_address.c_str(), server_port);
+      // Store the discovered server details so they can be retrieved later on
+      this->server_address_ = server_address;
+      this->server_port_ = server_port;
     }
   }
 


### PR DESCRIPTION
When the SignalK server is auto-discovered through mDNS, the address and port are now saved into the `WSClient` instance so they can be later retrieved via the `get_configuration` method. Before this they were never stored, so calling the `get_configuration` function always returned an empty Json object