### PR TITLE
Implement new ExpiringValue container class

### DIFF
--- a/src/sensesp/system/expiring_value.h
+++ b/src/sensesp/system/expiring_value.h
@@ -1,0 +1,56 @@
+#ifndef SENSESP_SRC_SENSESP_SYSTEM_EXPIRING_VALUE_H_
+#define SENSESP_SRC_SENSESP_SYSTEM_EXPIRING_VALUE_H_
+
+namespace sensesp {
+
+/**
+ * @brief Value container that keeps track of its expiration time.
+ *
+ * The value is considered expired if the time since the last update is greater
+ * than the expiration duration. When expired, the value is replaced with an
+ * expiration placeholder value.
+ *
+ * @tparam T
+ */
+template <typename T>
+class ExpiringValue {
+ public:
+  ExpiringValue()
+      : value_{},
+        expiration_duration_{1000},
+        last_update_{0},
+        expired_value_{T{}} {}
+
+  ExpiringValue(T value, unsigned long expiration_duration, T expired_value)
+      : value_{value},
+        expiration_duration_{expiration_duration},
+        expired_value_{expired_value},
+        last_update_{millis()} {}
+
+  void update(T value) {
+    value_ = value;
+    last_update_ = millis();
+  }
+
+  T get() const {
+    if (!is_expired()) {
+      return value_;
+    } else {
+      return expired_value_;
+    }
+  }
+
+  bool is_expired() const {
+    return millis() - last_update_ > expiration_duration_;
+  }
+
+ private:
+  T value_;
+  T expired_value_;
+  unsigned long expiration_duration_;
+  unsigned long last_update_;
+};
+
+}  // namespace sensesp
+
+#endif  // SENSESP_SRC_SENSESP_SYSTEM_EXPIRING_VALUE_H_

--- a/src/sensesp/system/serial_number.h
+++ b/src/sensesp/system/serial_number.h
@@ -1,0 +1,16 @@
+#ifndef SENSESP_SRC_SENSESP_SYSTEM_SERIAL_NUMBER_H_
+#define SENSESP_SRC_SENSESP_SYSTEM_SERIAL_NUMBER_H_
+
+#include <esp_mac.h>
+
+#include <cstdint>
+
+uint64_t GetBoardSerialNumber() {
+  uint8_t chipid[6];
+  esp_efuse_mac_get_default(chipid);
+  return ((uint64_t)chipid[0] << 0) + ((uint64_t)chipid[1] << 8) +
+         ((uint64_t)chipid[2] << 16) + ((uint64_t)chipid[3] << 24) +
+         ((uint64_t)chipid[4] << 32) + ((uint64_t)chipid[5] << 40);
+}
+
+#endif  // SENSESP_SRC_SENSESP_SYSTEM_SERIAL_NUMBER_H_


### PR DESCRIPTION
`ExpiringValue` is a container that returns the contained value if its age is less that `max_age`. Otherwise, an expiration marker value is returned. This comes handy if you want to combine a large number of values into a single output while ensuring that the values are still current.