### PR TITLE
Improved curve interpolator

### DIFF
--- a/src/sensesp/transforms/curveinterpolator.cpp
+++ b/src/sensesp/transforms/curveinterpolator.cpp
@@ -33,51 +33,66 @@ CurveInterpolator::CurveInterpolator(std::set<Sample>* defaults,
 }
 
 void CurveInterpolator::set_input(float input, uint8_t inputChannel) {
-  float x0 = 0.0;
-  float y0 = 0.0;
-  bool inputTooLow = false;
-  bool inputTooHigh = false;
-
-  std::set<Sample>::iterator it = samples_.begin();
-
-  while (it != samples_.end()) {
-    auto& sample = *it;
-
-    if (input < sample.input) {
-      // Input is lower than the current sample input
-      inputTooLow = true;
-      break;
-    } else if (input > sample.input) {
-      x0 = sample.input;
-      y0 = sample.output;
-    } else {
-      // Input matches a sample exactly
-      x0 = sample.input;
-      y0 = sample.output;
-      break;
+    if (samples_.empty()) {
+        output = 0;  // or any default output if no samples are available
+        notify();
+        return;
     }
 
-    it++;
-  }
+    std::set<Sample>::iterator it = samples_.begin();
+    float x0 = it->input;
+    float y0 = it->output;
 
-  if (!inputTooLow && it != samples_.end()) {
-    // We found our range. "input" is between
-    // x0 and it->input. Interpolate the result
-    Sample max = *it;
-    float x1 = max.input;
-    float y1 = max.output;
+    // Check if the input is below the lowest sample point
+    if (input < x0) {
+        // Need to extrapolate below the first point
+        if (samples_.size() > 1) {
+            auto second_it = std::next(it);
+            float x1 = second_it->input;
+            float y1 = second_it->output;
+            float gradient = (y1 - y0) / (x1 - x0);
 
-    output = (y0 * (x1 - input) + y1 * (input - x0)) / (x1 - x0);
-  } else if (inputTooLow) {
-    // Input is too low, return the minimum sample input
-    output = samples_.begin()->output;
-  } else {
-    // Input is too high, return the maximum sample input
-    output = samples_.rbegin()->output;
-  }
+            output = y0 + gradient * (input - x0);  // Extrapolate using the first segment's gradient
+        } else {
+            output = y0;  // Only one sample, output its value
+        }
+        notify();
+        return;
+    }
 
-  notify();
+    // Search for the correct interval or the last sample point
+    while (it != samples_.end()) {
+        if (input > it->input) {
+            x0 = it->input;
+            y0 = it->output;
+            ++it;
+        } else {
+            break;
+        }
+    }
+
+    // Interpolate or extrapolate above the highest point
+    if (it != samples_.end()) {
+        float x1 = it->input;
+        float y1 = it->output;
+        output = (y0 * (x1 - input) + y1 * (input - x0)) / (x1 - x0);
+    } else {
+        // Hit the end of the table with no match, calculate output using the gradient from the last two points
+        auto last = samples_.rbegin();
+        auto second_last = std::next(last);
+        float x1 = last->input;
+        float y1 = last->output;
+        float x2 = second_last->input;
+        float y2 = second_last->output;
+        float gradient = (y1 - y2) / (x1 - x2);
+
+        // Extrapolate using the gradient
+        output = y1 + gradient * (input - x1);
+    }
+
+    notify();
 }
+
 
 
 void CurveInterpolator::get_configuration(JsonObject& root) {


### PR DESCRIPTION
The curve interpolator reacted strangely to values beyond the curve limits.

Values below the lower bound were linearly interpolated between the point 0,0 and the first curve point, values above the upper bound translated to 9999.99

It seems more graceful to simply continue the curve linearly above and below the lower and upper pair of points.  

If "hard limits" are desired, such as a tank cannot be less 0.0 empty or 1.0 full simply adding bounds points with the same value at the top and bottom of the list produces a flat line:

eg: 

(50,0)
(100,0)
(1000,1)
(1050,1) 

Willl produce a "flat" curve lowwr than 100 and above 1000,  effectively limiting the output.   Without the bound points, the linear curve extends above 1000 and below 100 without unpredictable results.