### PR TITLE
Breaking change: rename WSClient to SKWSClient

### DIFF
--- a/examples/freertos_tasks.cpp
+++ b/examples/freertos_tasks.cpp
@@ -7,7 +7,7 @@
 #include "sensesp/net/discovery.h"
 #include "sensesp/net/http_server.h"
 #include "sensesp/net/networking.h"
-#include "sensesp/net/ws_client.h"
+#include "sensesp/signalk/signalk_ws_client.h"
 #include "sensesp/sensors/digital_input.h"
 #include "sensesp/signalk/signalk_delta_queue.h"
 #include "sensesp/signalk/signalk_output.h"
@@ -50,10 +50,10 @@ void setup() {
   auto sk_delta_queue_ = new SKDeltaQueue();
 
   // create the websocket client
-  auto ws_client_ = new WSClient("/system/sk", sk_delta_queue_, "", 0);
+  auto ws_client_ = new SKWSClient("/system/sk", sk_delta_queue_, "", 0);
 
-  ws_client_->connect_to(new LambdaConsumer<WSConnectionState>(
-      [](WSConnectionState input) { debugD("WSConnectionState: %d", input); }));
+  ws_client_->connect_to(new LambdaConsumer<SKWSConnectionState>(
+      [](SKWSConnectionState input) { debugD("SKWSConnectionState: %d", input); }));
 
   // create the MDNS discovery object
   auto mdns_discovery_ = new MDNSDiscovery();

--- a/src/sensesp/controllers/system_status_controller.cpp
+++ b/src/sensesp/controllers/system_status_controller.cpp
@@ -15,7 +15,7 @@ void SystemStatusController::set(WiFiState new_value,
       break;
     case WiFiState::kWifiConnectedToAP:
     case WiFiState::kWifiAPModeActivated:
-      this->update_state(SystemStatus::kWSDisconnected);
+      this->update_state(SystemStatus::kSKWSDisconnected);
       break;
     case WiFiState::kWifiManagerActivated:
       this->update_state(SystemStatus::kWifiManagerActivated);
@@ -23,25 +23,25 @@ void SystemStatusController::set(WiFiState new_value,
   }
 }
 
-void SystemStatusController::set(WSConnectionState new_value,
+void SystemStatusController::set(SKWSConnectionState new_value,
                                        uint8_t input_channel) {
   switch (new_value) {
-    case WSConnectionState::kWSDisconnected:
+    case SKWSConnectionState::kSKWSDisconnected:
       if (current_state_ != SystemStatus::kWifiDisconnected &&
           current_state_ != SystemStatus::kWifiNoAP &&
           current_state_ != SystemStatus::kWifiManagerActivated) {
         // Wifi disconnection states override the higher level protocol state
-        this->update_state(SystemStatus::kWSDisconnected);
+        this->update_state(SystemStatus::kSKWSDisconnected);
       }
       break;
-    case WSConnectionState::kWSConnecting:
-      this->update_state(SystemStatus::kWSConnecting);
+    case SKWSConnectionState::kSKWSConnecting:
+      this->update_state(SystemStatus::kSKWSConnecting);
       break;
-    case WSConnectionState::kWSAuthorizing:
-      this->update_state(SystemStatus::kWSAuthorizing);
+    case SKWSConnectionState::kSKWSAuthorizing:
+      this->update_state(SystemStatus::kSKWSAuthorizing);
       break;
-    case WSConnectionState::kWSConnected:
-      this->update_state(SystemStatus::kWSConnected);
+    case SKWSConnectionState::kSKWSConnected:
+      this->update_state(SystemStatus::kSKWSConnected);
       break;
   }
 }

--- a/src/sensesp/controllers/system_status_controller.h
+++ b/src/sensesp/controllers/system_status_controller.h
@@ -2,7 +2,7 @@
 #define _SYSTEM_STATUS_CONTROLLER_H_
 
 #include "sensesp/net/networking.h"
-#include "sensesp/net/ws_client.h"
+#include "sensesp/signalk/signalk_ws_client.h"
 #include "sensesp/system/valueproducer.h"
 
 namespace sensesp {
@@ -11,10 +11,10 @@ enum class SystemStatus {
   kWifiNoAP = 100,
   kWifiDisconnected,
   kWifiManagerActivated,
-  kWSDisconnected,
-  kWSAuthorizing,
-  kWSConnecting,
-  kWSConnected
+  kSKWSDisconnected,
+  kSKWSAuthorizing,
+  kSKWSConnecting,
+  kSKWSConnected
 };
 
 /**
@@ -25,7 +25,7 @@ enum class SystemStatus {
  * an event occurs.
  */
 class SystemStatusController : public ValueConsumer<WiFiState>,
-                               public ValueConsumer<WSConnectionState>,
+                               public ValueConsumer<SKWSConnectionState>,
                                public ValueProducer<SystemStatus> {
  public:
   SystemStatusController() {}
@@ -34,9 +34,9 @@ class SystemStatusController : public ValueConsumer<WiFiState>,
   /// state updates)
   virtual void set(WiFiState new_value,
                          uint8_t input_channel = 0) override;
-  /// ValueConsumer interface for ValueConsumer<WSConnectionState>
-  /// (WSClient object state updates)
-  virtual void set(WSConnectionState new_value,
+  /// ValueConsumer interface for ValueConsumer<SKWSConnectionState>
+  /// (SKWSClient object state updates)
+  virtual void set(SKWSConnectionState new_value,
                          uint8_t input_channel = 0) override;
 
  protected:

--- a/src/sensesp/signalk/signalk_delta_queue.h
+++ b/src/sensesp/signalk/signalk_delta_queue.h
@@ -11,7 +11,7 @@ namespace sensesp {
  * @brief Signal K delta queue
  *
  * This class implements a Signal K delta queue. There should be a unique queue
- * for each possible output channel (WSClient, NMEA 2000 messages,
+ * for each possible output channel (SKWSClient, NMEA 2000 messages,
  * carrier pigeons).
  */
 class SKDeltaQueue {

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -1,5 +1,5 @@
-#ifndef _ws_client_H_
-#define _ws_client_H_
+#ifndef SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_WS_CLIENT_H_
+#define SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_WS_CLIENT_H_
 
 #include <WiFi.h>
 #include <esp_websocket_client.h>
@@ -19,24 +19,24 @@ namespace sensesp {
 
 static const char* NULL_AUTH_TOKEN = "";
 
-enum class WSConnectionState {
-  kWSDisconnected,
-  kWSAuthorizing,
-  kWSConnecting,
-  kWSConnected
+enum class SKWSConnectionState {
+  kSKWSDisconnected,
+  kSKWSAuthorizing,
+  kSKWSConnecting,
+  kSKWSConnected
 };
 
 /**
  * @brief The websocket connection to the Signal K server.
  * @see SensESPApp
  */
-class WSClient : public Configurable,
-                 public ValueProducer<WSConnectionState> {
+class SKWSClient : public Configurable,
+                 public ValueProducer<SKWSConnectionState> {
  public:
   /////////////////////////////////////////////////////////
   // main task methods
 
-  WSClient(String config_path, SKDeltaQueue* sk_delta_queue,
+  SKWSClient(String config_path, SKDeltaQueue* sk_delta_queue,
            String server_address, uint16_t server_port, bool use_mdns = true);
 
   const String get_server_address() const { return server_address_; }
@@ -65,7 +65,7 @@ class WSClient : public Configurable,
   String get_connection_status();
 
   /////////////////////////////////////////////////////////
-  // WSClient task methods
+  // SKWSClient task methods
 
   void on_disconnected();
   void on_error();
@@ -101,13 +101,13 @@ class WSClient : public Configurable,
   bool server_detected_ = false;
   bool token_test_success_ = false;
 
-  TaskQueueProducer<WSConnectionState> connection_state_ =
-      TaskQueueProducer<WSConnectionState>(WSConnectionState::kWSDisconnected,
+  TaskQueueProducer<SKWSConnectionState> connection_state_ =
+      TaskQueueProducer<SKWSConnectionState>(SKWSConnectionState::kSKWSDisconnected,
                                            ReactESP::app);
 
   /// task_connection_state is used to track the internal task state which might
   /// be out of sync with the published connection state.
-  WSConnectionState task_connection_state_ = WSConnectionState::kWSDisconnected;
+  SKWSConnectionState task_connection_state_ = SKWSConnectionState::kSKWSDisconnected;
 
   WiFiClient wifi_client_;
   esp_websocket_client_handle_t client_;
@@ -143,7 +143,7 @@ class WSClient : public Configurable,
   void process_received_updates();
 
   /////////////////////////////////////////////////////////
-  // WSClient task methods
+  // SKWSClient task methods
 
   void connect_loop();
   void test_token(const String host, const uint16_t port);
@@ -154,11 +154,11 @@ class WSClient : public Configurable,
   void subscribe_listeners();
   bool get_mdns_service(String& server_address, uint16_t& server_port);
 
-  void set_connection_state(WSConnectionState state) {
+  void set_connection_state(SKWSConnectionState state) {
     task_connection_state_ = state;
     connection_state_.set(state);
   }
-  WSConnectionState get_connection_state() { return task_connection_state_; }
+  SKWSConnectionState get_connection_state() { return task_connection_state_; }
 };
 
 }  // namespace sensesp

--- a/src/sensesp/system/led_blinker.h
+++ b/src/sensesp/system/led_blinker.h
@@ -1,9 +1,9 @@
-#ifndef _led_blinker_H_
-#define _led_blinker_H_
+#ifndef SENSESP_SRC_SENSESP_SYSTEM_LED_BLINKER_H_
+#define SENSESP_SRC_SENSESP_SYSTEM_LED_BLINKER_H_
 
 #include <ReactESP.h>
 
-#include "sensesp/net/ws_client.h"
+#include "sensesp/signalk/signalk_ws_client.h"
 
 namespace sensesp {
 

--- a/src/sensesp/system/system_status_led.cpp
+++ b/src/sensesp/system/system_status_led.cpp
@@ -67,16 +67,16 @@ void SystemStatusLed::set(SystemStatus new_value, uint8_t input_channel) {
     case SystemStatus::kWifiManagerActivated:
       this->set_wifimanager_activated();
       break;
-    case SystemStatus::kWSDisconnected:
+    case SystemStatus::kSKWSDisconnected:
       this->set_ws_disconnected();
       break;
-    case SystemStatus::kWSConnecting:
+    case SystemStatus::kSKWSConnecting:
       this->set_ws_connecting();
       break;
-    case SystemStatus::kWSAuthorizing:
+    case SystemStatus::kSKWSAuthorizing:
       this->set_ws_authorizing();
       break;
-    case SystemStatus::kWSConnected:
+    case SystemStatus::kSKWSConnected:
       this->set_ws_connected();
       break;
   }

--- a/src/sensesp/system/system_status_led.h
+++ b/src/sensesp/system/system_status_led.h
@@ -1,5 +1,5 @@
-#ifndef _LED_CONTROLLER_H_
-#define _LED_CONTROLLER_H_
+#ifndef SENSESP_SRC_SENSESP_SYSTEM_SYSTEM_STATUS_LED_H_
+#define SENSESP_SRC_SENSESP_SYSTEM_SYSTEM_STATUS_LED_H_
 
 #include "lambda_consumer.h"
 #include "led_blinker.h"

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -55,7 +55,7 @@ void SensESPApp::setup() {
   // create the websocket client
   bool use_mdns = sk_server_address_ == "";
   this->ws_client_ =
-      new WSClient("/System/Signal K Settings", sk_delta_queue_,
+      new SKWSClient("/System/Signal K Settings", sk_delta_queue_,
                    sk_server_address_, sk_server_port_, use_mdns);
 
   // connect the system status controller

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -19,7 +19,7 @@
 #include "sensesp/net/web/base_command_handler.h"
 #include "sensesp/net/web/config_handler.h"
 #include "sensesp/net/web/static_file_handler.h"
-#include "sensesp/net/ws_client.h"
+#include "sensesp/signalk/signalk_ws_client.h"
 #include "sensesp/sensesp_version.h"
 #include "sensesp/sensors/sensor.h"
 #include "sensesp/signalk/signalk_delta_queue.h"
@@ -60,7 +60,7 @@ class SensESPApp : public SensESPBaseApp {
     return &(this->system_status_controller_);
   }
   Networking* get_networking() { return this->networking_; }
-  WSClient* get_ws_client() { return this->ws_client_; }
+  SKWSClient* get_ws_client() { return this->ws_client_; }
 
  protected:
   /**
@@ -135,7 +135,7 @@ class SensESPApp : public SensESPBaseApp {
   Networking* networking_ = NULL;
   OTA* ota_;
   SKDeltaQueue* sk_delta_queue_;
-  WSClient* ws_client_;
+  SKWSClient* ws_client_;
 
   UIOutput<String>* sensesp_version_ui_output_ = new UIOutput<String>(
       "SenseESP version", kSensESPVersion, "Software", 1900);


### PR DESCRIPTION
Renamed the `WSClient` class and related filenames to `SKWSClient` for clarity.