### PR TITLE
fix(signalk): add mDNS settle delay and backoff to fix Ethernet race

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -185,6 +185,43 @@ SKWSClient::SKWSClient(const String& config_path,
                 this, 1, NULL);
     MDNS.addService("signalk-sensesp", "tcp", 80);
   });
+
+  if (use_mdns_) {
+    // Arm mdns_ready_ after a settle delay following each network-got-IP event.
+    // Without this delay, MDNS.queryService() frequently returns 0 results on
+    // Ethernet because the mDNS multicast group join completes asynchronously
+    // after DHCP — the race is especially pronounced on Ethernet which gets an
+    // IP faster than WiFi.
+    Network.onEvent(
+        [this](arduino_event_id_t /*event*/, arduino_event_info_t /*info*/) {
+          mdns_ready_ = false;
+          mdns_retry_interval_ms_ = kMdnsInitialBackoffMs;
+          ESP_LOGI(__FILENAME__,
+                   "Network connected, waiting %lums for mDNS to settle",
+                   kMdnsSettleMs);
+          event_loop()->onDelay(kMdnsSettleMs,
+                                [this]() {
+                                  mdns_ready_ = true;
+                                  ESP_LOGI(__FILENAME__, "mDNS ready");
+                                });
+        },
+        ARDUINO_EVENT_ETH_GOT_IP);
+
+    Network.onEvent(
+        [this](arduino_event_id_t /*event*/, arduino_event_info_t /*info*/) {
+          mdns_ready_ = false;
+          mdns_retry_interval_ms_ = kMdnsInitialBackoffMs;
+          ESP_LOGI(__FILENAME__,
+                   "Network connected, waiting %lums for mDNS to settle",
+                   kMdnsSettleMs);
+          event_loop()->onDelay(kMdnsSettleMs,
+                                [this]() {
+                                  mdns_ready_ = true;
+                                  ESP_LOGI(__FILENAME__, "mDNS ready");
+                                });
+        },
+        ARDUINO_EVENT_WIFI_STA_GOT_IP);
+  }
 }
 
 void SKWSClient::connect_loop() {
@@ -552,14 +589,37 @@ void SKWSClient::connect() {
 
   set_connection_state(SKWSConnectionState::kSKWSAuthorizing);
   if (use_mdns_) {
-    if (!get_mdns_service(this->server_address_, this->server_port_)) {
-      ESP_LOGE(__FILENAME__,
-               "No Signal K server found in network when using mDNS service!");
-    } else {
-      ESP_LOGI(__FILENAME__,
-               "Signal K server has been found at address %s:%d by mDNS.",
-               this->server_address_.c_str(), this->server_port_);
+    if (!mdns_ready_) {
+      // mDNS settle timer hasn't fired yet — don't query, just wait.
+      ESP_LOGI(__FILENAME__, "Waiting for mDNS to settle after network up...");
+      set_connection_state(SKWSConnectionState::kSKWSDisconnected);
+      return;
     }
+
+    unsigned long now_ms = millis();
+    if (now_ms - mdns_last_attempt_ms_ < mdns_retry_interval_ms_) {
+      // Still within the backoff window from the last failed query.
+      set_connection_state(SKWSConnectionState::kSKWSDisconnected);
+      return;
+    }
+    mdns_last_attempt_ms_ = now_ms;
+
+    if (!get_mdns_service(this->server_address_, this->server_port_)) {
+      ESP_LOGW(__FILENAME__,
+               "No Signal K server found via mDNS, retrying in %lums",
+               mdns_retry_interval_ms_);
+      // Exponential backoff, capped at kMdnsMaxBackoffMs
+      mdns_retry_interval_ms_ =
+          min(mdns_retry_interval_ms_ * 2, kMdnsMaxBackoffMs);
+      set_connection_state(SKWSConnectionState::kSKWSDisconnected);
+      return;
+    }
+
+    // Successful lookup — reset backoff for next disconnection cycle
+    mdns_retry_interval_ms_ = kMdnsInitialBackoffMs;
+    ESP_LOGI(__FILENAME__,
+             "Signal K server found at %s:%d via mDNS",
+             this->server_address_.c_str(), this->server_port_);
   } else {
     this->server_address_ = this->conf_server_address_;
     this->server_port_ = this->conf_server_port_;

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -165,6 +165,18 @@ class SKWSClient : public FileSystemSaveable,
   bool server_detected_ = false;
   bool token_test_success_ = false;
 
+  // mDNS settle tracking: after a network-got-IP event, we wait
+  // kMdnsSettleMs before attempting the first mDNS query to avoid the
+  // race between DHCP completion and mDNS multicast group join on Ethernet.
+  static constexpr unsigned long kMdnsSettleMs = 4000;
+  bool mdns_ready_ = false;
+
+  // Retry backoff for failed mDNS lookups (ms), capped at kMdnsMaxBackoffMs.
+  static constexpr unsigned long kMdnsInitialBackoffMs = 5000;
+  static constexpr unsigned long kMdnsMaxBackoffMs = 60000;
+  unsigned long mdns_retry_interval_ms_ = kMdnsInitialBackoffMs;
+  unsigned long mdns_last_attempt_ms_ = 0;
+
   // SSL/TLS configuration
   bool ssl_enabled_ = false;
   bool tofu_enabled_ = true;  // TOFU enabled by default


### PR DESCRIPTION
On Ethernet, DHCP completes faster than on WiFi, which means the first MDNS.queryService() call fires before the mDNS stack has joined its multicast groups on the new interface. This causes the server discovery to silently return 0 results even when the Signal K server is present, and the 2-second flat retry loop spins indefinitely without connecting.

Two-part fix:

1. Settle delay: subscribe to ARDUINO_EVENT_ETH_GOT_IP and ARDUINO_EVENT_WIFI_STA_GOT_IP. On each event, reset mdns_ready_ and arm a 4-second one-shot timer via event_loop()->onDelay(). mDNS queries are blocked until the timer fires.

2. Exponential backoff: after a failed mDNS query, double the retry interval (starting at 5s, capped at 60s) instead of hammering queryService() every 2 seconds.

Both the settle timer and the backoff counter are reset when the network gets a new IP (e.g. after a cable reconnect), so recovery is still fast.