### PR TITLE
Make ESP32AnalogReader work for some ADC2 pins

### DIFF
--- a/src/sensesp/sensors/analog_input.h
+++ b/src/sensesp/sensors/analog_input.h
@@ -15,8 +15,9 @@ namespace sensesp {
  * SensESP supports the ADS1015 and ADS1115 ADC's.
  *
  * @param[in] pin The GPIO pin to read. On ESP32, at
- * the moment only ADC channel 1 (pins 32..39) is supported because
- * ADC2 clashes with Wi-Fi.
+ * the moment only ADC channel 1 (pins 32..39) is fully supported because
+ * ADC2 clashes with WiFi. But you can use pins 13, 25, 26, and 27 on ADC2
+ * if you aren't using WiFi in your project.
  *
  * @param[in] read_delay Time delay between consecutive readings, in ms
  *


### PR DESCRIPTION
The pins on ADC2 are configured and read differently from the pins on ADC1, so everything has to be done differently.

The code in this commit works perfectly for reading pins on both ADC1 and ADC2 in a non-SensESP project that I've been working on, but I currently have no Signal K / SensESP project going, so I can't really test this properly.