### PR TITLE
Lambda transform complex type support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - examples/async_repeat_sensor.cpp
           - examples/repeat_sensor_analog_input.cpp
           - examples/freertos_tasks.cpp
+          - examples/raw_json.cpp
         target_device:
           - esp32dev
     steps:

--- a/examples/raw_json.cpp
+++ b/examples/raw_json.cpp
@@ -1,0 +1,52 @@
+/**
+ * @brief Example and test program for using Raw Json output.
+ *
+ */
+
+#include "sensesp/system/lambda_consumer.h"
+#include "sensesp/transforms/lambda_transform.h"
+#include "sensesp_app_builder.h"
+
+using namespace sensesp;
+
+reactesp::ReactESP app;
+
+ObservableValue<bool> toggler;
+
+void setup() {
+#ifndef SERIAL_DEBUG_DISABLED
+  SetupSerialDebug(115200);
+#endif
+
+  SensESPAppBuilder builder;
+  SensESPApp *sensesp_app = builder.set_hostname("json_demo")
+                                ->set_wifi("Hat Labs Sensors", "kanneluuri2406")
+                                ->get_app();
+
+  ReactESP::app->onRepeat(1000, []() { toggler.set(!toggler.get()); });
+
+  // take some boolean input and convert it into a simple serialized JSON
+  // document
+  auto jsonify = new LambdaTransform<bool, String>([](bool input) -> String {
+    DynamicJsonDocument doc(1024);
+    doc["output_1"] = input;
+    String output;
+    serializeJson(doc, output);
+    return output;
+  });
+
+  toggler.connect_to(jsonify);
+
+  // print the JSON document to the serial console
+  jsonify->connect_to(new LambdaConsumer<String>(
+      [](String input) { debugD("JSONified output: %s", input.c_str()); }));
+
+  // connect jsonify to the SK delta queue
+
+  const char *sk_path = "environment.json.pin15";
+  jsonify->connect_to(new SKOutputRawJson(sk_path, ""));
+
+  sensesp_app->start();
+}
+
+void loop() { app.tick(); }

--- a/src/sensesp/signalk/signalk_output.h
+++ b/src/sensesp/signalk/signalk_output.h
@@ -1,8 +1,8 @@
 #ifndef _signalk_output_H_
 #define _signalk_output_H_
 
-#include "signalk_emitter.h"
 #include "sensesp/transforms/transform.h"
+#include "signalk_emitter.h"
 
 namespace sensesp {
 
@@ -82,6 +82,25 @@ class SKOutput : public SKEmitter, public SymmetricTransform<T> {
 
  protected:
   SKMetadata* meta_;
+};
+
+/**
+ * @brief Class for sending raw Json strings on a specific Signal K path.
+ */
+class SKOutputRawJson : public SKOutput<String> {
+ public:
+  SKOutputRawJson(String sk_path, String config_path = "",
+                  SKMetadata* meta = NULL)
+      : SKOutput<String>(sk_path, config_path, meta) {}
+
+  virtual String as_signalk() override {
+    DynamicJsonDocument json_doc(4096);
+    String json;
+    json_doc["path"] = this->get_sk_path();
+    json_doc["value"] = serialized(ValueProducer<String>::output);
+    serializeJson(json_doc, json);
+    return json;
+  }
 };
 
 /**

--- a/src/sensesp/transforms/difference.cpp
+++ b/src/sensesp/transforms/difference.cpp
@@ -21,15 +21,13 @@ void Difference::set_input(float input, uint8_t inputChannel) {
 void Difference::get_configuration(JsonObject& root) {
   root["k1"] = k1;
   root["k2"] = k2;
-  root["value"] = output;
 }
 
 static const char SCHEMA[] PROGMEM = R"({
     "type": "object",
     "properties": {
         "k1": { "title": "Input #1 multiplier", "type": "number" },
-        "k2": { "title": "Input #2 multiplier", "type": "number" },
-        "value": { "title": "Last value", "type" : "number", "readOnly": true }
+        "k2": { "title": "Input #2 multiplier", "type": "number" }
     }
   })";
 

--- a/src/sensesp/transforms/integrator.h
+++ b/src/sensesp/transforms/integrator.h
@@ -8,8 +8,7 @@ namespace sensesp {
 static const char INTEGRATOR_SCHEMA[] PROGMEM = R"({
     "type": "object",
     "properties": {
-        "k": { "title": "Multiplier", "type": "number" },
-        "value": { "title": "Current value", "type" : "number", "readOnly": false }
+        "k": { "title": "Multiplier", "type": "number" }
     }
   })";
 
@@ -53,7 +52,6 @@ class IntegratorT : public Transform<C, P> {
 
   virtual void get_configuration(JsonObject& doc) override final {
     doc["k"] = k;
-    doc["value"] = value;
   }
   virtual bool set_configuration(const JsonObject& config) override final {
     String expected[] = {"k"};
@@ -63,7 +61,6 @@ class IntegratorT : public Transform<C, P> {
       }
     }
     k = config["k"];
-    value = config["value"];
     return true;
   }
   virtual String get_config_schema() override {

--- a/src/sensesp/transforms/lambda_transform.cpp
+++ b/src/sensesp/transforms/lambda_transform.cpp
@@ -2,11 +2,6 @@
 
 namespace sensesp {
 
-template <class T>
-const char* get_schema_type_string(const T dummy) {
-  return "string";
-}
-
 template <>
 const char* get_schema_type_string(const int dummy) {
   return "number";

--- a/src/sensesp/transforms/lambda_transform.h
+++ b/src/sensesp/transforms/lambda_transform.h
@@ -224,7 +224,6 @@ class LambdaTransform : public Transform<IN, OUT> {
       default:
         break;
     }
-    doc["value"] = this->output;
   }
 
   bool set_configuration(const JsonObject& config) override {
@@ -273,40 +272,37 @@ class LambdaTransform : public Transform<IN, OUT> {
       output.concat(format_schema_row(param_info[0].key,
                                       param_info[0].description,
                                       get_schema_type_string(param1), false));
-      output.concat(",");
     }
     if (num_params > 1) {
+      output.concat(",");
       output.concat(format_schema_row(param_info[1].key,
                                       param_info[1].description,
                                       get_schema_type_string(param2), false));
-      output.concat(",");
     }
     if (num_params > 2) {
+      output.concat(",");
       output.concat(format_schema_row(param_info[2].key,
                                       param_info[2].description,
                                       get_schema_type_string(param3), false));
-      output.concat(",");
     }
     if (num_params > 3) {
+      output.concat(",");
       output.concat(format_schema_row(param_info[3].key,
                                       param_info[3].description,
                                       get_schema_type_string(param4), false));
-      output.concat(",");
     }
     if (num_params > 4) {
+      output.concat(",");
       output.concat(format_schema_row(param_info[4].key,
                                       param_info[4].description,
                                       get_schema_type_string(param5), false));
-      output.concat(",");
     }
     if (num_params > 5) {
+      output.concat(",");
       output.concat(format_schema_row(param_info[5].key,
                                       param_info[5].description,
                                       get_schema_type_string(param6), false));
-      output.concat(",");
     }
-    output.concat(format_schema_row(
-        "value", "Last value", get_schema_type_string(this->output), true));
     output.concat(FPSTR(kLambdaTransformSchemaTail));
 
     debugD("Prepared config schema.");

--- a/src/sensesp/transforms/lambda_transform.h
+++ b/src/sensesp/transforms/lambda_transform.h
@@ -20,9 +20,11 @@ static const char kLambdaTransformSchemaTail[] PROGMEM = R"(
  * Convert the variable type to a string representation of the type using
  * template specializations.
  **/
+// an unknown type may not be rendered in Json editor
 template <class T>
-const char* get_schema_type_string(const T dummy);
-
+const char* get_schema_type_string(const T dummy) {
+  return "unknown";
+}
 template <>
 const char* get_schema_type_string(const int dummy);
 


### PR DESCRIPTION
Lambda transforms were storing the current output value in the configuration json object. This failed whenever the transform had a complex type that didn't have a standard Json serialization available.

This PR now stops storing the output value in the configuration object. That was a bad idea anyway...

Similar change has been made to `Difference` and `Integrator` transforms as well.

EDIT: Also added support for raw JSON SK output. If `String` objects are passed as input to `SKOutputRawJson`, the string contents will be inserted as-is as the value field of the respective paths.
