### PR TITLE
Add an event_loop() convenience function

### DIFF
--- a/src/sensesp.cpp
+++ b/src/sensesp.cpp
@@ -1,0 +1,11 @@
+#include "sensesp.h"
+
+#include "sensesp_base_app.h"
+
+namespace sensesp {
+
+reactesp::EventLoop* event_loop() {
+  return SensESPBaseApp::get_event_loop();
+}
+
+}  // namespace sensesp

--- a/src/sensesp.h
+++ b/src/sensesp.h
@@ -19,6 +19,8 @@ namespace sensesp {
 
 typedef std::function<void()> void_cb_func;
 
+reactesp::EventLoop* event_loop();
+
 }  // namespace sensesp
 
 #endif


### PR DESCRIPTION
Calling `SensESPBaseApp::get_event_loop()` all the time grew old, so I added an `event_loop()` convenience function that just does the same.
