### PR TITLE
fix(led): apply brightness scaling after gamma correction

### DIFF
--- a/src/sensesp/system/crgb.h
+++ b/src/sensesp/system/crgb.h
@@ -98,6 +98,35 @@ inline constexpr CRGB CRGB::Yellow{255, 255, 0};
 inline constexpr CRGB CRGB::Blue{0, 0, 255};
 
 /**
+ * @brief Apply gamma correction and brightness scaling to a color value.
+ *
+ * Gamma correction is applied first to ensure perceptually correct colors,
+ * then brightness scaling is applied as a linear dimming factor.
+ *
+ * @param value Color value (0-255)
+ * @param brightness Brightness scale (0-255), where 255 = full brightness
+ * @return Scaled value (0-255)
+ */
+inline uint8_t apply_brightness(uint8_t value, uint8_t brightness) {
+  return static_cast<uint8_t>(gamma_correct(value) * brightness / 255);
+}
+
+/**
+ * @brief Convert RGB color to perceptual luminance.
+ *
+ * Uses the standard luminance formula (ITU-R BT.709) that weights
+ * green most heavily, followed by red, then blue.
+ *
+ * @param r Red component (0-255)
+ * @param g Green component (0-255)
+ * @param b Blue component (0-255)
+ * @return Luminance value (0-255)
+ */
+inline uint8_t rgb_to_luminance(uint8_t r, uint8_t g, uint8_t b) {
+  return static_cast<uint8_t>(0.2126 * r + 0.7152 * g + 0.0722 * b);
+}
+
+/**
  * @brief Linear interpolation (blend) between two colors.
  *
  * @param p1 First color (returned when amountOfP2 == 0)

--- a/src/sensesp/system/system_status_led.h
+++ b/src/sensesp/system/system_status_led.h
@@ -123,16 +123,9 @@ class SystemStatusLed : public BaseSystemStatusLed {
 #endif
   uint8_t brightness_;
   void show() override {
-    // Convert the RGB color to a single brightness value using the
-    // perceptual luminance formula.
-    // value is scaled to 0-255.
-    int value = ((0.2126 * leds_[0].r +  // Red contribution
-                    0.7152 * leds_[0].g +  // Green contribution
-                    0.0722 * leds_[0].b    // Blue contribution
-                    ) *
-                   brightness_ / (255.0));
-    // Apply gamma correction for perceptually linear brightness
-    value = gamma_correct(value);
+    // Convert RGB to luminance, then apply gamma correction and brightness
+    uint8_t luminance = rgb_to_luminance(leds_[0].r, leds_[0].g, leds_[0].b);
+    uint8_t value = apply_brightness(luminance, brightness_);
 #if ESP_ARDUINO_VERSION_MAJOR >= 3
     ledcWrite(pin_, value);
 #else
@@ -156,10 +149,10 @@ class RGBSystemStatusLed : public BaseSystemStatusLed {
   uint8_t pin_;
   uint8_t brightness_;
   void show() override {
-    // Apply gamma correction for perceptually linear brightness
-    rgbLedWrite(pin_, gamma_correct(brightness_ * leds_[0].r / 255),
-                gamma_correct(brightness_ * leds_[0].g / 255),
-                gamma_correct(brightness_ * leds_[0].b / 255));
+    rgbLedWrite(pin_,
+                apply_brightness(leds_[0].r, brightness_),
+                apply_brightness(leds_[0].g, brightness_),
+                apply_brightness(leds_[0].b, brightness_));
   }
 
   void set_brightness(uint8_t brightness) override { brightness_ = brightness; }

--- a/test/system/test_crgb/crgb_test.cpp
+++ b/test/system/test_crgb/crgb_test.cpp
@@ -1,0 +1,131 @@
+/**
+ * @file crgb_test.cpp
+ * @brief Unit tests for CRGB color functions (gamma correction, brightness, luminance)
+ */
+
+#include "sensesp/system/crgb.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+// Test gamma_correct() function
+void test_gamma_correct_zero() {
+  // Zero should remain zero
+  TEST_ASSERT_EQUAL(0, gamma_correct(0));
+}
+
+void test_gamma_correct_max() {
+  // 255 should remain 255
+  TEST_ASSERT_EQUAL(255, gamma_correct(255));
+}
+
+void test_gamma_correct_boosts_low_values() {
+  // Inverse gamma should boost low values
+  // For example, 40 should become ~110 (from the lookup table)
+  uint8_t result = gamma_correct(40);
+  TEST_ASSERT_GREATER_THAN(40, result);
+  TEST_ASSERT_EQUAL(110, result);  // Exact value from table
+}
+
+void test_gamma_correct_monotonic() {
+  // Gamma correction should be monotonically increasing
+  for (int i = 1; i < 256; i++) {
+    TEST_ASSERT_GREATER_OR_EQUAL(gamma_correct(i - 1), gamma_correct(i));
+  }
+}
+
+// Test apply_brightness() function
+void test_apply_brightness_full() {
+  // Full brightness (255) should give gamma-corrected value
+  TEST_ASSERT_EQUAL(gamma_correct(100), apply_brightness(100, 255));
+  TEST_ASSERT_EQUAL(gamma_correct(255), apply_brightness(255, 255));
+}
+
+void test_apply_brightness_zero() {
+  // Zero brightness should always give 0
+  TEST_ASSERT_EQUAL(0, apply_brightness(0, 0));
+  TEST_ASSERT_EQUAL(0, apply_brightness(255, 0));
+  TEST_ASSERT_EQUAL(0, apply_brightness(128, 0));
+}
+
+void test_apply_brightness_scaling() {
+  // With brightness=40 and color=255:
+  // gamma_correct(255) = 255, then 255 * 40 / 255 = 40
+  uint8_t result = apply_brightness(255, 40);
+  TEST_ASSERT_EQUAL(40, result);
+}
+
+void test_apply_brightness_order() {
+  // This test verifies the fix: gamma should be applied BEFORE brightness
+  // Old (wrong): gamma_correct(40 * 255 / 255) = gamma_correct(40) = 110
+  // New (correct): gamma_correct(255) * 40 / 255 = 255 * 40 / 255 = 40
+  uint8_t result = apply_brightness(255, 40);
+  TEST_ASSERT_EQUAL(40, result);  // Should be 40, not 110
+}
+
+// Test rgb_to_luminance() function
+void test_rgb_to_luminance_black() {
+  TEST_ASSERT_EQUAL(0, rgb_to_luminance(0, 0, 0));
+}
+
+void test_rgb_to_luminance_white() {
+  // 0.2126*255 + 0.7152*255 + 0.0722*255 = 255
+  TEST_ASSERT_EQUAL(255, rgb_to_luminance(255, 255, 255));
+}
+
+void test_rgb_to_luminance_red() {
+  // Pure red: 0.2126 * 255 = 54.2 ≈ 54
+  uint8_t result = rgb_to_luminance(255, 0, 0);
+  TEST_ASSERT_INT_WITHIN(1, 54, result);
+}
+
+void test_rgb_to_luminance_green() {
+  // Pure green: 0.7152 * 255 = 182.4 ≈ 182
+  uint8_t result = rgb_to_luminance(0, 255, 0);
+  TEST_ASSERT_INT_WITHIN(1, 182, result);
+}
+
+void test_rgb_to_luminance_blue() {
+  // Pure blue: 0.0722 * 255 = 18.4 ≈ 18
+  uint8_t result = rgb_to_luminance(0, 0, 255);
+  TEST_ASSERT_INT_WITHIN(1, 18, result);
+}
+
+void test_rgb_to_luminance_green_dominant() {
+  // Green should contribute most to luminance
+  uint8_t red_lum = rgb_to_luminance(100, 0, 0);
+  uint8_t green_lum = rgb_to_luminance(0, 100, 0);
+  uint8_t blue_lum = rgb_to_luminance(0, 0, 100);
+
+  TEST_ASSERT_GREATER_THAN(red_lum, green_lum);
+  TEST_ASSERT_GREATER_THAN(blue_lum, green_lum);
+  TEST_ASSERT_GREATER_THAN(blue_lum, red_lum);
+}
+
+void setup() {
+  UNITY_BEGIN();
+
+  // Gamma correction tests
+  RUN_TEST(test_gamma_correct_zero);
+  RUN_TEST(test_gamma_correct_max);
+  RUN_TEST(test_gamma_correct_boosts_low_values);
+  RUN_TEST(test_gamma_correct_monotonic);
+
+  // Brightness application tests
+  RUN_TEST(test_apply_brightness_full);
+  RUN_TEST(test_apply_brightness_zero);
+  RUN_TEST(test_apply_brightness_scaling);
+  RUN_TEST(test_apply_brightness_order);
+
+  // Luminance calculation tests
+  RUN_TEST(test_rgb_to_luminance_black);
+  RUN_TEST(test_rgb_to_luminance_white);
+  RUN_TEST(test_rgb_to_luminance_red);
+  RUN_TEST(test_rgb_to_luminance_green);
+  RUN_TEST(test_rgb_to_luminance_blue);
+  RUN_TEST(test_rgb_to_luminance_green_dominant);
+
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary

- Fixes brightness scaling order in both LED status classes
- Previously brightness was applied before gamma correction, causing the inverse gamma to boost dimmed values (brightness=40 resulted in output ~110)
- Now gamma correction is applied first, then brightness scaling, so brightness=40 correctly outputs ~40

### Changes
- Extract `apply_brightness()` and `rgb_to_luminance()` helper functions to `crgb.h` for testability and reuse
- `RGBSystemStatusLed`: Use `apply_brightness()` for each RGB channel
- `SystemStatusLed`: Use `rgb_to_luminance()` and `apply_brightness()` for cleaner code
- Add unit tests for `gamma_correct()`, `apply_brightness()`, and `rgb_to_luminance()`

## Test plan

- [x] Verified on HALSER ESP32-C3 with addressable RGB LED
- [x] LED is now properly dimmed at default brightness (40/255)
- [x] All test suites build successfully (`pio test --without-testing`)
- [x] New unit tests cover edge cases and verify correct calculation order

🤖 Generated with [Claude Code](https://claude.com/claude-code)