### PR TITLE
Refactor TaskQueueProducer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: SensESP Automatic Build
 
-on: [pull_request]
+on: [push]
 
 jobs:
   build:

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -118,7 +118,7 @@ class SKWSClient : virtual public FileSystemSaveable,
   SKDeltaQueue* sk_delta_queue_;
   /// @brief Emits the number of deltas sent since last report
   TaskQueueProducer<int> delta_tx_tick_producer_ =
-      TaskQueueProducer<int>(0, event_loop(), 5, 990);
+      TaskQueueProducer<int>(0, event_loop(), 990);
   Integrator<int, int> delta_tx_count_producer_{1, 0, ""};
   Integrator<int, int> delta_rx_count_producer_{1, 0, ""};
 

--- a/src/sensesp/system/semaphore_value.h
+++ b/src/sensesp/system/semaphore_value.h
@@ -12,9 +12,12 @@ namespace sensesp {
  *
  * SemaphoreValue is primarily useful for synchronizing access to a value.
  * It is a regular ValueConsumer that can receive values from a ValueProducer.
- * However, the value is wrapped in a mutex, which can be waited on.
+ * The value is wrapped in a semaphore which can be waited on.
  * This allows a thread to wait until the value is updated, making
  * SemaphoreValue useful for synchronizing threads.
+ *
+ * SemaphoreValue is similar to TaskQueueProducer, but it is not a queue and
+ * does not poll or emit the values.
  *
  */
 template <typename T>

--- a/src/sensesp/system/stream_producer.h
+++ b/src/sensesp/system/stream_producer.h
@@ -37,32 +37,36 @@ class StreamLineProducer : public ValueProducer<String> {
                      reactesp::EventLoop* event_loop = event_loop(),
                      int max_line_length = 256)
       : stream_{stream}, max_line_length_{max_line_length} {
-    static int buf_pos = 0;
     buf_ = new char[max_line_length_ + 1];
-    read_event_ = event_loop->onAvailable(*stream_, [this]() {
-      while (stream_->available()) {
-        char c = stream_->read();
-        if (c == '\n') {
-          // Include the newline character in the output
-          buf_[buf_pos++] = c;
-          buf_[buf_pos] = '\0';
-          this->emit(buf_);
-          buf_pos = 0;
-        } else {
-          buf_[buf_pos++] = c;
-          if (buf_pos >= max_line_length_ - 1) {
-            buf_pos = 0;
-          }
-        }
-      }
-    });
+    read_event_ =
+        event_loop->onAvailable(*stream_, [this]() { this->receive_line(); });
   }
 
  protected:
   const int max_line_length_;
+  int buf_pos = 0;
   char* buf_;
   Stream* stream_;
   reactesp::StreamEvent* read_event_;
+
+  void receive_line() {
+    while (stream_->available()) {
+      char c = stream_->read();
+      if (c == '\n') {
+        // Include the newline character in the output
+        buf_[buf_pos++] = c;
+        buf_[buf_pos] = '\0';
+        ESP_LOGV("StreamLineProducer", "About to emit line: %s", buf_);
+        this->emit(buf_);
+        buf_pos = 0;
+      } else {
+        buf_[buf_pos++] = c;
+        if (buf_pos >= max_line_length_ - 1) {
+          buf_pos = 0;
+        }
+      }
+    }
+  }
 };
 
 }  // namespace sensesp

--- a/src/sensesp/transforms/filter.h
+++ b/src/sensesp/transforms/filter.h
@@ -3,6 +3,8 @@
 
 #include <functional>
 
+#include "sensesp/transforms/transform.h"
+
 namespace sensesp {
 
 /**


### PR DESCRIPTION
TaskQueueProducer now uses std::queue internally instead of FreeRTOS task queues. The latter broke spectacularly when using them with C++ classes.