### PR TITLE
SKMetadata fix

### DIFF
--- a/src/sensesp/signalk/signalk_output.cpp
+++ b/src/sensesp/signalk/signalk_output.cpp
@@ -6,7 +6,7 @@ template <typename T>
 SKOutputNumeric<T>::SKOutputNumeric(String sk_path, String config_path,
                                     SKMetadata* meta)
     : SKOutput<T>(sk_path, config_path, meta) {
-  if (this->meta_ == NULL && !this->sk_path_.isEmpty()) {
+  if (this->meta_ == nullptr && !this->sk_path_.isEmpty()) {
     ESP_LOGW(
         __FILENAME__,
         "WARNING - No metadata for %s. Numeric values should specify units",

--- a/src/sensesp/signalk/signalk_output.h
+++ b/src/sensesp/signalk/signalk_output.h
@@ -32,7 +32,7 @@ class SKOutput : public SKEmitter, public SymmetricTransform<T> {
    * Signal K specification)
    */
   SKOutput(String sk_path, String config_path = "", SKMetadata* meta = nullptr)
-      : SKOutput(sk_path, config_path, std::make_shared<SKMetadata>(*meta)) {}
+      : SKOutput(sk_path, config_path, std::shared_ptr<SKMetadata>(meta)) {}
 
   SKOutput(String sk_path, String config_path, std::shared_ptr<SKMetadata> meta)
       : SKEmitter(sk_path), SymmetricTransform<T>(config_path), meta_{meta} {
@@ -112,7 +112,7 @@ template <typename T>
 class SKOutputNumeric : public SKOutput<T> {
  public:
   SKOutputNumeric(String sk_path, String config_path = "",
-                  SKMetadata* meta = NULL);
+                  SKMetadata* meta = nullptr);
 
   SKOutputNumeric(String sk_path, SKMetadata* meta)
       : SKOutputNumeric(sk_path, "", meta) {}

--- a/src/sensesp/system/stream_producer.h
+++ b/src/sensesp/system/stream_producer.h
@@ -56,7 +56,6 @@ class StreamLineProducer : public ValueProducer<String> {
         // Include the newline character in the output
         buf_[buf_pos++] = c;
         buf_[buf_pos] = '\0';
-        ESP_LOGV("StreamLineProducer", "About to emit line: %s", buf_);
         this->emit(buf_);
         buf_pos = 0;
       } else {


### PR DESCRIPTION
Giving an SKMetadata nullptr to SKOutput made the program crash. Fixed.