### PR TITLE
Rename ConstantSensor getters and setters

### DIFF
--- a/src/sensesp/sensors/constant_sensor.h
+++ b/src/sensesp/sensors/constant_sensor.h
@@ -62,7 +62,6 @@ class ConstantSensor : public Sensor<T> {
   }
 
   void set_value(T value) { value_ = value; }
-  T get_value() { return value_; }
 
  protected:
   virtual void get_configuration(JsonObject &doc) override {

--- a/src/sensesp/sensors/constant_sensor.h
+++ b/src/sensesp/sensors/constant_sensor.h
@@ -65,7 +65,7 @@ class ConstantSensor : public Sensor<T> {
                             [this]() { this->emit(value_); });
   }
 
-  void set_value(T value) { value_ = value; }
+  void set(T value) { value_ = value; }
 
  protected:
   virtual void get_configuration(JsonObject &doc) override {

--- a/src/sensesp/sensors/constant_sensor.h
+++ b/src/sensesp/sensors/constant_sensor.h
@@ -57,6 +57,10 @@ class ConstantSensor : public Sensor<T> {
       : Sensor<T>(config_path), value_{value}, send_interval_{send_interval} {
     this->load_configuration();
 
+    // Emit the initial value once to set the output
+    ReactESP::app->onDelay(0,
+                            [this]() { this->emit(value_); });
+    // Then, emit the value at the specified interval
     ReactESP::app->onRepeat(send_interval_ * 1000,
                             [this]() { this->emit(value_); });
   }


### PR DESCRIPTION
Removed `ConstantSensor::get_value` and made it emit the value immediately to allow value retrieval using `::get`. Also, Renamed `set_value()` to `set()` for consistency with the other classes.