### PR TITLE
Peg ArduinoJson version to 6.x.y

### DIFF
--- a/library.json
+++ b/library.json
@@ -45,7 +45,8 @@
     },
     {
       "owner": "bblanchon",
-      "name": "ArduinoJson"
+      "name": "ArduinoJson",
+      "version": "^6.0.0"
     },
     {
       "owner": "links2004",

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ lib_deps =
    me-no-dev/ESPAsyncTCP
    me-no-dev/ESP Async Webserver
    alanswx/ESPAsyncWifiManager
-   bblanchon/ArduinoJson
+   bblanchon/ArduinoJson @ ^6.0.0
    links2004/WebSockets
    pfeerick/elapsedMillis
    bxparks/AceButton @ ^1.10.1


### PR DESCRIPTION
ArduinoJson 7 has been just released. It breaks SensESP builds. Before changing the code to accommodate the new version, let's just peg the version dependency to 6.x.y.