### PR TITLE
Provide correct ConfigSchema for template classes

### DIFF
--- a/src/sensesp/net/http_server.h
+++ b/src/sensesp/net/http_server.h
@@ -179,6 +179,10 @@ class HTTPServer : public FileSystemSaveable {
   friend esp_err_t call_request_dispatcher(httpd_req_t* req);
 };
 
+inline const String ConfigSchema(const HTTPServer& obj) {
+  return "null";
+}
+
 inline bool ConfigRequiresRestart(const HTTPServer& obj) { return true; }
 
 }  // namespace sensesp

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -283,6 +283,10 @@ class Networking : public FileSystemSaveable,
   std::shared_ptr<LambdaConsumer<WiFiState>> wifi_state_emitter_;
 };
 
+inline const String ConfigSchema(const Networking& obj) {
+  return "null";
+}
+
 inline bool ConfigRequiresRestart(const Networking& obj) { return true; }
 
 }  // namespace sensesp

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -162,6 +162,10 @@ class SKWSClient : public FileSystemSaveable,
   SKWSConnectionState get_connection_state() { return task_connection_state_; }
 };
 
+inline const String ConfigSchema(const SKWSClient& obj) {
+  return "null";
+}
+
 inline bool ConfigRequiresRestart(const SKWSClient& obj) { return true; }
 
 }  // namespace sensesp

--- a/src/sensesp/ui/config_item.h
+++ b/src/sensesp/ui/config_item.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <cstddef>
 
 #include "Arduino.h"
 #include "ArduinoJson.h"
@@ -33,21 +34,18 @@ template <>
 const char* get_schema_type_string(const bool dummy);
 
 /**
- * @brief Template function to provide a configuration schema for a
- * ConfigItemT<T>.
+ * @brief Provide a configuration schema for a
+ * ConfigItemT<nullptr>.
+ *
+ * For this to work, an overload or a specialization of this function must
+ * be provided for each type T that is used in a ConfigItemT<T>.
  *
  * @tparam T
  * @param obj
  * @return const char*
  */
-template <typename T>
-const String ConfigSchema(const T& obj) {
+inline const String ConfigSchema(const std::nullptr_t& obj) {
   return "null";
-}
-
-template <typename T>
-const String ConfigSchema(const std::shared_ptr<T>& obj) {
-  return ConfigSchema(*obj);
 }
 
 template <typename T>
@@ -271,7 +269,6 @@ class ConfigItemT : public ConfigItemBase {
     String schema = ConfigSchema(*config_object_);
     return schema;
   }
-
 };
 
 /**


### PR DESCRIPTION
I have removed the default ConfigSchema template and provided overloads for built-in classes that have hardcoded UI implementations. ConfigItems should now work properly for template classes as well.