### PR TITLE
fix(signalk): connect without token when server security is disabled

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -814,6 +814,17 @@ void SKWSClient::send_access_request(const String server_address,
     return;
   }
 
+  // HTTP 404 means the server has no security enabled — access requests are
+  // not available. Connect without a token.
+  if (http_code == 404) {
+    ESP_LOGI(__FILENAME__,
+             "Server security disabled (404 on access request) — connecting "
+             "without token");
+    auth_token_ = NULL_AUTH_TOKEN;
+    this->connect_ws(server_address, server_port);
+    return;
+  }
+
   // Can't proceed - disconnect and retry later
   ESP_LOGW(__FILENAME__, "Cannot handle response: http=%d, state=%s", http_code, state.c_str());
   set_connection_state(SKWSConnectionState::kSKWSDisconnected);


### PR DESCRIPTION
## Problem

When a Signal K server has security disabled, `POST /signalk/v1/access/requests` returns **404** with the message `"Access requests not available. Server security may not be enabled."`

The client previously fell through to the catch-all handler, logged `"Cannot handle response: http=404"` and disconnected — looping indefinitely without ever connecting.

## Fix

Treat a 404 response on the access request endpoint as a signal that security is disabled. Log a clear message and proceed directly to the WebSocket connection without a token.

If security is later enabled on the server, the existing 401 handler in `test_token()` will catch the rejection and re-initiate the full access request flow.