### PR TITLE
Unit tests and memory safety

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -66,6 +66,7 @@ build_flags =
 ;debug_tool = esp-prog
 ;debug_init_break = tbreak setup
 
+test_build_src = true
 check_tool = clangtidy
 check_flags =
   clangtidy: --fix --format-style=file --config-file=.clang-tidy

--- a/src/sensesp/controllers/smart_switch_controller.cpp
+++ b/src/sensesp/controllers/smart_switch_controller.cpp
@@ -95,7 +95,7 @@ SmartSwitchController::SyncPath::SyncPath() {}
 SmartSwitchController::SyncPath::SyncPath(String sk_sync_path)
     : sk_sync_path_{sk_sync_path} {
   ESP_LOGD(__FILENAME__, "DoubleClick will also sync %s", sk_sync_path.c_str());
-  this->put_request_ = new BoolSKPutRequest(sk_sync_path, "", false);
+  this->put_request_ = std::make_shared<BoolSKPutRequest>(sk_sync_path, "", false);
 }
 
 }  // namespace sensesp

--- a/src/sensesp/controllers/smart_switch_controller.h
+++ b/src/sensesp/controllers/smart_switch_controller.h
@@ -1,10 +1,10 @@
 #ifndef _smart_switch_controller_h
 #define _smart_switch_controller_h
 
-#include "sensesp/ui/config_item.h"
 #include "sensesp/signalk/signalk_put_request.h"
 #include "sensesp/system/valueconsumer.h"
 #include "sensesp/transforms/click_type.h"
+#include "sensesp/ui/config_item.h"
 
 namespace sensesp {
 
@@ -74,8 +74,8 @@ class SmartSwitchController : public BooleanTransform,
   /// Used to store configuration internally.
   class SyncPath {
    public:
-    BoolSKPutRequest* put_request_;
     String sk_sync_path_;
+    std::shared_ptr<BoolSKPutRequest> put_request_;
 
     SyncPath();
     SyncPath(String sk_sync_path);

--- a/src/sensesp/net/http_server.cpp
+++ b/src/sensesp/net/http_server.cpp
@@ -74,8 +74,8 @@ esp_err_t HTTPServer::dispatch_request(httpd_req_t* req) {
 
   if (auth_required) {
     bool success;
-    success =
-        authenticate_request(authenticator_, call_request_dispatcher, req);
+    success = authenticate_request(authenticator_.get(),
+                                   call_request_dispatcher, req);
     if (!success) {
       // Authentication failed; do not continue but return success.
       // The client already received a 401 response.

--- a/src/sensesp/net/networking.cpp
+++ b/src/sensesp/net/networking.cpp
@@ -92,8 +92,14 @@ Networking::Networking(String config_path, String client_ssid,
     dns_server_->setErrorReplyCode(DNSReplyCode::NoError);
     dns_server_->start(53, "*", WiFi.softAPIP());
 
-    event_loop()->onRepeat(
-        1, [this]() { dns_server_->processNextRequest(); });
+    event_loop()->onRepeat(1, [this]() { dns_server_->processNextRequest(); });
+  }
+}
+
+Networking::~Networking() {
+  if (dns_server_) {
+    dns_server_->stop();
+    delete dns_server_;
   }
 }
 
@@ -280,13 +286,9 @@ void Networking::reset() {
   WiFi.begin("0", "0", 0, nullptr, false);
 }
 
-WiFiStateProducer* WiFiStateProducer::instance_ = nullptr;
-
 WiFiStateProducer* WiFiStateProducer::get_singleton() {
-  if (instance_ == nullptr) {
-    instance_ = new WiFiStateProducer();
-  }
-  return instance_;
+  static WiFiStateProducer instance;
+  return &instance;
 }
 
 void Networking::start_wifi_scan() {

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -6,9 +6,9 @@
 #include <WiFi.h>
 
 #include "sensesp/net/wifi_state.h"
-#include "sensesp/system/serializable.h"
 #include "sensesp/system/observablevalue.h"
 #include "sensesp/system/resettable.h"
+#include "sensesp/system/serializable.h"
 #include "sensesp/system/valueproducer.h"
 #include "sensesp_base_app.h"
 
@@ -97,8 +97,6 @@ class WiFiStateProducer : public ValueProducer<WiFiState> {
     ESP_LOGI(__FILENAME__, "Disconnected from wifi.");
     this->emit(WiFiState::kWifiDisconnected);
   }
-
-  static WiFiStateProducer* instance_;
 };
 
 /**
@@ -241,6 +239,8 @@ class Networking : virtual public FileSystemSaveable,
  public:
   Networking(String config_path, String client_ssid = "",
              String client_password = "");
+  ~Networking();
+
   virtual void reset() override;
 
   virtual bool to_json(JsonObject& doc) override;

--- a/src/sensesp/net/web/app_command_handler.cpp
+++ b/src/sensesp/net/web/app_command_handler.cpp
@@ -1,11 +1,13 @@
 #include "app_command_handler.h"
 
+#include <memory>
+
 #include <esp_http_server.h>
 
 namespace sensesp {
 
 void add_scan_wifi_networks_handlers(HTTPServer* server) {
-  HTTPRequestHandler* scan_wifi_networks_handler = new HTTPRequestHandler(
+  auto scan_wifi_networks_handler = std::make_shared<HTTPRequestHandler>(
       1 << HTTP_POST, "/api/wifi/scan", [](httpd_req_t* req) {
         auto networking = SensESPApp::get()->get_networking();
         networking->start_wifi_scan();
@@ -17,7 +19,7 @@ void add_scan_wifi_networks_handlers(HTTPServer* server) {
 
   server->add_handler(scan_wifi_networks_handler);
 
-  HTTPRequestHandler* scan_results_handler = new HTTPRequestHandler(
+  auto scan_results_handler = std::make_shared<HTTPRequestHandler>(
       1 << HTTP_GET, "/api/wifi/scan-results", [](httpd_req_t* req) {
         auto networking = SensESPApp::get()->get_networking();
         std::vector<WiFiNetworkInfo> ssid_list;

--- a/src/sensesp/net/web/config_handler.cpp
+++ b/src/sensesp/net/web/config_handler.cpp
@@ -171,6 +171,7 @@ void add_config_put_handler(HTTPServer* server) {
         // parse the content as JSON
         JsonDocument doc;
         DeserializationError error = deserializeJson(doc, payload);
+        delete[] payload;
         if (error) {
           ESP_LOGE("ConfigHandler", "Error parsing JSON payload: %s",
                    error.c_str());

--- a/src/sensesp/sensors/analog_input.cpp
+++ b/src/sensesp/sensors/analog_input.cpp
@@ -13,7 +13,7 @@ AnalogInput::AnalogInput(uint8_t pin, unsigned int read_delay,
       pin{pin},
       read_delay{read_delay},
       output_scale{output_scale} {
-  analog_reader_ = new AnalogReader(pin);
+  analog_reader_ = std::unique_ptr<AnalogReader>(new AnalogReader(pin));
   load();
 
   if (this->analog_reader_->configure()) {

--- a/src/sensesp/sensors/analog_input.h
+++ b/src/sensesp/sensors/analog_input.h
@@ -1,6 +1,7 @@
 #ifndef SENSESP_SENSORS_ANALOG_INPUT_H_
 #define SENSESP_SENSORS_ANALOG_INPUT_H_
 
+#include <memory>
 #include "analog_reader.h"
 #include "sensesp/ui/config_item.h"
 #include "sensor.h"
@@ -47,11 +48,11 @@ class AnalogInput : public FloatSensor {
   virtual bool to_json(JsonObject& root) override;
   virtual bool from_json(const JsonObject& config) override;
 
- private:
+ protected:
   uint8_t pin{};
   unsigned int read_delay;
   float output_scale;
-  BaseAnalogReader* analog_reader_;
+  std::unique_ptr<BaseAnalogReader> analog_reader_{};
   void update();
 };
 

--- a/src/sensesp/sensors/system_info.h
+++ b/src/sensesp/sensors/system_info.h
@@ -1,6 +1,7 @@
 #ifndef SENSESP_SENSORS_SYSTEM_INFO_H_
 #define SENSESP_SENSORS_SYSTEM_INFO_H_
 
+#include <memory>
 #include <Arduino.h>
 #include <elapsedMillis.h>
 
@@ -19,7 +20,7 @@ void connect_system_info_sensor(ValueProducer<T>* sensor, String prefix, String 
   String hostname = hostname_obs->get();
   String path = prefix + hostname + "." + name;
 
-  auto* sk_output = new SKOutput<T>(path);
+  auto sk_output = std::make_shared<SKOutput<T>>(path);
 
   // connect an observer to hostname to change the output path
   // if the hostname is changed

--- a/src/sensesp/signalk/signalk_emitter.h
+++ b/src/sensesp/signalk/signalk_emitter.h
@@ -42,7 +42,7 @@ class SKEmitter : virtual public Observable {
    * returned.
    * @see add_metadata()
    */
-  virtual SKMetadata* get_metadata() { return NULL; }
+  virtual SKMetadata* get_metadata() { return nullptr; }
 
   /**
    * Adds this emitter's Signal K meta data to the specified

--- a/src/sensesp/signalk/signalk_output.h
+++ b/src/sensesp/signalk/signalk_output.h
@@ -1,8 +1,10 @@
 #ifndef SENSESP_SIGNALK_SIGNALK_OUTPUT_H_
 #define SENSESP_SIGNALK_SIGNALK_OUTPUT_H_
 
-#include "sensesp/ui/config_item.h"
+#include <memory>
+
 #include "sensesp/transforms/transform.h"
+#include "sensesp/ui/config_item.h"
 #include "signalk_emitter.h"
 
 namespace sensesp {
@@ -29,7 +31,10 @@ class SKOutput : public SKEmitter, public SymmetricTransform<T> {
    * metadata to report (or if the path is already an official part of the
    * Signal K specification)
    */
-  SKOutput(String sk_path, String config_path = "", SKMetadata* meta = NULL)
+  SKOutput(String sk_path, String config_path = "", SKMetadata* meta = nullptr)
+      : SKOutput(sk_path, config_path, std::make_shared<SKMetadata>(*meta)) {}
+
+  SKOutput(String sk_path, String config_path, std::shared_ptr<SKMetadata> meta)
       : SKEmitter(sk_path), SymmetricTransform<T>(config_path), meta_{meta} {
     this->load();
   }
@@ -64,12 +69,14 @@ class SKOutput : public SKEmitter, public SymmetricTransform<T> {
    * method of setting the metadata (the first being a parameter
    * to the constructor).
    */
-  virtual void set_metadata(SKMetadata* meta) { this->meta_ = meta; }
+  virtual void set_metadata(SKMetadata* meta) {
+    this->meta_ = std::make_shared<SKMetadata>(*meta);
+  }
 
-  virtual SKMetadata* get_metadata() override { return meta_; }
+  virtual SKMetadata* get_metadata() override { return meta_.get(); }
 
  protected:
-  SKMetadata* meta_;
+  std::shared_ptr<SKMetadata> meta_;
 };
 
 template <typename T>

--- a/src/sensesp/system/base_button.h
+++ b/src/sensesp/system/base_button.h
@@ -1,6 +1,7 @@
 #ifndef SENSESP_SRC_SENSESP_SYSTEM_BASE_BUTTON_H_
 #define SENSESP_SRC_SENSESP_SYSTEM_BASE_BUTTON_H_
 
+#include <memory>
 #include "sensesp.h"
 
 #include "AceButton.h"
@@ -20,7 +21,7 @@ using namespace ace_button;
 class BaseButtonHandler : public IEventHandler {
  public:
   BaseButtonHandler(int pin, String config_path = "") {
-    button_ = new AceButton(pin);
+    button_ = std::unique_ptr<AceButton>(new AceButton(pin));
     pinMode(pin, INPUT_PULLUP);
 
     ButtonConfig* button_config = button_->getButtonConfig();
@@ -35,7 +36,7 @@ class BaseButtonHandler : public IEventHandler {
   }
 
  protected:
-  AceButton* button_;
+  std::unique_ptr<AceButton> button_;
 };
 
 }  // namespace sensesp

--- a/src/sensesp/system/filesystem.cpp
+++ b/src/sensesp/system/filesystem.cpp
@@ -13,6 +13,10 @@ Filesystem::Filesystem() : Resettable(-100) {
   }
 }
 
+Filesystem::~Filesystem() {
+  SPIFFS.end();
+}
+
 void Filesystem::reset() {
   ESP_LOGI(__FILENAME__, "Formatting filesystem");
   SPIFFS.format();

--- a/src/sensesp/system/filesystem.h
+++ b/src/sensesp/system/filesystem.h
@@ -8,6 +8,7 @@ namespace sensesp {
 class Filesystem : public Resettable {
  public:
   Filesystem();
+  ~Filesystem();
   virtual void reset() override;
 };
 

--- a/src/sensesp/system/system_status_led.cpp
+++ b/src/sensesp/system/system_status_led.cpp
@@ -33,7 +33,8 @@ int ws_disconnected_pattern[] = {50, 50, 50, 50, 50, 50, 50, 650, PATTERN_END};
 int ws_authorizing_pattern[] = {200, 200, PATTERN_END};
 
 SystemStatusLed::SystemStatusLed(int pin)
-    : blinker_(new PatternBlinker(pin, no_ap_pattern)) {}
+    : blinker_(std::unique_ptr<PatternBlinker>(
+          new PatternBlinker(pin, no_ap_pattern))) {}
 
 void SystemStatusLed::set_wifi_no_ap() { blinker_->set_pattern(no_ap_pattern); }
 void SystemStatusLed::set_wifi_disconnected() {

--- a/src/sensesp/system/system_status_led.h
+++ b/src/sensesp/system/system_status_led.h
@@ -1,6 +1,8 @@
 #ifndef SENSESP_SRC_SENSESP_SYSTEM_SYSTEM_STATUS_LED_H_
 #define SENSESP_SRC_SENSESP_SYSTEM_SYSTEM_STATUS_LED_H_
 
+#include <memory>
+
 #include "lambda_consumer.h"
 #include "led_blinker.h"
 #include "sensesp/controllers/system_status_controller.h"
@@ -15,7 +17,7 @@ namespace sensesp {
 class SystemStatusLed : public ValueConsumer<SystemStatus>,
                         public ValueConsumer<int> {
  protected:
-  PatternBlinker* blinker_;
+  std::unique_ptr<PatternBlinker> blinker_;
 
   virtual void set_wifi_no_ap();
   virtual void set_wifi_disconnected();

--- a/src/sensesp/system/valueproducer.h
+++ b/src/sensesp/system/valueproducer.h
@@ -2,6 +2,7 @@
 #define SENSESP_SYSTEM_VALUE_PRODUCER_H_
 
 #include <ArduinoJson.h>
+#include <memory>
 
 #include "observable.h"
 #include "valueconsumer.h"
@@ -38,6 +39,9 @@ class ValueProducer : virtual public Observable {
   void connect_to(ValueConsumer<T>* consumer) {
     this->attach([this, consumer]() { consumer->set(this->get()); });
   }
+  void connect_to(std::shared_ptr<ValueConsumer<T>> consumer) {
+    this->attach([this, consumer]() { consumer->set(this->get()); });
+  }
   void connect_to(ValueConsumer<T>& consumer) {
     this->attach([this, consumer]() { consumer.set(this->get()); });
   }
@@ -56,6 +60,11 @@ class ValueProducer : virtual public Observable {
     this->attach([this, consumer]() { consumer->set(CT(this->get())); });
   }
   template <typename CT>
+  void connect_to(std::shared_ptr<ValueConsumer<CT>> consumer) const {
+    this->attach([this, consumer]() { consumer->set(CT(this->get())); });
+  }
+
+  template <typename CT>
   void connect_to(ValueConsumer<CT>& consumer) {
     this->attach([this, consumer]() { consumer.set(CT(this->get())); });
   }
@@ -72,6 +81,14 @@ class ValueProducer : virtual public Observable {
       consumer_producer->set(T(this->get()));
     });
     return consumer_producer;
+  }
+  template <typename T2>
+  Transform<T, T2>* connect_to(
+      std::shared_ptr<Transform<T, T2>> consumer_producer) {
+    this->attach([this, consumer_producer]() {
+      consumer_producer->set(T(this->get()));
+    });
+    return consumer_producer.get();
   }
   template <typename T2>
   Transform<T, T2>* connect_to(Transform<T, T2>& consumer_producer) {
@@ -97,6 +114,14 @@ class ValueProducer : virtual public Observable {
       consumer_producer->set(TT(this->get()));
     });
     return consumer_producer;
+  }
+  template <typename TT, typename T2>
+  Transform<TT, T2>* connect_to(
+      std::shared_ptr<Transform<TT, T2>> consumer_producer) {
+    this->attach([this, consumer_producer]() {
+      consumer_producer->set(TT(this->get()));
+    });
+    return consumer_producer.get();
   }
   template <typename TT, typename T2>
   Transform<TT, T2>* connect_to(Transform<TT, T2>& consumer_producer) {

--- a/src/sensesp/ui/ui_button.cpp
+++ b/src/sensesp/ui/ui_button.cpp
@@ -2,6 +2,6 @@
 
 namespace sensesp {
 
-std::map<String, UIButton*> UIButton::ui_buttons_;
+std::map<String, std::shared_ptr<UIButton>> UIButton::ui_buttons_;
 
 }  // namespace sensesp

--- a/src/sensesp/ui/ui_button.h
+++ b/src/sensesp/ui/ui_button.h
@@ -2,6 +2,7 @@
 #define SENSESP_UI_UI_BUTTON_H
 
 #include <map>
+#include <memory>
 
 #include "Arduino.h"
 #include "sensesp/system/observable.h"
@@ -23,15 +24,15 @@ class UIButton : public Observable {
   const String get_title() { return title_; }
   const String get_name() { return name_; }
 
-  static const std::map<String, UIButton*>& get_ui_buttons() {
+  static const std::map<String, std::shared_ptr<UIButton>>& get_ui_buttons() {
     return ui_buttons_;
   }
 
   static UIButton* add(String name, String title, bool must_confirm = true) {
-    UIButton* new_cmd = new UIButton(title, name, must_confirm);
+    auto new_cmd = std::make_shared<UIButton>(title, name, must_confirm);
     ui_buttons_[name] = new_cmd;
 
-    return new_cmd;
+    return new_cmd.get();
   }
 
  protected:
@@ -39,7 +40,7 @@ class UIButton : public Observable {
   String name_;
   bool must_confirm_;
 
-  static std::map<String, UIButton*> ui_buttons_;
+  static std::map<String, std::shared_ptr<UIButton>> ui_buttons_;
 };
 
 }  // namespace sensesp

--- a/src/sensesp_app.cpp
+++ b/src/sensesp_app.cpp
@@ -11,6 +11,17 @@
 
 namespace sensesp {
 
+SensESPApp::~SensESPApp() {
+  delete networking_;
+  delete ota_;
+  delete ws_client_;
+  delete mdns_discovery_;
+  delete http_server_;
+  delete sk_delta_queue_;
+  delete system_status_led_;
+  delete button_handler_;
+}
+
 SensESPApp* SensESPApp::get() {
   if (instance_ == nullptr) {
     instance_ = new SensESPApp();
@@ -91,26 +102,26 @@ void SensESPApp::setup() {
 }
 
 void SensESPApp::connect_status_page_items() {
-  this->hostname_->connect_to(this->hostname_ui_output_);
+  this->hostname_->connect_to(&this->hostname_ui_output_);
   this->event_loop_.onRepeat(
-      4999, [this]() { wifi_ssid_ui_output_->set(WiFi.SSID()); });
+      4999, [this]() { wifi_ssid_ui_output_.set(WiFi.SSID()); });
   this->event_loop_.onRepeat(
-      4998, [this]() { free_memory_ui_output_->set(ESP.getFreeHeap()); });
+      4998, [this]() { free_memory_ui_output_.set(ESP.getFreeHeap()); });
   this->event_loop_.onRepeat(
-      4997, [this]() { wifi_rssi_ui_output_->set(WiFi.RSSI()); });
+      4997, [this]() { wifi_rssi_ui_output_.set(WiFi.RSSI()); });
   this->event_loop_.onRepeat(4996, [this]() {
-    sk_server_address_ui_output_->set(ws_client_->get_server_address());
+    sk_server_address_ui_output_.set(ws_client_->get_server_address());
   });
   this->event_loop_.onRepeat(4995, [this]() {
-    sk_server_port_ui_output_->set(ws_client_->get_server_port());
+    sk_server_port_ui_output_.set(ws_client_->get_server_port());
   });
   this->event_loop_.onRepeat(4994, [this]() {
-    sk_server_connection_ui_output_->set(ws_client_->get_connection_status());
+    sk_server_connection_ui_output_.set(ws_client_->get_connection_status());
   });
   ws_client_->get_delta_tx_count_producer().connect_to(
-      delta_tx_count_ui_output_);
+      &delta_tx_count_ui_output_);
   ws_client_->get_delta_rx_count_producer().connect_to(
-      delta_rx_count_ui_output_);
+      &delta_rx_count_ui_output_);
 }
 
 ObservableValue<String>* SensESPApp::get_hostname_observable() {

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -71,6 +71,8 @@ class SensESPApp : public SensESPBaseApp {
    */
   SensESPApp() : SensESPBaseApp() {}
 
+  ~SensESPApp();
+
   // setters for all constructor arguments
 
   const SensESPApp* set_hostname(String hostname) {
@@ -138,32 +140,28 @@ class SensESPApp : public SensESPBaseApp {
   SKDeltaQueue* sk_delta_queue_;
   SKWSClient* ws_client_;
 
-  StatusPageItem<String>* sensesp_version_ui_output_ =
-      new StatusPageItem<String>("SenseESP version", kSensESPVersion,
-                                 "Software", 1900);
-  StatusPageItem<String>* build_info_ui_output_ = new StatusPageItem<String>(
-      "Build date", __DATE__ " " __TIME__, "Software", 2000);
-  StatusPageItem<String>* hostname_ui_output_ =
-      new StatusPageItem<String>("Hostname", "", "Network", 500);
-  StatusPageItem<String>* mac_address_ui_output_ = new StatusPageItem<String>(
-      "MAC Address", WiFi.macAddress(), "Network", 1100);
-  StatusPageItem<String>* wifi_ssid_ui_output_ =
-      new StatusPageItem<String>("SSID", "", "Network", 1200);
-  StatusPageItem<int>* free_memory_ui_output_ =
-      new StatusPageItem<int>("Free memory (bytes)", 0, "System", 1250);
-  StatusPageItem<int8_t>* wifi_rssi_ui_output_ = new StatusPageItem<int8_t>(
-      "WiFi signal strength (dB)", -128, "Network", 1300);
-  StatusPageItem<String>* sk_server_address_ui_output_ =
-      new StatusPageItem<String>("Signal K server address", "", "Signal K",
-                                 1400);
-  StatusPageItem<uint16_t>* sk_server_port_ui_output_ =
-      new StatusPageItem<uint16_t>("Signal K server port", 0, "Signal K", 1500);
-  StatusPageItem<String>* sk_server_connection_ui_output_ =
-      new StatusPageItem<String>("SK connection status", "", "Signal K", 1600);
-  StatusPageItem<int>* delta_tx_count_ui_output_ =
-      new StatusPageItem<int>("SK Delta TX count", 0, "Signal K", 1700);
-  StatusPageItem<int>* delta_rx_count_ui_output_ =
-      new StatusPageItem<int>("SK Delta RX count", 0, "Signal K", 1800);
+  StatusPageItem<String> sensesp_version_ui_output_{
+      "SenseESP version", kSensESPVersion, "Software", 1900};
+  StatusPageItem<String> build_info_ui_output_{
+      "Build date", __DATE__ " " __TIME__, "Software", 2000};
+  StatusPageItem<String> hostname_ui_output_{"Hostname", "", "Network", 500};
+  StatusPageItem<String> mac_address_ui_output_{
+      "MAC Address", WiFi.macAddress(), "Network", 1100};
+  StatusPageItem<String> wifi_ssid_ui_output_{"SSID", "", "Network", 1200};
+  StatusPageItem<int> free_memory_ui_output_{"Free memory (bytes)", 0, "System",
+                                             1250};
+  StatusPageItem<int8_t> wifi_rssi_ui_output_{"WiFi signal strength (dB)", -128,
+                                              "Network", 1300};
+  StatusPageItem<String> sk_server_address_ui_output_{"Signal K server address",
+                                                      "", "Signal K", 1400};
+  StatusPageItem<uint16_t> sk_server_port_ui_output_{"Signal K server port", 0,
+                                                     "Signal K", 1500};
+  StatusPageItem<String> sk_server_connection_ui_output_{"SK connection status",
+                                                         "", "Signal K", 1600};
+  StatusPageItem<int> delta_tx_count_ui_output_{"SK Delta TX count", 0,
+                                                "Signal K", 1700};
+  StatusPageItem<int> delta_rx_count_ui_output_{"SK Delta RX count", 0,
+                                                "Signal K", 1800};
 
   friend class WebServer;
   friend class SensESPAppBuilder;

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -1,6 +1,8 @@
 #ifndef SENSESP_APP_BUILDER_H
 #define SENSESP_APP_BUILDER_H
 
+#include <memory>
+
 #include "sensesp/sensors/system_info.h"
 #include "sensesp/transforms/debounce.h"
 #include "sensesp_app.h"

--- a/src/sensesp_base_app.cpp
+++ b/src/sensesp_base_app.cpp
@@ -25,6 +25,13 @@ SensESPBaseApp::SensESPBaseApp() : filesystem_(new Filesystem()) {
   ConfigItem(hostname_);  // Make hostname configurable
 }
 
+SensESPBaseApp::~SensESPBaseApp() {
+  delete filesystem_;
+  delete hostname_;
+
+  instance_ = nullptr;
+}
+
 /**
  * Get the singleton SensESPBaseApp singleton instance.
  * The instance must be set by the builder.

--- a/src/sensesp_base_app.h
+++ b/src/sensesp_base_app.h
@@ -70,6 +70,7 @@ class SensESPBaseApp {
    * refactored into a singleton.
    */
   SensESPBaseApp();
+  ~SensESPBaseApp();
 
   virtual void setup();
 

--- a/test/system/test_config_item/config_item.cpp
+++ b/test/system/test_config_item/config_item.cpp
@@ -1,0 +1,50 @@
+#include "sensesp.h"
+
+#include "sensesp/ui/config_item.h"
+
+#include "sensesp/system/filesystem.h"
+#include "sensesp/system/observablevalue.h"
+#include "sensesp/system/serializable.h"
+#include "sensesp/system/valueproducer.h"
+#include "sensesp/transforms/angle_correction.h"
+#include "sensesp_base_app.h"
+#include "sensesp_minimal_app_builder.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+void test_persisting_observable_value_schema() {
+  SensESPMinimalAppBuilder builder;
+  SensESPMinimalApp* sensesp_app = builder.get_app();
+  TEST_ASSERT_NOT_NULL(sensesp_app);
+
+  PersistingObservableValue<int> value{2, "/test"};
+
+  auto config_item = ConfigItem(&value);
+
+  value.set(3);
+
+  String ref_schema = R"###({"type":"object","properties":{"value":{"title":"Value","type":"number"}}})###";
+  String schema = config_item->get_config_schema();
+  ESP_LOGD("test_schema", "schema: %s", schema.c_str());
+
+  TEST_ASSERT_EQUAL_STRING(ref_schema.c_str(), schema.c_str());
+
+  value.save();
+  value.set(4);
+  value.load();
+
+  TEST_ASSERT_EQUAL(3, value.get());
+}
+
+void setup() {
+  esp_log_level_set("*", ESP_LOG_VERBOSE);
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_persisting_observable_value_schema);
+
+  UNITY_END();
+}
+
+void loop() {}

--- a/test/system/test_minimal_app/minimal_app.cpp
+++ b/test/system/test_minimal_app/minimal_app.cpp
@@ -38,6 +38,9 @@ void test_sensesp() {
 void setup() {
   UNITY_BEGIN();
   RUN_TEST(test_sensesp);
+  // Run the same test again to ensure that the app can be torn down and
+  // reinitialized.
+  RUN_TEST(test_sensesp);
   UNITY_END();
 }
 

--- a/test/system/test_minimal_app/minimal_app.cpp
+++ b/test/system/test_minimal_app/minimal_app.cpp
@@ -1,0 +1,44 @@
+#include "sensesp.h"
+
+#include "elapsedMillis.h"
+#include "sensesp/sensors/sensor.h"
+#include "sensesp/system/observablevalue.h"
+#include "sensesp/system/lambda_consumer.h"
+#include "sensesp_minimal_app_builder.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+void test_sensesp() {
+  SensESPMinimalAppBuilder builder;
+  SensESPMinimalApp* sensesp_app = builder.get_app();
+  TEST_ASSERT_NOT_NULL(sensesp_app);
+
+  auto sensor = RepeatSensor<int>(10, []() {
+    static int value = 42;
+    return value++;
+  });
+
+  ObservableValue<int>* observable = new ObservableValue<int>();
+  sensor.connect_to(observable);
+
+  auto test_consumer = new LambdaConsumer<int>([](int value) {
+    static int target_value = 42;
+    TEST_ASSERT_EQUAL(target_value, value);
+    TEST_ASSERT_TRUE(42 <= target_value && target_value < 47);
+    target_value++;
+  });
+
+  elapsedMillis elapsed = 0;
+  while (elapsed < 100) {
+    event_loop()->tick();
+  }
+}
+
+void setup() {
+  UNITY_BEGIN();
+  RUN_TEST(test_sensesp);
+  UNITY_END();
+}
+
+void loop() {}

--- a/test/system/test_serialization/serializable.cpp
+++ b/test/system/test_serialization/serializable.cpp
@@ -1,0 +1,145 @@
+#include "sensesp.h"
+
+#include "sensesp/system/serializable.h"
+#include "sensesp/system/valueproducer.h"
+#include "sensesp/transforms/angle_correction.h"
+#include "sensesp_base_app.h"
+#include "sensesp_minimal_app_builder.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+class TestProducer : public ValueProducer<int>, public Serializable {
+ public:
+  TestProducer() : ValueProducer<int>() {}
+
+  bool to_json(JsonObject& root) override {
+    root["a"] = a_;
+    root["b"] = b_;
+    JsonArray float_array = root["c"].to<JsonArray>();
+    for (int i = 0; i < 3; i++) {
+      float_array.add(c_[i]);
+    }
+    JsonObject map = root["map"].to<JsonObject>();
+    map[map_key_] = map_value_;
+    return true;
+  }
+
+  // Normally these would be protected, but for testing purposes, we make them
+  // public.
+  int a_ = 567;
+  String b_ = "hello";
+  float c_[3] = {1.1, 2.2, 3.3};
+  String map_key_ = "key";
+  String map_value_ = "value";
+
+  bool from_json(const JsonObject& root) override {
+    a_ = root["a"];
+    b_ = root["b"].as<String>();
+    JsonArray float_array = root["c"];
+    for (int i = 0; i < 3; i++) {
+      c_[i] = float_array[i];
+    }
+    JsonObject map = root["map"];
+    map_value_ = map["key"].as<String>();
+    return true;
+  }
+};
+
+void test_to_json() {
+  TestProducer producer;
+  JsonDocument doc;
+  JsonObject root = doc.to<JsonObject>();
+
+  // This is not particularly useful as a test because we are simply testing
+  // the implementation written above.
+
+  producer.to_json(root);
+
+  TEST_ASSERT_EQUAL(567, root["a"]);
+  TEST_ASSERT_EQUAL_STRING("hello", root["b"]);
+  TEST_ASSERT_EQUAL_FLOAT(1.1, root["c"][0]);
+  TEST_ASSERT_EQUAL_FLOAT(2.2, root["c"][1]);
+  TEST_ASSERT_EQUAL_FLOAT(3.3, root["c"][2]);
+  TEST_ASSERT_EQUAL_STRING("value", root["map"]["key"]);
+
+  String json_str;
+  serializeJson(doc, json_str);
+  ESP_LOGD("test_to_json", "json_str: %s", json_str.c_str());
+
+  String test_str =
+      R"...({"a":567,"b":"hello","c":[1.1,2.2,3.3],"map":{"key":"value"}})...";
+
+  TEST_ASSERT_EQUAL_STRING(test_str.c_str(), json_str.c_str());
+}
+
+void test_from_json() {
+  String test_str =
+      R"...({"a":123,"b":"goodbye","c":[4.4,5.5,6.6],"map":{"key":"new_value"}})...";
+
+  TestProducer producer;
+  JsonDocument doc;
+  DeserializationError error = deserializeJson(doc, test_str);
+  TEST_ASSERT_FALSE(error);
+
+  JsonObject root = doc.as<JsonObject>();
+  producer.from_json(root);
+
+  TEST_ASSERT_EQUAL(123, producer.a_);
+  TEST_ASSERT_EQUAL_STRING("goodbye", producer.b_.c_str());
+  TEST_ASSERT_EQUAL_FLOAT(4.4, producer.c_[0]);
+  TEST_ASSERT_EQUAL_FLOAT(5.5, producer.c_[1]);
+  TEST_ASSERT_EQUAL_FLOAT(6.6, producer.c_[2]);
+  TEST_ASSERT_EQUAL_STRING("new_value", producer.map_value_.c_str());
+}
+
+// To access protected members, we need to create a child class
+class AngleCorrection_ : public AngleCorrection {
+ public:
+  AngleCorrection_(float offset, float min_angle, const String& config_path = "")
+      : AngleCorrection(offset, min_angle, config_path) {}
+
+  float get_offset() { return offset_; }
+  float get_min_angle() { return min_angle_; }
+};
+
+void test_angle_correction_to_json() {
+  AngleCorrection_ angle_correction(1.1, 2.2);
+  JsonDocument doc;
+  JsonObject root = doc.to<JsonObject>();
+
+  angle_correction.to_json(root);
+
+  TEST_ASSERT_EQUAL_FLOAT(1.1, root["offset"]);
+  TEST_ASSERT_EQUAL_FLOAT(2.2, root["min_angle"]);
+}
+
+void test_angle_correction_from_json() {
+  String test_str = R"...({"offset":3.3,"min_angle":4.4})...";
+
+  AngleCorrection_ angle_correction(1.1, 2.2);
+  JsonDocument doc;
+  DeserializationError error = deserializeJson(doc, test_str);
+  TEST_ASSERT_FALSE(error);
+
+  JsonObject root = doc.as<JsonObject>();
+  angle_correction.from_json(root);
+
+  TEST_ASSERT_EQUAL_FLOAT(3.3, angle_correction.get_offset());
+  TEST_ASSERT_EQUAL_FLOAT(4.4, angle_correction.get_min_angle());
+}
+
+void setup() {
+  esp_log_level_set("*", ESP_LOG_VERBOSE);
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_to_json);
+  RUN_TEST(test_from_json);
+  RUN_TEST(test_angle_correction_to_json);
+  RUN_TEST(test_angle_correction_from_json);
+
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
At long last, I have implemented few rudimentary unit tests for SensESP. Not great, but at least it will be easier to add new ones in the future.

Also at long last, I have taken some steps to improve memory safety on SensESP. The codebase has been quite nonchalant about creating objects on the heap and not properly tracking them. This hasn't been an issue as long as the enclosing objects haven't been destroyed, but it's not a good practice, and with unit testing, it should be expected that the whole SensESP app will be torn down. I have now wrapped many internal heap objects in `shared_ptr` or `unique_ptr` and also added some destructors for select classes.