### PR TITLE
Pass received Json objects always by value

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -70,7 +70,7 @@ class SKWSClient : public Configurable,
   void on_disconnected();
   void on_error();
   void on_connected();
-  void on_receive_delta(uint8_t* payload);
+  void on_receive_delta(uint8_t* payload, size_t length);
   void on_receive_updates(JsonDocument& message);
   void on_receive_put(JsonDocument& message);
   void connect();
@@ -120,7 +120,7 @@ class SKWSClient : public Configurable,
 
   SemaphoreHandle_t received_updates_semaphore_ =
       xSemaphoreCreateRecursiveMutex();
-  std::list<JsonObject> received_updates_;
+  std::list<JsonDocument> received_updates_;
 
   /////////////////////////////////////////////////////////
   // methods for all tasks


### PR DESCRIPTION
Updating to ArduinoJson 7 broke SKListener functionality because apparently the previous ArduinoJson copied JsonObjects by value and the new one does that by reference. Nothing wrong with that change in ArduinoJson, should've tested that.

Fixes Issue #688.