### PR TITLE
Store EventLoop in a shared_ptr

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,7 @@ upload_speed = 2000000
 monitor_speed = 115200
 
 lib_deps =
-  mairas/ReactESP @ ^3.1.0
+  mairas/ReactESP @ ^3.2.0
   bblanchon/ArduinoJson @ ^7.0.0
   pfeerick/elapsedMillis @ ^1.0.6
   bxparks/AceButton @ ^1.10.1

--- a/src/sensesp.cpp
+++ b/src/sensesp.cpp
@@ -1,10 +1,12 @@
 #include "sensesp.h"
 
+#include <memory>
+
 #include "sensesp_base_app.h"
 
 namespace sensesp {
 
-reactesp::EventLoop* event_loop() {
+std::shared_ptr<reactesp::EventLoop> event_loop() {
   return SensESPBaseApp::get_event_loop();
 }
 

--- a/src/sensesp.h
+++ b/src/sensesp.h
@@ -2,6 +2,7 @@
 #define SENSESP_H
 
 #include <ReactESP.h>
+#include <memory>
 
 #include "sensesp/system/local_debug.h"
 
@@ -19,7 +20,7 @@ namespace sensesp {
 
 typedef std::function<void()> void_cb_func;
 
-reactesp::EventLoop* event_loop();
+std::shared_ptr<reactesp::EventLoop> event_loop();
 
 }  // namespace sensesp
 

--- a/src/sensesp/system/stream_producer.h
+++ b/src/sensesp/system/stream_producer.h
@@ -3,6 +3,8 @@
 
 #include "sensesp.h"
 
+#include <memory>
+
 #include "ReactESP.h"
 #include "sensesp/system/valueproducer.h"
 #include "sensesp_base_app.h"
@@ -33,9 +35,10 @@ class StreamCharProducer : public ValueProducer<char> {
  */
 class StreamLineProducer : public ValueProducer<String> {
  public:
-  StreamLineProducer(Stream* stream,
-                     reactesp::EventLoop* event_loop = event_loop(),
-                     int max_line_length = 256)
+  StreamLineProducer(
+      Stream* stream,
+      std::shared_ptr<reactesp::EventLoop> event_loop = event_loop(),
+      int max_line_length = 256)
       : stream_{stream}, max_line_length_{max_line_length} {
     buf_ = new char[max_line_length_ + 1];
     read_event_ =

--- a/src/sensesp/system/task_queue_producer.h
+++ b/src/sensesp/system/task_queue_producer.h
@@ -79,7 +79,8 @@ class SafeQueue : public std::queue<T> {
 template <class T>
 class TaskQueueProducer : public ObservableValue<T> {
  public:
-  TaskQueueProducer(const T& value, reactesp::EventLoop* consumer_event_loop,
+  TaskQueueProducer(const T& value,
+                    std::shared_ptr<reactesp::EventLoop> consumer_event_loop,
                     unsigned int poll_rate = 990)
       : ObservableValue<T>(value) {
     auto func = [this]() {

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -222,7 +222,7 @@ class SensESPApp : public SensESPBaseApp {
   // Collect metrics for the status page
   void connect_status_page_items() {
     this->hostname_->connect_to(&this->hostname_ui_output_);
-    this->event_loop_.onRepeat(4999, [this]() {
+    this->event_loop_->onRepeat(4999, [this]() {
       wifi_ssid_ui_output_.set(WiFi.SSID());
       free_memory_ui_output_.set(ESP.getFreeHeap());
       wifi_rssi_ui_output_.set(WiFi.RSSI());
@@ -231,19 +231,19 @@ class SensESPApp : public SensESPBaseApp {
       uptime_ui_output_.set(millis() / 1000);
 
       // Event loop queue sizes
-      int event_loop_queue_size = event_loop_.getEventQueueSize();
-      int event_loop_timed_queue_size = event_loop_.getTimedEventQueueSize();
+      int event_loop_queue_size = event_loop_->getEventQueueSize();
+      int event_loop_timed_queue_size = event_loop_->getTimedEventQueueSize();
       int event_loop_untimed_queue_size =
-          event_loop_.getUntimedEventQueueSize();
+          event_loop_->getUntimedEventQueueSize();
 
       // Total tick count
-      uint64_t current_tick_count = event_loop_.getTickCount();
+      uint64_t current_tick_count = event_loop_->getTickCount();
       total_tick_count_ui_output_.set(current_tick_count);
 
       // Event counts
-      uint64_t current_event_count = event_loop_.getEventCount();
-      uint64_t current_timed_event_count = event_loop_.getTimedEventCount();
-      uint64_t current_untimed_event_count = event_loop_.getUntimedEventCount();
+      uint64_t current_event_count = event_loop_->getEventCount();
+      uint64_t current_timed_event_count = event_loop_->getTimedEventCount();
+      uint64_t current_untimed_event_count = event_loop_->getUntimedEventCount();
       event_count_ui_output_.set(current_event_count);
       timed_event_count_ui_output_.set(current_timed_event_count);
       untimed_event_count_ui_output_.set(current_untimed_event_count);
@@ -269,7 +269,7 @@ class SensESPApp : public SensESPBaseApp {
       event_loop_timed_queue_ui_output_.set(event_loop_timed_queue_size);
       event_loop_untimed_queue_ui_output_.set(event_loop_untimed_queue_size);
       event_loop_interrupt_queue_ui_output_.set(
-          event_loop_.getISREventQueueSize());
+          event_loop_->getISREventQueueSize());
 
       ticks_per_second_ui_output_.set(int(ticks_diff / interval_seconds));
       events_per_second_ui_output_.set(int(events_diff / interval_seconds));

--- a/src/sensesp_base_app.h
+++ b/src/sensesp_base_app.h
@@ -41,7 +41,7 @@ inline void SetupSerialDebug(uint32_t baudrate) {
  */
 class SensESPBaseApp {
  protected:
-  reactesp::EventLoop event_loop_;
+  std::shared_ptr<reactesp::EventLoop> event_loop_;
 
  public:
   /**
@@ -81,7 +81,7 @@ class SensESPBaseApp {
              "Resetting the device configuration to system defaults.");
     Resettable::reset_all();
 
-    this->event_loop_.onDelay(1000, []() {
+    this->event_loop_->onDelay(1000, []() {
       ESP.restart();
       delay(1000);
     });
@@ -110,8 +110,8 @@ class SensESPBaseApp {
    * instance.
    *
    */
-  static reactesp::EventLoop* get_event_loop() {
-    return &(SensESPBaseApp::get()->event_loop_);
+  static std::shared_ptr<reactesp::EventLoop> get_event_loop() {
+    return SensESPBaseApp::get()->event_loop_;
   }
 
  protected:
@@ -122,7 +122,9 @@ class SensESPBaseApp {
    * be called only once. For compatibility reasons, the class hasn't been
    * refactored into a singleton.
    */
-  SensESPBaseApp() : filesystem_{std::make_shared<Filesystem>()} {
+  SensESPBaseApp()
+      : filesystem_{std::make_shared<Filesystem>()},
+        event_loop_{std::make_shared<reactesp::EventLoop>()} {
     // Instance is now set by the builder
   }
 


### PR DESCRIPTION
Strictly speaking, this is a breaking change, but since the impact should be quite limited and it removes a major use case of raw pointers, I'll just keep quiet and do it. Naughty me.