### PR TITLE
Link fix for clients that use RepeatExpiring<int>

### DIFF
--- a/src/sensesp/types/nullable.cpp
+++ b/src/sensesp/types/nullable.cpp
@@ -28,6 +28,8 @@ uint32_t Nullable<uint32_t>::invalid_value_ = 0xffffffff;
 template <>
 int32_t Nullable<int32_t>::invalid_value_ = 0x7fffffff;
 template <>
+int Nullable<int>::invalid_value_ = 0x7fffffff;
+template <>
 uint64_t Nullable<uint64_t>::invalid_value_ = 0xffffffffffffffffLL;
 template <>
 int64_t Nullable<int64_t>::invalid_value_ = 0x7fffffffffffffffLL;


### PR DESCRIPTION
Such as engine_load_ in n2k_senders.h of
HALMET example firmware.