### PR TITLE
Add a DigitalInputPcntCounter to count pulses using PCNT units

### DIFF
--- a/examples/rpm_counter.cpp
+++ b/examples/rpm_counter.cpp
@@ -2,7 +2,7 @@
 
 // #define SERIAL_DEBUG_DISABLED
 
-#include "sensesp/sensors/digital_input.h"
+#include "sensesp/sensors/digital_pcnt_input.h"
 #include "sensesp/signalk/signalk_output.h"
 #include "sensesp/transforms/frequency.h"
 #include "sensesp_app_builder.h"
@@ -51,9 +51,10 @@ void setup() {
   const char* config_path_skpath = "/sensors/engine_rpm/sk";
 
   //////////
-  // connect a RPM meter. A DigitalInputCounter implements an interrupt
-  // to count pulses and reports the readings every read_delay ms
-  // (500 in the example). A Frequency
+  // connect a RPM meter. A DigitalInputPcntCounter implements 
+  // access to a pulse counter peripheral. Every read_delay ms, it
+  // reads the number of pulses that have occurred since the last
+  // read, and reports that number (500ms in the example). A Frequency
   // transform takes a number of pulses and converts that into
   // a frequency. The sample multiplier converts the 97 tooth
   // tach output into Hz, SK native units.
@@ -64,7 +65,7 @@ void setup() {
   // ESP32 pins are specified as just the X in GPIOX
   uint8_t pin = 4;
 
-  auto* sensor = new DigitalInputCounter(pin, INPUT_PULLUP, RISING, read_delay);
+  auto* sensor = new DigitalInputPcntCounter(pin, INPUT_PULLUP, RISING, read_delay);
 
   auto frequency = new Frequency(multiplier, config_path_calibrate);
 

--- a/src/sensesp/sensors/digital_pcnt_input.cpp
+++ b/src/sensesp/sensors/digital_pcnt_input.cpp
@@ -1,0 +1,96 @@
+#include "digital_pcnt_input.h"
+
+namespace sensesp {
+
+DigitalInputPcntCounter::DigitalInputPcntCounter(uint8_t pin, int pin_mode,
+                                                 int interrupt_type,
+                                                 unsigned int read_delay,
+                                                 String config_path)
+    : DigitalInput(pin, pin_mode),
+      Sensor(config_path),
+      read_delay_(read_delay),
+      interrupt_type_(interrupt_type) {
+  load();
+
+  ESP_ERROR_CHECK(configurePcnt(interrupt_type));
+
+  event_loop()->onRepeat(read_delay_, [this]() {
+    noInterrupts();
+    int count = 0;
+    ESP_ERROR_CHECK(pcnt_unit_get_count(pcnt_unit_, &count));
+    ESP_ERROR_CHECK(pcnt_unit_clear_count(pcnt_unit_));
+    output_ = count;
+    interrupts();
+    notify();
+  });
+}
+
+DigitalInputPcntCounter::~DigitalInputPcntCounter() {
+  if (pcnt_channel_) {
+    ESP_ERROR_CHECK(pcnt_del_channel(pcnt_channel_));
+  }
+  if (pcnt_unit_) {
+    ESP_ERROR_CHECK(pcnt_unit_stop(pcnt_unit_));
+    ESP_ERROR_CHECK(pcnt_unit_disable(pcnt_unit_));
+    ESP_ERROR_CHECK(pcnt_del_unit(pcnt_unit_));
+  }
+}
+
+esp_err_t DigitalInputPcntCounter::configurePcnt(int interrupt_mode) {
+  pcnt_unit_config_t unit_config = {
+      .low_limit = -1,
+      .high_limit = INT16_MAX,
+  };
+
+  ESP_ERROR_CHECK(pcnt_new_unit(&unit_config, &pcnt_unit_));
+
+  pcnt_chan_config_t chan_config = {.edge_gpio_num = pin_,
+                                    .level_gpio_num = -1,
+                                    .flags = {.invert_edge_input = false,
+                                              .invert_level_input = false,
+                                              .virt_edge_io_level = 0,
+                                              .virt_level_io_level = 0,
+                                              .io_loop_back = false}};
+
+  ESP_ERROR_CHECK(pcnt_new_channel(pcnt_unit_, &chan_config, &pcnt_channel_));
+
+  pcnt_channel_edge_action_t edge_action_pos =
+      (interrupt_mode == RISING || interrupt_mode == CHANGE)
+          ? PCNT_CHANNEL_EDGE_ACTION_INCREASE
+          : PCNT_CHANNEL_EDGE_ACTION_HOLD;
+  pcnt_channel_edge_action_t edge_action_neg =
+      (interrupt_mode == FALLING || interrupt_mode == CHANGE)
+          ? PCNT_CHANNEL_EDGE_ACTION_INCREASE
+          : PCNT_CHANNEL_EDGE_ACTION_HOLD;
+  ESP_ERROR_CHECK(pcnt_channel_set_edge_action(pcnt_channel_, edge_action_pos,
+                                               edge_action_neg));
+
+  ESP_ERROR_CHECK(pcnt_unit_enable(pcnt_unit_));
+  ESP_ERROR_CHECK(pcnt_unit_clear_count(pcnt_unit_));
+
+  return pcnt_unit_start(pcnt_unit_);
+}
+
+bool DigitalInputPcntCounter::to_json(JsonObject& root) {
+  root["read_delay"] = read_delay_;
+  return true;
+}
+
+bool DigitalInputPcntCounter::from_json(const JsonObject& config) {
+  String const expected[] = {"read_delay"};
+  for (auto str : expected) {
+    if (!config[str].is<JsonVariant>()) {
+      return false;
+    }
+  }
+  read_delay_ = config["read_delay"];
+  return true;
+}
+
+const String ConfigSchema(const DigitalInputPcntCounter& obj) {
+  return R"###({"type":"object","properties":{"read_delay":{"title":"Read delay","type":"number","description":"The time, in milliseconds, between each read of the input"}}  })###";
+}
+
+bool ConfigRequiresRestart(const DigitalInputPcntCounter& obj) { return true; }
+
+}  // namespace sensesp

--- a/src/sensesp/sensors/digital_pcnt_input.h
+++ b/src/sensesp/sensors/digital_pcnt_input.h
@@ -1,0 +1,62 @@
+#ifndef SENSESP_SENSORS_DIGITAL_PCNT_INPUT_H_
+#define SENSESP_SENSORS_DIGITAL_PCNT_INPUT_H_
+
+#include <elapsedMillis.h>
+
+#include "sensesp/sensors/digital_input.h"
+#include "sensesp/sensors/sensor.h"
+#include "sensesp_base_app.h"
+
+#include "driver/pulse_cnt.h"
+
+namespace sensesp {
+
+/**
+ * @brief DigitalInputPcntCounter is the base class for reading
+ * a digital GPIO pin using the Pulse Counter peripheral.
+ *
+ * A typical use case is to count the revolutions of something, such as an
+ * engine, to determine RPM. See /examples/rpm_counter.cpp
+ *
+ * @param pin The GPIO pin to which the device is connected
+ *
+ * @param pin_mode Will be INPUT or INPUT_PULLUP
+ *
+ * @param interrupt_type Accepted values be RISING, FALLING, CHANGE see
+ * Arduino.h
+ *
+ * @param read_delay How often you want to read the pin, in ms
+ *
+ * @param config_path The path to configuring read_delay in the Config UI
+ *
+ * */
+class DigitalInputPcntCounter : public DigitalInput, public Sensor<int> {
+ public:
+  DigitalInputPcntCounter(uint8_t pin, int pin_mode, int interrupt_type,
+                          unsigned int read_delay,
+                          String config_path = "");
+
+  ~DigitalInputPcntCounter();
+
+  
+
+  virtual bool to_json(JsonObject& root) override;
+  virtual bool from_json(const JsonObject& config) override;
+
+ protected:
+  unsigned int read_delay_;
+
+ private:
+  esp_err_t configurePcnt(int interrupt_type);
+  pcnt_unit_handle_t pcnt_unit_ = nullptr;
+  pcnt_channel_handle_t pcnt_channel_ = nullptr;
+
+  int interrupt_type_;
+};
+
+const String ConfigSchema(const DigitalInputPcntCounter& obj);
+
+bool ConfigRequiresRestart(const DigitalInputPcntCounter& obj);
+}  // namespace sensesp
+
+#endif  // SENSESP_SENSORS_DIGITAL_PCNT_INPUT_H_


### PR DESCRIPTION
Using the new PCNT API in ESP IDF 5.x [1], allocate a unit and channel,
configure edge actions and report back to client on a specified interval.

API surface similar to the previous interrupt-based DigitalInputCounter.
    
[1] https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/pcnt.html
    
Fixes #805.
