### PR TITLE
fix: move deprecated attribute after class keyword in AnalogInput

### DIFF
--- a/src/sensesp/sensors/analog_input.h
+++ b/src/sensesp/sensors/analog_input.h
@@ -40,8 +40,7 @@ namespace sensesp {
  * make this parameter be the maximum voltage that you would send into the
  * voltage divider circuit.
  */
-[[deprecated("Use RepeatSensor and Arduino analogReadMilliVolts() instead")]]
-class AnalogInput : public FloatSensor {
+class [[deprecated("Use RepeatSensor and Arduino analogReadMilliVolts() instead")]] AnalogInput : public FloatSensor {
  public:
   AnalogInput(uint8_t pin = A0, unsigned int read_delay = 200,
               const String& config_path = "", float output_scale = 1024.);


### PR DESCRIPTION
Fixes compiler warning about misplaced C++ attribute in `AnalogInput` class declaration.

Modern compilers (gcc 13.2+) require C++ attributes to follow the `class` keyword per C++11/14 standards. The `[[deprecated]]` attribute was positioned before the class keyword, causing a compiler warning.

## Problem
```
.pio/libdeps/halmet/SensESP/src/sensesp/sensors/analog_input.h:44:7: warning: attribute ignored in declaration of 'class sensesp::AnalogInput' [-Wattributes]
   44 | class AnalogInput : public FloatSensor {
      |       ^~~~~~~~~~~
.pio/libdeps/halmet/SensESP/src/sensesp/sensors/analog_input.h:44:7: note: attribute for 'class sensesp::AnalogInput' must follow the 'class' keyword
```

## Changes
- Moved `[[deprecated]]` attribute from before `class` keyword to after it in `analog_input.h`
- No functional changes - deprecation warning still works correctly
- One line change for C++ standard compliance

**Before:**
```cpp
[[deprecated("Use RepeatSensor and Arduino analogReadMilliVolts() instead")]]
class AnalogInput : public FloatSensor {
```

**After:**
```cpp
class [[deprecated("Use RepeatSensor and Arduino analogReadMilliVolts() instead")]] AnalogInput : public FloatSensor {
```

## Testing
- ✅ Compiled successfully with xtensa-esp-elf-gcc 13.2.0 on ESP32 platform
- ✅ "attribute ignored" warning eliminated
- ✅ Deprecation warnings still work correctly (confirmed deprecation messages appear when class is used)
- ✅ No functional changes - attribute behavior unchanged

## Impact
- Fixes compiler warning for users building with recent gcc toolchains
- Improves code standards compliance
- No breaking changes
- No behavior changes

## Environment Tested
- **Platform**: ESP32 (pioarduino platform-espressif32 53.03.13)
- **Compiler**: xtensa-esp-elf-gcc 13.2.0+20240530
- **Framework**: Arduino
- **Build System**: PlatformIO