### PR TITLE
Fix access point terminology

### DIFF
--- a/examples/milone_level_sensor/milone_level_sensor.cpp
+++ b/examples/milone_level_sensor/milone_level_sensor.cpp
@@ -56,9 +56,9 @@ void setup() {
 
   // Create the global SensESPApp() object. If you add the line ->set_wifi("your
   // ssid", "your password") you can specify the wifi parameters in the builder.
-  // If you do not do that, the SensESP device wifi configuration hotspot will
-  // appear and you can use a web browser pointed to 192.168.4.1 to configure
-  // the wifi parameters.
+  // If you do not do that, the SensESP device wifi configuration access point
+  // will appear and you can use a web browser pointed to 192.168.4.1 to
+  // configure the wifi parameters.
 
   sensesp_app = builder.set_hostname("milone")
                     ->set_sk_server("192.168.0.1", 3000)

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -273,7 +273,7 @@ String Networking::get_config_schema() {
       "hostname": { "title": "Device hostname", "type": "string" },
       "ssid": { "title": "WiFi SSID", "type": "string" },
       "password": { "title": "WiFi password", "type": "string", "format": "password" },
-      "ap_mode": { "type": "string", "format": "radio", "title": "WiFi mode", "enum": ["Client", "Hotspot"] }
+      "ap_mode": { "type": "string", "format": "radio", "title": "WiFi mode", "enum": ["Client", "Access Point"] }
     }
   })###";
 
@@ -288,7 +288,7 @@ void Networking::get_configuration(JsonObject& root) {
   root["default_hostname"] = default_hostname;
   root["ssid"] = ap_ssid;
   root["password"] = ap_password;
-  root["ap_mode"] = ap_mode_ ? "Hotspot" : "Client";
+  root["ap_mode"] = ap_mode_ ? "Access Point" : "Client";
 }
 
 bool Networking::set_configuration(const JsonObject& config) {
@@ -306,7 +306,12 @@ bool Networking::set_configuration(const JsonObject& config) {
   ap_password = config["password"].as<String>();
 
   if (config.containsKey("ap_mode")) {
-    ap_mode_ = config["ap_mode"].as<String>() == "Hotspot";
+    if (config["ap_mode"].as<String>() == "Access Point" ||
+        config["ap_mode"].as<String>() == "Hotspot") {
+      ap_mode_ = true;
+    } else {
+      ap_mode_ = false;
+    }
   }
 
   return true;

--- a/src/sensesp/system/task_queue_producer.h
+++ b/src/sensesp/system/task_queue_producer.h
@@ -10,7 +10,7 @@ namespace sensesp {
  *
  * Normal ObservableValues call the observer callbacks within the same
  * task content. In a multi-task software, this is not always preferable.
- * This class allows you to produce values in one class and consume them
+ * This class allows you to produce values in one task and consume them
  * in another.
  *
  * @tparam T


### PR DESCRIPTION
According to e.g. https://www.intel.com/content/www/us/en/tech-tips-and-tricks/what-is-a-hotspot.html, a WiFi Hotspot is a physical location with internet access. So, we're always creating Access Points, not hotspots.