### PR TITLE
Rename ValueProducer::output

### DIFF
--- a/src/sensesp/controllers/smart_switch_controller.h
+++ b/src/sensesp/controllers/smart_switch_controller.h
@@ -74,21 +74,21 @@ class SmartSwitchController : public BooleanTransform,
   /// Used to store configuration internally.
   class SyncPath {
    public:
-    String sk_sync_path;
-    BoolSKPutRequest* put_request;
+    BoolSKPutRequest* put_request_;
+    String sk_sync_path_;
 
     SyncPath();
     SyncPath(String sk_sync_path);
 
     friend bool operator<(const SyncPath& lhs, const SyncPath& rhs) {
-      return lhs.sk_sync_path < rhs.sk_sync_path;
+      return lhs.sk_sync_path_ < rhs.sk_sync_path_;
     }
   };
 
  protected:
-  bool is_on = false;
+  bool is_on_ = false;
   bool auto_initialize_;
-  std::set<SyncPath> sync_paths;
+  std::set<SyncPath> sync_paths_;
 };
 
 const String ConfigSchema(const SmartSwitchController& obj) {

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -44,12 +44,12 @@ class WiFiStateProducer : public ValueProducer<WiFiState> {
 
  protected:
   WiFiStateProducer() {
-    this->output = WiFiState::kWifiNoAP;
+    this->output_ = WiFiState::kWifiNoAP;
 
     setup_wifi_callbacks();
 
     // Emit the current state as soon as the event loop starts
-    event_loop()->onDelay(0, [this]() { this->emit(this->output); });
+    event_loop()->onDelay(0, [this]() { this->emit(this->output_); });
   }
 
   void setup_wifi_callbacks() {

--- a/src/sensesp/sensors/analog_input.cpp
+++ b/src/sensesp/sensors/analog_input.cpp
@@ -13,15 +13,15 @@ AnalogInput::AnalogInput(uint8_t pin, unsigned int read_delay,
       pin{pin},
       read_delay{read_delay},
       output_scale{output_scale} {
-  analog_reader = new AnalogReader(pin);
+  analog_reader_ = new AnalogReader(pin);
   load();
 
-  if (this->analog_reader->configure()) {
+  if (this->analog_reader_->configure()) {
     event_loop()->onRepeat(read_delay, [this]() { this->update(); });
   }
 }
 
-void AnalogInput::update() { this->emit(output_scale * analog_reader->read()); }
+void AnalogInput::update() { this->emit(output_scale * analog_reader_->read()); }
 
 bool AnalogInput::to_json(JsonObject& root) {
   root["read_delay"] = read_delay;

--- a/src/sensesp/sensors/analog_input.h
+++ b/src/sensesp/sensors/analog_input.h
@@ -51,7 +51,7 @@ class AnalogInput : public FloatSensor {
   uint8_t pin{};
   unsigned int read_delay;
   float output_scale;
-  BaseAnalogReader* analog_reader{};
+  BaseAnalogReader* analog_reader_;
   void update();
 };
 

--- a/src/sensesp/sensors/analog_reader.h
+++ b/src/sensesp/sensors/analog_reader.h
@@ -23,7 +23,7 @@ class BaseAnalogReader {
 };
 
 class ESP32AnalogReader : public BaseAnalogReader {
- private:
+ protected:
   int pin_;
   adc_atten_t attenuation_ = ADC_ATTEN_DB_12;
   // This should work with ESP32 and newer variants, ADCs are different

--- a/src/sensesp/sensors/digital_input.h
+++ b/src/sensesp/sensors/digital_input.h
@@ -99,7 +99,7 @@ class DigitalInputCounter : public DigitalInput, public Sensor<int> {
 
     event_loop()->onRepeat(read_delay_, [this]() {
       noInterrupts();
-      output = counter_;
+      output_ = counter_;
       counter_ = 0;
       interrupts();
       notify();
@@ -206,19 +206,19 @@ class DigitalInputChange : public DigitalInput, public Sensor<bool> {
         interrupt_type_{interrupt_type},
         triggered_{true} {
     load();
-    output = (bool)digitalRead(pin_);
-    last_output_ = !output;  // ensure that we always send the first output
+    output_ = (bool)digitalRead(pin_);
+    last_output_ = !output_;  // ensure that we always send the first output_
 
     event_loop()->onInterrupt(pin_, interrupt_type_, [this]() {
-      output = (bool)digitalRead(pin_);
+      output_ = (bool)digitalRead(pin_);
       triggered_ = true;
     });
 
     event_loop()->onTick([this]() {
-      if (triggered_ && (output != last_output_)) {
+      if (triggered_ && (output_ != last_output_)) {
         noInterrupts();
         triggered_ = false;
-        last_output_ = output;
+        last_output_ = output_;
         interrupts();
         notify();
       }

--- a/src/sensesp/sensors/system_info.cpp
+++ b/src/sensesp/sensors/system_info.cpp
@@ -16,7 +16,7 @@ void SystemHz::update() {
     return;
   }
 
-  output = (tick_count_ * 1000) / elapsed_millis_;
+  output_ = (tick_count_ * 1000) / elapsed_millis_;
 
   tick_count_ = 0;
   elapsed_millis_ = 0;

--- a/src/sensesp/signalk/signalk_output.h
+++ b/src/sensesp/signalk/signalk_output.h
@@ -42,7 +42,7 @@ class SKOutput : public SKEmitter, public SymmetricTransform<T> {
 
   virtual void as_signalk_json(JsonDocument& doc) override {
     doc["path"] = this->get_sk_path();
-    doc["value"] = ValueProducer<T>::output;
+    doc["value"] = ValueProducer<T>::output_;
   }
 
   virtual bool to_json(JsonObject& root) override {
@@ -93,7 +93,7 @@ class SKOutputRawJson : public SKOutput<String> {
 
   virtual void as_signalk_json(JsonDocument& doc) override {
     doc["path"] = this->get_sk_path();
-    doc["value"] = serialized(ValueProducer<String>::output);
+    doc["value"] = serialized(ValueProducer<String>::output_);
   }
 };
 

--- a/src/sensesp/signalk/signalk_put_request.h
+++ b/src/sensesp/signalk/signalk_put_request.h
@@ -145,14 +145,14 @@ class SKPutRequest : public SKPutRequestBase,
   SKPutRequest(String sk_path, String config_path = "",
                bool ignore_duplicates = true, uint32_t timeout = 5000)
       : SKPutRequestBase(sk_path, config_path, timeout),
-        ignore_duplicates{ignore_duplicates} {}
+        ignore_duplicates_{ignore_duplicates} {}
 
   virtual void set(const T& new_value) override {
-    if (ignore_duplicates && new_value == value) {
+    if (ignore_duplicates_ && new_value == value_) {
       return;
     }
     if (!request_pending()) {
-      this->value = new_value;
+      this->value_ = new_value;
       send_put_request();
     } else {
       ESP_LOGW(__FILENAME__,
@@ -161,12 +161,12 @@ class SKPutRequest : public SKPutRequestBase,
   };
 
   virtual void set_put_value(JsonObject& put_data) override {
-    put_data["value"] = value;
+    put_data["value"] = value_;
   };
 
  protected:
-  T value;
-  bool ignore_duplicates;
+  T value_;
+  bool ignore_duplicates_;
 };
 
 template <typename T>

--- a/src/sensesp/signalk/signalk_time.cpp
+++ b/src/sensesp/signalk/signalk_time.cpp
@@ -10,7 +10,7 @@ SKOutputTime::SKOutputTime(const String& sk_path, const String& config_path)
 
 void SKOutputTime::as_signalk_json(JsonDocument& doc){
   doc["path"] = this->sk_path_;
-  doc["value"] = output;
+  doc["value"] = output_;
 }
 
 bool SKOutputTime::to_json(JsonObject& doc) {

--- a/src/sensesp/signalk/signalk_types.cpp
+++ b/src/sensesp/signalk/signalk_types.cpp
@@ -16,10 +16,10 @@ template <>
 void SKOutput<Position>::as_signalk_json(JsonDocument& doc) {
   doc["path"] = this->get_sk_path();
   JsonObject value = doc["value"].to<JsonObject>();
-  value["latitude"] = output.latitude;
-  value["longitude"] = output.longitude;
-  if (output.altitude != kPositionInvalidAltitude) {
-    value["altitude"] = output.altitude;
+  value["latitude"] = output_.latitude;
+  value["longitude"] = output_.longitude;
+  if (output_.altitude != kPositionInvalidAltitude) {
+    value["altitude"] = output_.altitude;
   }
 }
 
@@ -27,10 +27,10 @@ template <>
 void SKOutput<ENUVector>::as_signalk_json(JsonDocument& doc) {
   doc["path"] = this->get_sk_path();
   JsonObject value = doc["value"].to<JsonObject>();
-  value["east"] = output.east;
-  value["north"] = output.north;
-  if (output.up != kPositionInvalidAltitude) {
-    value["up"] = output.up;
+  value["east"] = output_.east;
+  value["north"] = output_.north;
+  if (output_.up != kPositionInvalidAltitude) {
+    value["up"] = output_.up;
   }
 }
 
@@ -38,9 +38,9 @@ template <>
 void SKOutput<AttitudeVector>::as_signalk_json(JsonDocument& doc) {
   doc["path"] = this->get_sk_path();
   JsonObject value = doc["value"].to<JsonObject>();
-  value["roll"] = output.roll;
-  value["pitch"] = output.pitch;
-  value["yaw"] = output.yaw;
+  value["roll"] = output_.roll;
+  value["pitch"] = output_.pitch;
+  value["yaw"] = output_.yaw;
 }
 
 }  // namespace sensesp

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -88,7 +88,7 @@ class SKWSClient : virtual public FileSystemSaveable,
    */
   void sendTXT(String& payload);
 
- private:
+ protected:
   // these are the actually used values
   String server_address_ = "";
   uint16_t server_port_ = 80;

--- a/src/sensesp/system/observablevalue.h
+++ b/src/sensesp/system/observablevalue.h
@@ -14,12 +14,12 @@ class ObservableValue;
 
 template <class T>
 bool operator==(ObservableValue<T> const& lhs, T const& rhs) {
-  return lhs.output == rhs;
+  return lhs.output_ == rhs;
 }
 
 template <class T>
 bool operator!=(ObservableValue<T> const& lhs, T const& rhs) {
-  return lhs.output != rhs;
+  return lhs.output_ != rhs;
 }
 
 /**
@@ -41,35 +41,35 @@ class ObservableValue : public ValueConsumer<T>, public ValueProducer<T> {
   }
 
   T& operator++() {
-    set(this->output + 1);
-    return this->output;
+    set(this->output_ + 1);
+    return this->output_;
   }
 
   T& operator--() {
-    set(this->output - 1);
-    return this->output;
+    set(this->output_ - 1);
+    return this->output_;
   }
 
   T operator++(int) {
-    T old = this->output;
-    set(this->output + 1);
+    T old = this->output_;
+    set(this->output_ + 1);
     return old;
   }
 
   T operator--(int) {
-    T old = this->output;
-    set(this->output - 1);
+    T old = this->output_;
+    set(this->output_ - 1);
     return old;
   }
 
   const T& operator+=(const T& value) {
-    set(this->output + value);
-    return this->output;
+    set(this->output_ + value);
+    return this->output_;
   }
 
   const T& operator-=(const T& value) {
-    set(this->output - value);
-    return this->output;
+    set(this->output_ - value);
+    return this->output_;
   }
 
  protected:
@@ -96,7 +96,7 @@ class PersistingObservableValue : public ObservableValue<T>,
     load();
 
     // Emit the current state as soon as the event loop starts
-    event_loop()->onDelay(0, [this]() { this->emit(this->output); });
+    event_loop()->onDelay(0, [this]() { this->emit(this->output_); });
   }
 
   virtual void set(const T& value) override {
@@ -105,7 +105,7 @@ class PersistingObservableValue : public ObservableValue<T>,
   }
 
   virtual bool to_json(JsonObject& doc) override {
-    doc["value"] = this->output;
+    doc["value"] = this->output_;
     return true;
   }
 

--- a/src/sensesp/system/stream_producer.h
+++ b/src/sensesp/system/stream_producer.h
@@ -15,13 +15,12 @@ namespace sensesp {
 class StreamCharProducer : public ValueProducer<char> {
  public:
   StreamCharProducer(Stream* stream) : stream_{stream} {
-    read_event_ =
-        event_loop()->onAvailable(*stream_, [this]() {
-          while (stream_->available()) {
-            char c = stream_->read();
-            this->emit(c);
-          }
-        });
+    read_event_ = event_loop()->onAvailable(*stream_, [this]() {
+      while (stream_->available()) {
+        char c = stream_->read();
+        this->emit(c);
+      }
+    });
   }
 
  protected:
@@ -34,28 +33,29 @@ class StreamCharProducer : public ValueProducer<char> {
  */
 class StreamLineProducer : public ValueProducer<String> {
  public:
-  StreamLineProducer(Stream* stream, int max_line_length = 256)
+  StreamLineProducer(Stream* stream,
+                     reactesp::EventLoop* event_loop = event_loop(),
+                     int max_line_length = 256)
       : stream_{stream}, max_line_length_{max_line_length} {
     static int buf_pos = 0;
     buf_ = new char[max_line_length_ + 1];
-    read_event_ =
-        event_loop()->onAvailable(*stream_, [this]() {
-          while (stream_->available()) {
-            char c = stream_->read();
-            if (c == '\n') {
-              // Include the newline character in the output
-              buf_[buf_pos++] = c;
-              buf_[buf_pos] = '\0';
-              this->emit(buf_);
-              buf_pos = 0;
-            } else {
-              buf_[buf_pos++] = c;
-              if (buf_pos >= max_line_length_ - 1) {
-                buf_pos = 0;
-              }
-            }
+    read_event_ = event_loop->onAvailable(*stream_, [this]() {
+      while (stream_->available()) {
+        char c = stream_->read();
+        if (c == '\n') {
+          // Include the newline character in the output
+          buf_[buf_pos++] = c;
+          buf_[buf_pos] = '\0';
+          this->emit(buf_);
+          buf_pos = 0;
+        } else {
+          buf_[buf_pos++] = c;
+          if (buf_pos >= max_line_length_ - 1) {
+            buf_pos = 0;
           }
-        });
+        }
+      }
+    });
   }
 
  protected:

--- a/src/sensesp/system/valueproducer.h
+++ b/src/sensesp/system/valueproducer.h
@@ -24,12 +24,12 @@ template <typename T>
 class ValueProducer : virtual public Observable {
  public:
   ValueProducer() {}
-  ValueProducer(const T& initial_value) : output(initial_value) {}
+  ValueProducer(const T& initial_value) : output_(initial_value) {}
 
   /**
    * Returns the current value of this producer
    */
-  virtual const T& get() const { return output; }
+  virtual const T& get() const { return output_; }
 
   /**
    * Connects this producer to the specified consumer, registering that
@@ -110,7 +110,7 @@ class ValueProducer : virtual public Observable {
    * Set a new output value and notify consumers about it
    */
   void emit(const T& new_value) {
-    this->output = new_value;
+    this->output_ = new_value;
     Observable::notify();
   }
 
@@ -119,7 +119,7 @@ class ValueProducer : virtual public Observable {
    * The current value of this producer is stored here in this output member
    * (unless descendant classes override ValueProducer::get())
    */
-  T output;
+  T output_;
 };
 
 typedef ValueProducer<float> FloatProducer;

--- a/src/sensesp/transforms/change_filter.cpp
+++ b/src/sensesp/transforms/change_filter.cpp
@@ -20,7 +20,7 @@ ChangeFilter::ChangeFilter(float min_delta, float max_delta, int max_skips,
 }
 
 void ChangeFilter::set(const float& new_value) {
-  float delta = absf(new_value - output);
+  float delta = absf(new_value - output_);
   if ((delta >= min_delta_ && delta <= max_delta_) || skips_ > max_skips_) {
     skips_ = 0;
     this->emit(new_value);

--- a/src/sensesp/transforms/curveinterpolator.cpp
+++ b/src/sensesp/transforms/curveinterpolator.cpp
@@ -7,10 +7,10 @@ namespace sensesp {
 CurveInterpolator::Sample::Sample() = default;
 
 CurveInterpolator::Sample::Sample(float input, float output)
-    : input{input}, output{output} {}
+    : input_{input}, output_{output} {}
 
 CurveInterpolator::Sample::Sample(JsonObject& obj)
-    : input{obj["input"]}, output{obj["output"]} {}
+    : input_{obj["input"]}, output_{obj["output"]} {}
 
 /**
  * @brief Construct a new CurveInterpolator object
@@ -34,29 +34,29 @@ CurveInterpolator::CurveInterpolator(std::set<Sample>* defaults,
 
 void CurveInterpolator::set(const float& input) {
   if (samples_.empty()) {
-    output = 0;  // or any default output if no samples are available
+    output_ = 0;  // or any default output if no samples are available
     notify();
     return;
   }
 
   std::set<Sample>::iterator it = samples_.begin();
-  float x0 = it->input;
-  float y0 = it->output;
+  float x0 = it->input_;
+  float y0 = it->output_;
 
   // Check if the input is below the lowest sample point
   if (input < x0) {
     // Need to extrapolate below the first point
     if (samples_.size() > 1) {
       auto second_it = std::next(it);
-      float x1 = second_it->input;
-      float y1 = second_it->output;
+      float x1 = second_it->input_;
+      float y1 = second_it->output_;
       float const gradient = (y1 - y0) / (x1 - x0);
 
-      output = y0 + gradient *
+      output_ = y0 + gradient *
                         (input -
                          x0);  // Extrapolate using the first segment's gradient
     } else {
-      output = y0;  // Only one sample, output its value
+      output_ = y0;  // Only one sample, output its value
     }
     notify();
     return;
@@ -64,9 +64,9 @@ void CurveInterpolator::set(const float& input) {
 
   // Search for the correct interval or the last sample point
   while (it != samples_.end()) {
-    if (input > it->input) {
-      x0 = it->input;
-      y0 = it->output;
+    if (input > it->input_) {
+      x0 = it->input_;
+      y0 = it->output_;
       ++it;
     } else {
       break;
@@ -75,22 +75,22 @@ void CurveInterpolator::set(const float& input) {
 
   // Interpolate or extrapolate above the highest point
   if (it != samples_.end()) {
-    float x1 = it->input;
-    float y1 = it->output;
-    output = (y0 * (x1 - input) + y1 * (input - x0)) / (x1 - x0);
+    float x1 = it->input_;
+    float y1 = it->output_;
+    output_ = (y0 * (x1 - input) + y1 * (input - x0)) / (x1 - x0);
   } else {
     // Hit the end of the table with no match, calculate output using the
     // gradient from the last two points
     auto last = samples_.rbegin();
     auto second_last = std::next(last);
-    float x1 = last->input;
-    float y1 = last->output;
-    float x2 = second_last->input;
-    float y2 = second_last->output;
+    float x1 = last->input_;
+    float y1 = last->output_;
+    float x2 = second_last->input_;
+    float y2 = second_last->output_;
     float const gradient = (y1 - y2) / (x1 - x2);
 
     // Extrapolate using the gradient
-    output = y1 + gradient * (input - x1);
+    output_ = y1 + gradient * (input - x1);
   }
 
   notify();
@@ -105,8 +105,8 @@ bool CurveInterpolator::to_json(JsonObject& doc) {
       ESP_LOGE(__FILENAME__, "No memory for sample");
       return false;
     }
-    entry["input"] = sample.input;
-    entry["output"] = sample.output;
+    entry["input"] = sample.input_;
+    entry["output"] = sample.output_;
   }
   return true;
 }

--- a/src/sensesp/transforms/curveinterpolator.h
+++ b/src/sensesp/transforms/curveinterpolator.h
@@ -40,15 +40,15 @@ class CurveInterpolator : public FloatTransform {
  public:
   class Sample {
    public:
-    float input{};
-    float output{};
+    float input_{};
+    float output_{};
 
     Sample();
     Sample(float input, float output);
     Sample(JsonObject& obj);
 
     friend bool operator<(const Sample& lhs, const Sample& rhs) {
-      return lhs.input < rhs.input;
+      return lhs.input_ < rhs.input_;
     }
   };
 

--- a/src/sensesp/transforms/lambda_transform.h
+++ b/src/sensesp/transforms/lambda_transform.h
@@ -152,26 +152,26 @@ class LambdaTransform : public Transform<IN, OUT> {
   void set(const IN& input) override {
     switch (num_params_) {
       case 0:
-        this->output = function0_(input);
+        this->output_ = function0_(input);
         break;
       case 1:
-        this->output = function1_(input, param1_);
+        this->output_ = function1_(input, param1_);
         break;
       case 2:
-        this->output = function2_(input, param1_, param2_);
+        this->output_ = function2_(input, param1_, param2_);
         break;
       case 3:
-        this->output = function3_(input, param1_, param2_, param3_);
+        this->output_ = function3_(input, param1_, param2_, param3_);
         break;
       case 4:
-        this->output = function4_(input, param1_, param2_, param3_, param4_);
+        this->output_ = function4_(input, param1_, param2_, param3_, param4_);
         break;
       case 5:
-        this->output =
+        this->output_ =
             function5_(input, param1_, param2_, param3_, param4_, param5_);
         break;
       case 6:
-        this->output = function6_(input, param1_, param2_, param3_, param4_,
+        this->output_ = function6_(input, param1_, param2_, param3_, param4_,
                                   param5_, param6_);
         break;
       default:

--- a/src/sensesp/transforms/linear.h
+++ b/src/sensesp/transforms/linear.h
@@ -7,7 +7,7 @@ namespace sensesp {
 
 /**
  * @brief Performs a linear transform on the input value:
- * output = (input * multiplier) + offset.
+ * output_ = (input * multiplier) + offset.
  *
  * @param multiplier The input is multiplied this value.
  *

--- a/src/sensesp/transforms/median.cpp
+++ b/src/sensesp/transforms/median.cpp
@@ -15,7 +15,7 @@ void Median::set(const float& input) {
     // Its time to output a value
     sort(buf_.begin(), buf_.end());
     const unsigned int mid = sample_size_ / 2;
-    output = buf_[mid];
+    output_ = buf_[mid];
     buf_.clear();
     notify();
   }

--- a/src/sensesp/transforms/moving_average.cpp
+++ b/src/sensesp/transforms/moving_average.cpp
@@ -20,12 +20,12 @@ void MovingAverage::set(const float& input) {
   // So the first value to be included in the average doesn't default to 0.0
   if (!initialized_) {
     buf_.assign(sample_size_, input);
-    output = input;
+    output_ = input;
     initialized_ = true;
   } else {
     // Subtract 1/nth of the oldest value and add 1/nth of the newest value
-    output += -multiplier_ * buf_[ptr_] / sample_size_;
-    output += multiplier_ * input / sample_size_;
+    output_ += -multiplier_ * buf_[ptr_] / sample_size_;
+    output_ += multiplier_ * input / sample_size_;
 
     // Save the most recent input, then advance to the next storage location.
     // When storage location n is reached, start over again at 0.

--- a/src/sensesp/transforms/repeat.h
+++ b/src/sensesp/transforms/repeat.h
@@ -172,7 +172,7 @@ class RepeatConstantRate : public RepeatExpiring<T> {
   }
 
   void set(T input) override {
-    this->output = input;
+    this->output_ = input;
     this->age_ = 0;
   }
 };


### PR DESCRIPTION
ValueProducer::output has been renamed to ValueProducer::output_ in conformance with the used Google C++ Style naming conventions.