### PR TITLE
Make ValueConsumer::set argument a const ref

### DIFF
--- a/src/sensesp/controllers/smart_switch_controller.cpp
+++ b/src/sensesp/controllers/smart_switch_controller.cpp
@@ -26,12 +26,12 @@ SmartSwitchController::SmartSwitchController(bool auto_initialize,
   }
 }
 
-void SmartSwitchController::set(bool new_value) {
+void SmartSwitchController::set(const bool& new_value) {
   is_on = new_value;
   this->emit(is_on);
 }
 
-void SmartSwitchController::set(ClickTypes new_value) {
+void SmartSwitchController::set(const ClickTypes& new_value) {
   if (!ClickType::is_click(new_value)) {
     // Ignore button presses (we only want interpreted clicks)
     return;
@@ -56,7 +56,7 @@ void SmartSwitchController::set(ClickTypes new_value) {
   }
 }
 
-void SmartSwitchController::set(String new_value) {
+void SmartSwitchController::set(const String& new_value) {
   if (TextToTruth::is_valid_true(new_value)) {
     is_on = true;
   } else if (TextToTruth::is_valid_false(new_value)) {

--- a/src/sensesp/controllers/smart_switch_controller.h
+++ b/src/sensesp/controllers/smart_switch_controller.h
@@ -61,9 +61,9 @@ class SmartSwitchController : public BooleanTransform,
    */
   SmartSwitchController(bool auto_initialize = true, String config_path = "",
                         const char* sk_sync_paths[] = NULL);
-  void set(bool new_value) override;
-  void set(String new_value) override;
-  void set(ClickTypes new_value) override;
+  void set(const bool& new_value) override;
+  void set(const String& new_value) override;
+  void set(const ClickTypes& new_value) override;
 
   // For reading and writing the configuration of this transformation
   virtual void get_configuration(JsonObject& doc) override;

--- a/src/sensesp/controllers/system_status_controller.cpp
+++ b/src/sensesp/controllers/system_status_controller.cpp
@@ -2,7 +2,7 @@
 
 namespace sensesp {
 
-void SystemStatusController::set(WiFiState new_value) {
+void SystemStatusController::set(const WiFiState& new_value) {
   // FIXME: If pointers to member functions would be held in an array,
   // this would be a simple array dereferencing
   switch (new_value) {
@@ -22,7 +22,7 @@ void SystemStatusController::set(WiFiState new_value) {
   }
 }
 
-void SystemStatusController::set(SKWSConnectionState new_value) {
+void SystemStatusController::set(const SKWSConnectionState& new_value) {
   switch (new_value) {
     case SKWSConnectionState::kSKWSDisconnected:
       if (current_state_ != SystemStatus::kWifiDisconnected &&

--- a/src/sensesp/controllers/system_status_controller.h
+++ b/src/sensesp/controllers/system_status_controller.h
@@ -32,10 +32,10 @@ class SystemStatusController : public ValueConsumer<WiFiState>,
 
   /// ValueConsumer interface for ValueConsumer<WiFiState> (Networking object
   /// state updates)
-  virtual void set(WiFiState new_value) override;
+  virtual void set(const WiFiState& new_value) override;
   /// ValueConsumer interface for ValueConsumer<SKWSConnectionState>
   /// (SKWSClient object state updates)
-  virtual void set(SKWSConnectionState new_value) override;
+  virtual void set(const SKWSConnectionState& new_value) override;
 
  protected:
   void update_state(const SystemStatus new_state) {

--- a/src/sensesp/sensors/digital_output.cpp
+++ b/src/sensesp/sensors/digital_output.cpp
@@ -9,7 +9,7 @@ DigitalOutput::DigitalOutput(int pin) {
   pinMode(pin, OUTPUT);
 }
 
-void DigitalOutput::set(bool new_value) {
+void DigitalOutput::set(const bool& new_value) {
   digitalWrite(pin_number_, new_value);
   this->emit(new_value);
 }

--- a/src/sensesp/sensors/digital_output.h
+++ b/src/sensesp/sensors/digital_output.h
@@ -17,7 +17,7 @@ namespace sensesp {
 class DigitalOutput : public BooleanTransform {
  public:
   DigitalOutput(int pin);
-  void set(bool new_value) override;
+  void set(const bool& new_value) override;
 
  private:
   int pin_number_;

--- a/src/sensesp/signalk/signalk_output.h
+++ b/src/sensesp/signalk/signalk_output.h
@@ -42,7 +42,7 @@ class SKOutput : public SKEmitter, public SymmetricTransform<T> {
 
   SKOutput(String sk_path, SKMetadata* meta) : SKOutput(sk_path, "", meta) {}
 
-  virtual void set(T new_value) override {
+  virtual void set(const T& new_value) override {
     this->ValueProducer<T>::emit(new_value);
   }
 

--- a/src/sensesp/signalk/signalk_put_request.h
+++ b/src/sensesp/signalk/signalk_put_request.h
@@ -146,7 +146,7 @@ class SKPutRequest : public SKPutRequestBase, public ValueConsumer<T> {
       : SKPutRequestBase(sk_path, config_path, timeout),
         ignore_duplicates{ignore_duplicates} {}
 
-  virtual void set(T new_value) override {
+  virtual void set(const T& new_value) override {
     if (ignore_duplicates && new_value == value) {
       return;
     }

--- a/src/sensesp/system/lambda_consumer.h
+++ b/src/sensesp/system/lambda_consumer.h
@@ -27,7 +27,7 @@ class LambdaConsumer : public ValueConsumer<IN> {
   LambdaConsumer(std::function<void(IN)> function)
       : ValueConsumer<IN>(), function{function} {}
 
-  void set(IN input) override { function(input); }
+  void set(const IN& input) override { function(input); }
 
  protected:
   std::function<void(IN)> function;

--- a/src/sensesp/system/observablevalue.h
+++ b/src/sensesp/system/observablevalue.h
@@ -32,7 +32,7 @@ class ObservableValue : public ValueConsumer<T>, public ValueProducer<T> {
   ObservableValue(const T& value)
       : ValueConsumer<T>(), ValueProducer<T>(value) {}
 
-  void set(T value) override { this->ValueProducer<T>::emit(value); }
+  void set(const T& value) override { this->ValueProducer<T>::emit(value); }
 
   const T& operator=(const T& value) {
     set(value);
@@ -65,7 +65,7 @@ class PersistingObservableValue : public ObservableValue<T>,
     load_configuration();
   }
 
-  virtual void set(T value) override {
+  virtual void set(const T& value) override {
     ObservableValue<T>::set(value);
     this->save_configuration();
   }

--- a/src/sensesp/system/pwm_output.cpp
+++ b/src/sensesp/system/pwm_output.cpp
@@ -18,7 +18,7 @@ PWMOutput::PWMOutput(int pin, int pwm_channel) {
   }
 }
 
-void PWMOutput::set(float new_value) {
+void PWMOutput::set(const float& new_value) {
   uint8_t pwm_channel = default_channel_;
 
   set_pwm(pwm_channel, new_value);

--- a/src/sensesp/system/pwm_output.h
+++ b/src/sensesp/system/pwm_output.h
@@ -48,7 +48,7 @@ class PWMOutput : public ValueConsumer<float> {
    * pwm_channel is zero, the channel assigned when the PWMOutput instance
    * was instantiated will be used.
    */
-  virtual void set(float new_value) override;
+  virtual void set(const float& new_value) override;
 
   /**
    * Assigns the specified GPIO pin to the specified pwm channel.

--- a/src/sensesp/system/rgb_led.cpp
+++ b/src/sensesp/system/rgb_led.cpp
@@ -32,7 +32,7 @@ static float get_pwm(long rgb, int shift_right, bool common_anode) {
   }
 }
 
-void RgbLed::set(long new_value) {
+void RgbLed::set(const long& new_value) {
   if (led_r_channel_ >= 0) {
     float r = get_pwm(new_value, 16, common_anode_);
     PWMOutput::set_pwm(led_r_channel_, r);
@@ -49,7 +49,7 @@ void RgbLed::set(long new_value) {
   }
 }
 
-void RgbLed::set(bool new_value) {
+void RgbLed::set(const bool& new_value) {
   if (new_value) {
     set(led_on_rgb_);
   } else {

--- a/src/sensesp/system/rgb_led.h
+++ b/src/sensesp/system/rgb_led.h
@@ -55,14 +55,14 @@ class RgbLed : public Configurable,
    * Used to set the current display state of the LED.
    * @param new_value The RGB color to display.
    */
-  virtual void set(long new_value) override;
+  virtual void set(const long& new_value) override;
 
   /**
    * Used to set the current display state of the LED with a simple on/off
    * boolean value.  Using TRUE for new_value sets the color to the ON color.
    * Using FALSE uses the OFF color.
    */
-  virtual void set(bool new_value) override;
+  virtual void set(const bool& new_value) override;
 
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;

--- a/src/sensesp/system/system_status_led.cpp
+++ b/src/sensesp/system/system_status_led.cpp
@@ -56,7 +56,7 @@ void SystemStatusLed::set_ws_connected() {
   blinker_->set_pattern(ws_connected_pattern);
 }
 
-void SystemStatusLed::set(SystemStatus new_value) {
+void SystemStatusLed::set(const SystemStatus& new_value) {
   switch (new_value) {
     case SystemStatus::kWifiNoAP:
       this->set_wifi_no_ap();
@@ -82,6 +82,6 @@ void SystemStatusLed::set(SystemStatus new_value) {
   }
 }
 
-void SystemStatusLed::set(int new_value) { blinker_->blip(); }
+void SystemStatusLed::set(const int& new_value) { blinker_->blip(); }
 
 }  // namespace sensesp

--- a/src/sensesp/system/system_status_led.h
+++ b/src/sensesp/system/system_status_led.h
@@ -29,8 +29,8 @@ class SystemStatusLed : public ValueConsumer<SystemStatus>,
  public:
   SystemStatusLed(int pin);
 
-  virtual void set(SystemStatus new_value) override;
-  virtual void set(int new_value) override;
+  virtual void set(const SystemStatus& new_value) override;
+  virtual void set(const int& new_value) override;
 };
 
 }  // namespace sensesp

--- a/src/sensesp/system/task_queue_producer.h
+++ b/src/sensesp/system/task_queue_producer.h
@@ -44,7 +44,7 @@ class TaskQueueProducer : public ObservableValue<T> {
                     unsigned int poll_rate = 990)
       : TaskQueueProducer(value, ReactESP::app, queue_size, poll_rate) {}
 
-  virtual void set(T value) override {
+  virtual void set(const T& value) override {
     int retval;
     if (queue_size_ == 1) {
       retval = xQueueOverwrite(queue_, &value);

--- a/src/sensesp/system/valueconsumer.h
+++ b/src/sensesp/system/valueconsumer.h
@@ -26,9 +26,9 @@ class ValueConsumer {
    * automatically by a ValueProducer.
    * @param new_value the value of the input
    */
-  virtual void set(T new_value) {}
+  virtual void set(const T& new_value) {}
 
-  virtual void set_input(T new_value) {
+  virtual void set_input(const T& new_value) {
     static bool warned = false;
     if (!warned) {
       warned = true;

--- a/src/sensesp/system/valueproducer.h
+++ b/src/sensesp/system/valueproducer.h
@@ -109,7 +109,7 @@ class ValueProducer : virtual public Observable {
   /*
    * Set a new output value and notify consumers about it
    */
-  void emit(T new_value) {
+  void emit(const T& new_value) {
     this->output = new_value;
     Observable::notify();
   }

--- a/src/sensesp/transforms/air_density.cpp
+++ b/src/sensesp/transforms/air_density.cpp
@@ -8,7 +8,7 @@ namespace sensesp {
 
 AirDensity::AirDensity() : FloatTransform() {}
 
-void AirDensity::set(float input) {
+void AirDensity::set(const float& input) {
   // For more info on the calculation see
   // https://en.wikipedia.org/wiki/Density_of_air
 

--- a/src/sensesp/transforms/air_density.h
+++ b/src/sensesp/transforms/air_density.h
@@ -14,7 +14,7 @@ namespace sensesp {
 class AirDensity : public FloatTransform {
  public:
   AirDensity();
-  virtual void set(float input) override;
+  virtual void set(const float& input) override;
 
  private:
   float inputs[3];

--- a/src/sensesp/transforms/analogvoltage.cpp
+++ b/src/sensesp/transforms/analogvoltage.cpp
@@ -11,7 +11,7 @@ AnalogVoltage::AnalogVoltage(float max_voltage, float multiplier, float offset,
   load_configuration();
 }
 
-void AnalogVoltage::set(float input) {
+void AnalogVoltage::set(const float& input) {
   this->emit(((input * (max_voltage_ / MAX_ANALOG_OUTPUT)) * multiplier_) +
              offset_);
 }

--- a/src/sensesp/transforms/analogvoltage.h
+++ b/src/sensesp/transforms/analogvoltage.h
@@ -42,7 +42,7 @@ class AnalogVoltage : public FloatTransform {
  public:
   AnalogVoltage(float max_voltage = 3.3, float multiplier = 1.0,
                 float offset = 0.0, String config_path = "");
-  virtual void set(float input) override;
+  virtual void set(const float& input) override;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensesp/transforms/angle_correction.cpp
+++ b/src/sensesp/transforms/angle_correction.cpp
@@ -10,7 +10,7 @@ AngleCorrection::AngleCorrection(float offset, float min_angle,
   load_configuration();
 }
 
-void AngleCorrection::set(float input) {
+void AngleCorrection::set(const float& input) {
   // first the correction
   float x = input + offset_;
 

--- a/src/sensesp/transforms/angle_correction.h
+++ b/src/sensesp/transforms/angle_correction.h
@@ -20,7 +20,7 @@ namespace sensesp {
 class AngleCorrection : public FloatTransform {
  public:
   AngleCorrection(float offset, float min_angle = 0, String config_path = "");
-  virtual void set(float input) override;
+  virtual void set(const float& input) override;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensesp/transforms/change_filter.cpp
+++ b/src/sensesp/transforms/change_filter.cpp
@@ -20,7 +20,7 @@ ChangeFilter::ChangeFilter(float min_delta, float max_delta, int max_skips,
   skips_ = max_skips_ + 1;
 }
 
-void ChangeFilter::set(float new_value) {
+void ChangeFilter::set(const float& new_value) {
   float delta = absf(new_value - output);
   if ((delta >= min_delta_ && delta <= max_delta_) || skips_ > max_skips_) {
     skips_ = 0;

--- a/src/sensesp/transforms/change_filter.h
+++ b/src/sensesp/transforms/change_filter.h
@@ -35,7 +35,7 @@ class ChangeFilter : public FloatTransform {
   ChangeFilter(float min_delta = 0.0, float max_delta = 9999.0,
                int max_skips = 99, String config_path = "");
 
-  virtual void set(float new_value) override;
+  virtual void set(const float& new_value) override;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensesp/transforms/click_type.cpp
+++ b/src/sensesp/transforms/click_type.cpp
@@ -16,7 +16,7 @@ ClickType::ClickType(String config_path, uint16_t long_click_delay,
   load_configuration();
 }
 
-void ClickType::set(bool input) {
+void ClickType::set(const bool& input) {
   if (input) {
     on_button_press();
   } else {

--- a/src/sensesp/transforms/click_type.h
+++ b/src/sensesp/transforms/click_type.h
@@ -58,7 +58,7 @@ class ClickType : public Transform<bool, ClickTypes> {
    */
   static bool is_click(ClickTypes value);
 
-  virtual void set(bool input) override;
+  virtual void set(const bool& input) override;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensesp/transforms/curveinterpolator.cpp
+++ b/src/sensesp/transforms/curveinterpolator.cpp
@@ -32,7 +32,7 @@ CurveInterpolator::CurveInterpolator(std::set<Sample>* defaults,
   load_configuration();
 }
 
-void CurveInterpolator::set(float input) {
+void CurveInterpolator::set(const float& input) {
   float x0 = 0.0;
   float y0 = 0.0;
 

--- a/src/sensesp/transforms/curveinterpolator.h
+++ b/src/sensesp/transforms/curveinterpolator.h
@@ -55,7 +55,7 @@ class CurveInterpolator : public FloatTransform {
   CurveInterpolator(std::set<Sample>* defaults = NULL, String config_path = "");
 
   // Set and retrieve the transformed value
-  void set(float input) override;
+  void set(const float& input) override;
 
   // Web UI configuration methods
   CurveInterpolator* set_input_title(String input_title) {

--- a/src/sensesp/transforms/debounce.h
+++ b/src/sensesp/transforms/debounce.h
@@ -42,7 +42,7 @@ class Debounce : public SymmetricTransform<T> {
     this->load_configuration();
   }
 
-  virtual void set(T input) override {
+  virtual void set(const T& input) override {
     // Input has changed since the last emit, or this is the first
     // input since the program started to run.
 

--- a/src/sensesp/transforms/dew_point.cpp
+++ b/src/sensesp/transforms/dew_point.cpp
@@ -6,7 +6,7 @@ namespace sensesp {
 
 DewPoint::DewPoint() : FloatTransform() {}
 
-void DewPoint::set(float input) {
+void DewPoint::set(const float& input) {
   // Dew point is calculated with Arden Buck Equation and Arden Buck valuation
   // sets For more info on the calculation see
   // https://en.wikipedia.org/wiki/Dew_point#Calculating_the_dew_point

--- a/src/sensesp/transforms/dew_point.h
+++ b/src/sensesp/transforms/dew_point.h
@@ -15,7 +15,7 @@ namespace sensesp {
 class DewPoint : public FloatTransform {
  public:
   DewPoint();
-  virtual void set(float input) override;
+  virtual void set(const float& input) override;
 
  private:
   float inputs[2];

--- a/src/sensesp/transforms/difference.cpp
+++ b/src/sensesp/transforms/difference.cpp
@@ -9,7 +9,7 @@ Difference::Difference(float k1, float k2, String config_path)
   load_configuration();
 }
 
-void Difference::set(float input) {
+void Difference::set(const float& input) {
   this->emit(k1 * inputs[0] - k2 * inputs[1]);
 }
 

--- a/src/sensesp/transforms/difference.h
+++ b/src/sensesp/transforms/difference.h
@@ -9,7 +9,7 @@ namespace sensesp {
 class Difference : public FloatTransform {
  public:
   Difference(float k1, float k2, String config_path = "");
-  virtual void set(float input) override;
+  virtual void set(const float& input) override;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensesp/transforms/frequency.cpp
+++ b/src/sensesp/transforms/frequency.cpp
@@ -11,7 +11,7 @@ Frequency::Frequency(float multiplier, String config_path)
   last_update_ = millis();
 }
 
-void Frequency::set(int input) {
+void Frequency::set(const int& input) {
   unsigned long cur_millis = millis();
   unsigned long elapsed_millis = cur_millis - last_update_;
   last_update_ = cur_millis;

--- a/src/sensesp/transforms/frequency.h
+++ b/src/sensesp/transforms/frequency.h
@@ -21,7 +21,7 @@ namespace sensesp {
 class Frequency : public Transform<int, float> {
  public:
   Frequency(float multiplier = 1, String config_path = "");
-  virtual void set(int input) override;
+  virtual void set(const int& input) override;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensesp/transforms/heat_index.cpp
+++ b/src/sensesp/transforms/heat_index.cpp
@@ -6,7 +6,7 @@ namespace sensesp {
 
 HeatIndexTemperature::HeatIndexTemperature() : FloatTransform() {}
 
-void HeatIndexTemperature::set(float input) {
+void HeatIndexTemperature::set(const float& input) {
   // The following equation approximate the heat index
   // using both Steadman's and Rothfusz equations
   // See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3801457/
@@ -77,7 +77,7 @@ void HeatIndexTemperature::set(float input) {
 
 HeatIndexEffect::HeatIndexEffect() : Transform<float, String>() {}
 
-void HeatIndexEffect::set(float input) {
+void HeatIndexEffect::set(const float& input) {
   float heat_index_temperature = input - 273.15;  // celsius = kelvin - 273.15
   String heat_index_effect = "";
   if (heat_index_temperature > 54) {

--- a/src/sensesp/transforms/heat_index.h
+++ b/src/sensesp/transforms/heat_index.h
@@ -16,7 +16,7 @@ namespace sensesp {
 class HeatIndexTemperature : public FloatTransform {
  public:
   HeatIndexTemperature();
-  virtual void set(float input) override;
+  virtual void set(const float& input) override;
 
  private:
   float inputs[2];
@@ -32,7 +32,7 @@ class HeatIndexTemperature : public FloatTransform {
 class HeatIndexEffect : public Transform<float, String> {
  public:
   HeatIndexEffect();
-  virtual void set(float input) override;
+  virtual void set(const float& input) override;
 };
 
 }  // namespace sensesp

--- a/src/sensesp/transforms/integrator.h
+++ b/src/sensesp/transforms/integrator.h
@@ -37,7 +37,7 @@ class Integrator : public Transform<C, P> {
     this->emit(value);
   }
 
-  virtual void set(C input) override final {
+  virtual void set(const C& input) override final {
     value += input * k;
     this->emit(value);
   }

--- a/src/sensesp/transforms/lambda_transform.h
+++ b/src/sensesp/transforms/lambda_transform.h
@@ -177,7 +177,7 @@ class LambdaTransform : public Transform<IN, OUT> {
     this->load_configuration();
   }
 
-  void set(IN input) override {
+  void set(const IN& input) override {
     switch (num_params) {
       case 0:
         this->output = function0(input);

--- a/src/sensesp/transforms/median.cpp
+++ b/src/sensesp/transforms/median.cpp
@@ -9,7 +9,7 @@ Median::Median(unsigned int sample_size, String config_path)
   buf_.clear();
 }
 
-void Median::set(float input) {
+void Median::set(const float& input) {
   buf_.push_back(input);
   if (buf_.size() >= sample_size_) {
     // Its time to output a value

--- a/src/sensesp/transforms/median.h
+++ b/src/sensesp/transforms/median.h
@@ -20,7 +20,7 @@ namespace sensesp {
 class Median : public FloatTransform {
  public:
   Median(unsigned int sample_size = 10, String config_path = "");
-  virtual void set(float input) override;
+  virtual void set(const float& input) override;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensesp/transforms/moving_average.cpp
+++ b/src/sensesp/transforms/moving_average.cpp
@@ -14,7 +14,7 @@ MovingAverage::MovingAverage(int sample_size, float multiplier,
   load_configuration();
 }
 
-void MovingAverage::set(float input) {
+void MovingAverage::set(const float& input) {
   // So the first value to be included in the average doesn't default to 0.0
   if (!initialized_) {
     buf_.assign(sample_size_, input);

--- a/src/sensesp/transforms/moving_average.h
+++ b/src/sensesp/transforms/moving_average.h
@@ -34,7 +34,7 @@ class MovingAverage : public FloatTransform {
    * */
   MovingAverage(int sample_size, float multiplier = 1.0,
                 String config_path = "");
-  virtual void set(float input) override;
+  virtual void set(const float& input) override;
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
   virtual String get_config_schema() override;

--- a/src/sensesp/transforms/press_repeater.cpp
+++ b/src/sensesp/transforms/press_repeater.cpp
@@ -31,11 +31,11 @@ PressRepeater::PressRepeater(String config_path, int integer_false,
   });
 }
 
-void PressRepeater::set(int new_value) {
+void PressRepeater::set(const int& new_value) {
   this->set(new_value != integer_false_);
 }
 
-void PressRepeater::set(bool new_value) {
+void PressRepeater::set(const bool& new_value) {
   if (new_value != pushed_) {
     pushed_ = new_value;
 

--- a/src/sensesp/transforms/press_repeater.h
+++ b/src/sensesp/transforms/press_repeater.h
@@ -43,8 +43,8 @@ class PressRepeater : public BooleanTransform, public IntConsumer {
   PressRepeater(String config_path = "", int integer_false = 0,
                 int repeat_start_interval = 1500, int repeat_interval = 250);
 
-  virtual void set(bool new_value) override;
-  virtual void set(int new_value) override;
+  virtual void set(const bool& new_value) override;
+  virtual void set(const int& new_value) override;
 
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;

--- a/src/sensesp/transforms/repeat.h
+++ b/src/sensesp/transforms/repeat.h
@@ -67,7 +67,7 @@ class RepeatStopping : public Repeat<T> {
         this->interval_, [this]() { this->repeat_function(); });
   }
 
-  virtual void set(T input) override {
+  virtual void set(const T& input) override {
     this->emit(input);
     age_ = 0;
     if (this->repeat_reaction_ != nullptr) {
@@ -117,7 +117,7 @@ class RepeatExpiring : public Repeat<T> {
         this->interval_, [this]() { this->repeat_function(); });
   }
 
-  virtual void set(T input) override {
+  virtual void set(const T& input) override {
     this->emit(input);
     age_ = 0;
     if (this->repeat_reaction_ != nullptr) {

--- a/src/sensesp/transforms/threshold.cpp
+++ b/src/sensesp/transforms/threshold.cpp
@@ -3,7 +3,7 @@
 namespace sensesp {
 
 template <class C, class P>
-void ThresholdTransform<C, P>::set(C input) {
+void ThresholdTransform<C, P>::set(const C& input) {
   if (input >= min_value_ && input <= max_value_) {
     this->output = in_range_;
   } else {

--- a/src/sensesp/transforms/threshold.h
+++ b/src/sensesp/transforms/threshold.h
@@ -27,7 +27,7 @@ class ThresholdTransform : public Transform<C, P> {
         in_range_{in_range} {
     this->load_configuration();
   };
-  virtual void set(C new_value) override;
+  virtual void set(const C& new_value) override;
 
  protected:
   C min_value_;

--- a/src/sensesp/transforms/throttle.h
+++ b/src/sensesp/transforms/throttle.h
@@ -31,7 +31,7 @@ class Throttle : public SymmetricTransform<T> {
   Throttle(long min_interval)
       : SymmetricTransform<T>(), min_interval_{min_interval} {}
 
-  void set(T input) override {
+  void set(const T& input) override {
     if (age_ < min_interval_) {
       return;
     }

--- a/src/sensesp/transforms/time_counter.h
+++ b/src/sensesp/transforms/time_counter.h
@@ -35,7 +35,7 @@ class TimeCounter : public Transform<T, float> {
     this->load_configuration();
   }
 
-  virtual void set(T input) override {
+  virtual void set(const T& input) override {
     if (previous_state_ == -1) {
       // Initialize the previous state
       previous_state_ = (bool)input;

--- a/src/sensesp/transforms/timestring.cpp
+++ b/src/sensesp/transforms/timestring.cpp
@@ -6,7 +6,7 @@ namespace sensesp {
 TimeString::TimeString(String config_path)
     : Transform<time_t, String>(config_path) {}
 
-void TimeString::set(time_t input) {
+void TimeString::set(const time_t& input) {
   char buf[sizeof "2011-10-08T07:07:09Z"];
   strftime(buf, sizeof buf, "%FT%TZ", gmtime(&input));
   this->emit(String(buf));

--- a/src/sensesp/transforms/timestring.h
+++ b/src/sensesp/transforms/timestring.h
@@ -15,7 +15,7 @@ namespace sensesp {
 class TimeString : public Transform<time_t, String> {
  public:
   TimeString(String config_path = "");
-  virtual void set(time_t input) override;
+  virtual void set(const time_t& input) override;
 };
 
 }  // namespace sensesp

--- a/src/sensesp/transforms/truth_text.cpp
+++ b/src/sensesp/transforms/truth_text.cpp
@@ -35,7 +35,7 @@ bool TextToTruth::is_valid_false(String input) {
   return false;
 }
 
-void TextToTruth::set(String input) {
+void TextToTruth::set(const String& input) {
   this->emit(TextToTruth::is_valid_true(input));
 }
 
@@ -46,7 +46,7 @@ TruthToText::TruthToText(String true_value, String false_value)
   truth_value_[1] = true_value;
 }
 
-void TruthToText::set(bool input) {
+void TruthToText::set(const bool& input) {
   if (input) {
     this->emit(truth_value_[1]);
   } else {

--- a/src/sensesp/transforms/truth_text.h
+++ b/src/sensesp/transforms/truth_text.h
@@ -23,7 +23,7 @@ namespace sensesp {
  */
 class TextToTruth : public Transform<String, bool> {
  public:
-  virtual void set(String input) override;
+  virtual void set(const String& input) override;
 
   /**
    * Returns TRUE if `value` represents one of the truth values recognized by
@@ -49,7 +49,7 @@ class TruthToText : public Transform<bool, String> {
  public:
   TruthToText(String true_value = "ON", String false_value = "OFF");
 
-  virtual void set(bool input) override;
+  virtual void set(const bool& input) override;
 
  protected:
   String* truth_value_;

--- a/src/sensesp/transforms/voltage_multiplier.cpp
+++ b/src/sensesp/transforms/voltage_multiplier.cpp
@@ -6,7 +6,7 @@ VoltageMultiplier::VoltageMultiplier(uint16_t R1, uint16_t R2,
                                      String config_path)
     : FloatTransform(config_path), R1_{R1}, R2_{R2} {}
 
-void VoltageMultiplier::set(float input) {
+void VoltageMultiplier::set(const float& input) {
   // Ohms Law at work!
   this->emit(input * (((float)R1_ + (float)R2_) / (float)R2_));
 }

--- a/src/sensesp/transforms/voltage_multiplier.h
+++ b/src/sensesp/transforms/voltage_multiplier.h
@@ -31,7 +31,7 @@ class VoltageMultiplier : public FloatTransform {
  public:
   VoltageMultiplier(uint16_t R1, uint16_t R2, String config_path = "");
 
-  virtual void set(float input);
+  virtual void set(const float& input);
 
  private:
   uint16_t R1_;

--- a/src/sensesp/transforms/voltagedivider.cpp
+++ b/src/sensesp/transforms/voltagedivider.cpp
@@ -7,7 +7,7 @@ VoltageDividerR1::VoltageDividerR1(float R2, float Vin, String config_path)
   load_configuration();
 }
 
-void VoltageDividerR1::set(float Vout) {
+void VoltageDividerR1::set(const float& Vout) {
   this->emit((Vin_ - Vout) * R2_ / Vout);
 }
 
@@ -48,7 +48,7 @@ VoltageDividerR2::VoltageDividerR2(float R1, float Vin, String config_path)
   load_configuration();
 }
 
-void VoltageDividerR2::set(float Vout) {
+void VoltageDividerR2::set(const float& Vout) {
   this->emit((Vout * R1_) / (Vin_ - Vout));
 }
 

--- a/src/sensesp/transforms/voltagedivider.h
+++ b/src/sensesp/transforms/voltagedivider.h
@@ -34,7 +34,7 @@ class VoltageDividerR1 : public SymmetricTransform<float> {
  public:
   VoltageDividerR1(float R2, float Vin = 3.3, String config_path = "");
 
-  virtual void set(float Vout) override;
+  virtual void set(const float& Vout) override;
 
   virtual void get_configuration(JsonObject& doc) override;
   virtual bool set_configuration(const JsonObject& config) override;
@@ -74,7 +74,7 @@ class VoltageDividerR2 : public SymmetricTransform<float> {
  public:
   VoltageDividerR2(float R1, float Vin = 3.3, String config_path = "");
 
-  virtual void set(float Vout) override;
+  virtual void set(const float& Vout) override;
 
   // For reading and writing the configuration of this transformation
   virtual void get_configuration(JsonObject& doc) override;

--- a/src/sensesp/ui/ui_output.h
+++ b/src/sensesp/ui/ui_output.h
@@ -83,7 +83,7 @@ class UIOutput : public UIOutputBase, public ObservableValue<T> {
     return obj;
   }
 
-  void set(T new_value) override { this->ValueProducer<T>::emit(new_value); }
+  void set(const T& new_value) override { this->ValueProducer<T>::emit(new_value); }
 };
 }  // namespace sensesp
 


### PR DESCRIPTION
`set()` no longer copies its argument but provides a const reference. This should make it quite a bit faster if the argument is a complex class.