### PR TITLE
fix: Replace deprecated AnalogInput with RepeatSensor in examples

### DIFF
--- a/examples/analog_input.cpp
+++ b/examples/analog_input.cpp
@@ -1,5 +1,5 @@
 
-#include "sensesp/sensors/analog_input.h"
+#include "sensesp/sensors/sensor.h"
 
 #include <Arduino.h>
 
@@ -34,27 +34,20 @@ void setup() {
   // that indicates this sensor or transform does not have any
   // configuration to save, or that you're not interested in doing
   // run-time configuration.
-  const char* analog_in_config_path = "/indoor_illuminance/analog_in";
   const char* linear_config_path = "/indoor_illuminance/linear";
 
   // Create a sensor that is the source of the data, which will be read every
-  // 500 ms. It's a light sensor that's connected to the ESP's AnalogIn pin.
+  // 500 ms. It's a light sensor that's connected to the ESP's analog input pin.
   // ESP32 has many pins that can be
-  // used for AnalogIn, and they're expressed here as the XX in GPIOXX.
-  // When it's dark, the sensor's output (as read by analogRead()) is 120, and
-  // when it's bright, the output is 850, for a range of 730.
-  uint8_t pin = 34;
+  // used for analog input, and they're expressed here as the XX in GPIOXX.
+  // When it's dark, the sensor's output voltage is about 0.097V, and
+  // when it's bright, the output is about 0.685V, for a range of 0.588V.
+  const uint8_t pin = 34;
   unsigned int read_delay = 500;
 
-  auto* analog_input = new AnalogInput(pin, read_delay, analog_in_config_path);
-
-  // Create a configuration item for the analog input sensor.
-  // This is needed to make the sensor configurable via the web interface.
-
-  ConfigItem(analog_input)
-      ->set_title("Analog Input")
-      ->set_description("Analog input read interval.")
-      ->set_sort_order(1000);
+  auto* analog_input = new RepeatSensor<float>(read_delay, [pin]() {
+    return analogReadMilliVolts(pin) / 1000.;
+  });
 
   // A Linear transform takes its input, multiplies it by the multiplier, then
   // adds the offset, to calculate its output. In this example, the final output
@@ -67,24 +60,24 @@ void setup() {
   // for more details.
   //
   // First, calculate the multiplier. Since the total measurement range
-  // is 730 "analogRead units", and that will be represented by a total
-  // output range of 1.000 (from 0.000 to 1.000), divide 1.000 by 730 to
-  // get the "value per analogRead unit": 1.000 / 730 = 0.00137
+  // is 0.588V, and that will be represented by a total output range of
+  // 1.000 (from 0.000 to 1.000), divide 1.000 by 0.588 to get the
+  // "value per volt": 1.000 / 0.588 = 1.7007
   //
-  // To calculate the offset, multiply the analogRead units at Dark times
-  // the multiplier: 120 * 0.00137 = 0.1644
+  // To calculate the offset, multiply the voltage at Dark times
+  // the multiplier: 0.097 * 1.7007 = 0.1650
   // and make it negative, because the final value for "dark" needs to be 0.000.
   //
   // Proof:
-  // Dark = 120 analogRead units x 0.00137 = 0.1644
-  //        0.1644 + -0.1644 = 0.000
-  // Bright = 850 analogRead units x 0.00137 = 1.1645
-  //        1.1645 + -0.1644 = 1.0001 (rounds to 1.000)
+  // Dark = 0.097V x 1.7007 = 0.1650
+  //        0.1650 + -0.1650 = 0.000
+  // Bright = 0.685V x 1.7007 = 1.1650
+  //        1.1650 + -0.1650 = 1.0000
 
-  const float multiplier = 0.00137;
-  const float offset = -0.1644;
+  const float multiplier = 1.7007;
+  const float offset = -0.1650;
 
-  // Create a linear transform for calibrating the raw input value.
+  // Create a linear transform for calibrating the voltage input value.
   // Connect the analog input to the linear transform.
 
   auto input_calibration = new Linear(multiplier, offset, linear_config_path);

--- a/examples/fuel_level_sensor/fuel_level_sensor_example.cpp
+++ b/examples/fuel_level_sensor/fuel_level_sensor_example.cpp
@@ -1,4 +1,4 @@
-#include "sensesp/sensors/analog_input.h"
+#include "sensesp/sensors/sensor.h"
 #include "sensesp/signalk/signalk_output.h"
 #include "sensesp/transforms/moving_average.h"
 #include "sensesp_app_builder.h"
@@ -14,16 +14,17 @@ void setup() {
   SensESPAppBuilder builder;
   auto sensesp_app = builder.get_app();
 
-  // This reads A0 every 100 ms.
-  // If you're using an ESP32, you must specify the pin number: AnalogInput(14);
-  // You can also specify any read interval: AnalogInput(A0, 500);
-  AnalogInput* input = new AnalogInput();
+  // Read the analog input pin every 200 ms and return the voltage in volts.
+  const uint8_t pin = 36;
+  auto* input = new RepeatSensor<float>(200, [pin]() {
+    return analogReadMilliVolts(pin) / 1000.;
+  });
 
   // scale factor. this will depend on your circuit:
-  // 1. Take the maximum analog input value (i.e. value when sensor is at the
+  // 1. Take the maximum voltage value (i.e. voltage when sensor is at the
   // high end)
-  // 2. Divide 1 by max value. In my case: 1 / 870 = 0.001149425
-  float scale = 0.001149425F;
+  // 2. Divide 1 by max voltage. In my case: 1 / 2.8 = 0.357
+  float scale = 0.357F;
 
   // Takes a moving average for every 10 values, with scale factor
   MovingAverage* avg = new MovingAverage(10, scale);

--- a/examples/hysteresis.cpp
+++ b/examples/hysteresis.cpp
@@ -3,7 +3,7 @@
 
 #include <math.h>
 
-#include "sensesp/sensors/analog_input.h"
+#include "sensesp/sensors/sensor.h"
 #include "sensesp/signalk/signalk_output.h"
 #include "sensesp_app_builder.h"
 
@@ -19,24 +19,18 @@ void setup() {
                     ->get_app();
 
   const char* sk_path = "environment.indoor.illuminance";
-  const char* analog_in_config_path = "/indoor_illuminance/analog_in";
 
   unsigned int read_delay = 500;
 
-  uint8_t pin = 32;
+  const uint8_t pin = 32;
 
-  float output_scale = 3.3;
+  // Use a RepeatSensor to read the analog input voltage. Connect it e.g. to
+  // a photoresistor or a potentiometer with a voltage divider to get an
+  // illustrative test input.
 
-  // Use AnalogInput as an example sensor. Connect it e.g. to a photoresistor
-  // or a potentiometer with a voltage divider to get an illustrative test
-  // input.
-
-  auto* analog_input =
-      new AnalogInput(pin, read_delay, analog_in_config_path, output_scale);
-
-  ConfigItem(analog_input)
-      ->set_title("Analog Input")
-      ->set_sort_order(1000);
+  auto* analog_input = new RepeatSensor<float>(read_delay, [pin]() {
+    return analogReadMilliVolts(pin) / 1000.;
+  });
 
   // Connect the analog input via a hysteresis transform
   // to an SKOutputBool object. The hysteresis function has arbitrary voltage

--- a/examples/lambda_transform.cpp
+++ b/examples/lambda_transform.cpp
@@ -2,7 +2,7 @@
 
 #include <math.h>
 
-#include "sensesp/sensors/analog_input.h"
+#include "sensesp/sensors/sensor.h"
 #include "sensesp/signalk/signalk_output.h"
 #include "sensesp_app_builder.h"
 
@@ -24,28 +24,18 @@ void setup() {
   // To find valid Signal K Paths that fits your need you look at this link:
   // https://signalk.org/specification/1.4.0/doc/vesselsBranch.html
   const char* sk_path = "environment.indoor.illuminance";
-  const char* analog_in_config_path = "/Sensors/Analog Input";
 
   unsigned int read_delay = 500;
 
-  uint8_t pin = 32;
+  const uint8_t pin = 32;
 
-  float output_scale = 3.3;
+  // Use a RepeatSensor to read the analog input voltage. Connect it e.g. to
+  // a photoresistor or a potentiometer with a voltage divider to get an
+  // illustrative test input.
 
-  // Use AnalogInput as an example sensor. Connect it e.g. to a photoresistor
-  // or a potentiometer with a voltage divider to get an illustrative test
-  // input.
-
-  auto* analog_input =
-      new AnalogInput(pin, read_delay, analog_in_config_path, output_scale);
-
-  ConfigItem(analog_input)
-      ->set_title("Analog Input")
-      ->set_description(
-          "Connect the analog input at pin 32 to a photoresistor or "
-          "potentiometer with a voltage divider to get an illustrative test "
-          "input.")
-      ->set_sort_order(1000);
+  auto* analog_input = new RepeatSensor<float>(read_delay, [pin]() {
+    return analogReadMilliVolts(pin) / 1000.;
+  });
 
   // This is our transform function. The example is artificial; a log transform
   // with configurable multiplier, base, and offset parameters. The

--- a/examples/milone_level_sensor/milone_level_sensor.cpp
+++ b/examples/milone_level_sensor/milone_level_sensor.cpp
@@ -1,6 +1,5 @@
-#include "sensesp/sensors/analog_input.h"
+#include "sensesp/sensors/sensor.h"
 #include "sensesp/signalk/signalk_output.h"
-#include "sensesp/transforms/analogvoltage.h"
 #include "sensesp/transforms/curveinterpolator.h"
 #include "sensesp/transforms/linear.h"
 #include "sensesp/transforms/moving_average.h"
@@ -63,48 +62,24 @@ void setup() {
   // broadcast SignalK data. This path should appear as an argument in the
   // SKOutputNumber transform.
 
-  // The "Configuration path" is combined with "/config" to formulate a URL
-  // used by the RESTful API for retrieving or setting configuration data.
-  // It is ALSO used to specify a path to the SPIFFS file system
-  // where configuration data is saved on the MCU board. It should
-  // ALWAYS start with a forward slash if specified. If left blank,
-  // that indicates this sensor or transform does not have any
-  // configuration to save, or that you're not interested in doing
-  // run-time configuration.
-
-  const char *kAnalogInConfigPath = "/freshWaterTank_starboard/analogin";
-
   // Create a sensor that is the source of our data, that will be read every 500
-  // ms. It's a Milone depth sensor that's connected to the ESP's AnalogIn pin.
-  // ESP32 has many pins that can be
-  // used for AnalogIn, and they're expressed here as the XX in GPIOXX.
-  uint8_t pin = 36;
+  // ms. It's a Milone depth sensor that's connected to the ESP's analog input
+  // pin. ESP32 has many pins that can be used for analog input, and they're
+  // expressed here as the XX in GPIOXX.
+  const uint8_t pin = 36;
 
   unsigned int read_delay = 500;
 
-  auto *analog_input = new AnalogInput(pin, read_delay, kAnalogInConfigPath);
-
-  ConfigItem(analog_input)
-      ->set_title("Analog Input")
-      ->set_description("Analog input from Milone depth sensor")
-      ->set_sort_order(1000);
-
-  // comment out the following line to suppress the output of the raw ADC
-  // measurement values. analog_input->connect_to(new
-  // SKOutputNumber("tanks.freshWater.starboard.rawADC"));
-
-  // Comment out the following 2 lines to suppress the output of the ADC
-  // measurement in volts. analog_input->connect_to(new AnalogVoltage(1.0, 1.0,
-  // 0))
-  //             ->connect_to(new
-  //             SKOutputNumber("tanks.freshWater.starboard.voltsADC"));
+  auto* analog_input = new RepeatSensor<float>(read_delay, [pin]() {
+    return analogReadMilliVolts(pin) / 1000.;
+  });
 
   // The Milone depth sensor is wired as a voltage divider with Vin connected to
   // the sensor, a variable resistor. The sensor is then connected to R2, a
-  // fixed resistor then connected to gnd. The voltrage across the fixed
+  // fixed resistor then connected to gnd. The voltage across the fixed
   // resistor is measured by the MCU analog input ADC.
 
-  // A VoltageDeviderR1 transform is used to extract the Milone sensor
+  // A VoltageDividerR1 transform is used to extract the Milone sensor
   // resistance from the data.
 
   const float scale = 1.0;
@@ -112,18 +87,10 @@ void setup() {
   const float R2 = 100;
   const unsigned int samples = 10;
 
-  // Wire up the output of the analog input to the VoltageDividerR1 transform.
+  // Wire up the output of the analog input to the VoltageDividerR1 transform
   // and then output the results to the SignalK server.
-
-  // Comment out the following 3 lines to suppress the output of the eTape
-  // sensor resistance.
-
-  auto analog_voltage = new AnalogVoltage(1.0, 1.0, 0.);
-
-  ConfigItem(analog_voltage)
-      ->set_title("Analog Voltage")
-      ->set_description("Voltage from Milone depth sensor")
-      ->set_sort_order(1000);
+  // The RepeatSensor outputs voltage directly, so no AnalogVoltage conversion
+  // is needed.
 
   auto voltage_divider = new VoltageDividerR1(R2, Vin, "/freshWaterTank_starboard/divider");
 
@@ -131,18 +98,11 @@ void setup() {
       ->set_title("Voltage Divider")
       ->set_sort_order(1100);
 
-  analog_input->connect_to(analog_voltage)
-      ->connect_to(voltage_divider)
+  analog_input->connect_to(voltage_divider)
       ->connect_to(new SKOutputFloat("tanks.freshWater.starboard.R1"));
 
   // Use the ETapeInterpolator to output the water level depth in the tank and
   // pass it through the MovingAverage transport before outputting the result.
-
-  auto analog_voltage2 = new AnalogVoltage(1.0, 1.0, 0.);
-
-  ConfigItem(analog_voltage2)
-      ->set_title("Analog Voltage 2")
-      ->set_sort_order(1200);
 
   auto voltage_divider2 = new VoltageDividerR1(R2, Vin, "/freshWaterTank_starboard/divider2");
 
@@ -152,8 +112,7 @@ void setup() {
 
   auto moving_average = new MovingAverage(samples, scale, "/freshWaterTank_starboard/samples");
 
-  analog_input->connect_to(analog_voltage2)
-      ->connect_to(voltage_divider2)
+  analog_input->connect_to(voltage_divider2)
       ->connect_to(new ETapeInterpreter(""))
       ->connect_to(moving_average)
       ->connect_to(

--- a/examples/ssl_connection.cpp
+++ b/examples/ssl_connection.cpp
@@ -28,7 +28,7 @@
  * after the initial connection, without requiring a CA certificate bundle.
  */
 
-#include "sensesp/sensors/analog_input.h"
+#include "sensesp/sensors/sensor.h"
 #include "sensesp/signalk/signalk_output.h"
 #include "sensesp_app.h"
 #include "sensesp_app_builder.h"
@@ -73,10 +73,12 @@ void setup() {
   ws_client->set_tofu_enabled(true);
 
   // Create a simple sensor to demonstrate the connection is working.
-  // This reads the ESP32's internal hall effect sensor and sends it to
+  // This reads an analog input pin and sends the voltage to
   // the Signal K server.
-  uint8_t pin = 34;
-  auto* analog_input = new AnalogInput(pin, 1000, "/sensors/analog");
+  const uint8_t pin = 34;
+  auto* analog_input = new RepeatSensor<float>(1000, [pin]() {
+    return analogReadMilliVolts(pin) / 1000.;
+  });
 
   analog_input->connect_to(
       new SKOutputFloat("electrical.batteries.house.voltage"));

--- a/examples/temperature_sender.cpp
+++ b/examples/temperature_sender.cpp
@@ -1,8 +1,7 @@
 #include <Arduino.h>
 
-#include "sensesp/sensors/analog_input.h"
+#include "sensesp/sensors/sensor.h"
 #include "sensesp/signalk/signalk_output.h"
-#include "sensesp/transforms/analogvoltage.h"
 #include "sensesp/transforms/curveinterpolator.h"
 #include "sensesp/transforms/linear.h"
 #include "sensesp/transforms/voltagedivider.h"
@@ -90,28 +89,25 @@ void setup() {
   Connecting a physical temperature sender to the MCU involves using a "voltage
   divider" circuit. A resistor (R1) is connected to the voltage output of the
   board (3.3v or 5v, specified in Vin) to an intersection of two wires. One wire
-  connects to the AnalogInput pin of the MCU, and the other wire connects to the
-  sending unit doing the measurement. The sender is itself a variable resistor
-  that is then connected to ground, forming the "R2" of a voltage divider
-  circuit. The transform "VoltageDividerR2" takes a known voltage in (3.3 in
-  this example), a known value for resistor R1 (51 ohms in this example), and
-  based on the voltage read from AnalogInput, computes the resistance of the
-  sender (R2), in ohms.
+  connects to the analog input pin of the MCU, and the other wire connects to
+  the sending unit doing the measurement. The sender is itself a variable
+  resistor that is then connected to ground, forming the "R2" of a voltage
+  divider circuit. The transform "VoltageDividerR2" takes a known voltage in
+  (3.3 in this example), a known value for resistor R1 (51 ohms in this
+  example), and based on the voltage read from the analog input, computes the
+  resistance of the sender (R2), in ohms.
 
-  One important point: the value of the output from the AnalogIn pin is not in
-  volts, as implied above. It's a value in the range 0 - 1023, and it represents
-  the voltage in the range 0.0V - 3.3V. But we need to send an actual voltage to
-  VoltageDivider2(), which means we need to first convert the value of
-  AnalogInput to volts, which is done with AnalogVoltage().
+  Using analogReadMilliVolts() via a RepeatSensor, we get the pin voltage
+  directly in volts, which can be fed straight into VoltageDividerR2().
 
-  Although complex, this example perfectly illustrates the normal "chain" for
-  getting a value from a sensor all the way to the Signal K server:
+  This example illustrates the normal "chain" for getting a value from a sensor
+  all the way to the Signal K server:
   - A real-world sensor sends its output to an input pin on the microcontroller
   - The value read from that pin gives us our actual input to the program. In
-  this example, that's an AnalogInput().
+  this example, that's a RepeatSensor reading analogReadMilliVolts().
   - That input is then sent through one or more transforms so that the end
   result is the value we want to send to Signal K. In this example, the
-  transforms are VoltageDivider2(), then
+  transforms are VoltageDividerR2(), then
   TemperatureInterpreter(), then Linear().
   - Finally, the value we want is sent to the final "consumer", in this case
   SKOutputNumber().
@@ -135,18 +131,17 @@ void setup() {
   // circuit
   const float R1 = 51.0;
 
-  // An AnalogInput gets the value from the microcontroller's AnalogIn pin,
-  // which is a value from 0 to 1023 and then scales it to the max pin voltage
-  // (max_analog_in_voltage), giving the pin voltage.
-  const float max_analog_in_voltage = 3.3;
-  // ESP32 has many pins that can be used for AnalogIn, and they're
+  // A RepeatSensor reads the analog input pin voltage using
+  // analogReadMilliVolts() and converts to volts.
+  // ESP32 has many pins that can be used for analog input, and they're
   // expressed here as the XX in GPIOXX.
-  auto* analog_input = new AnalogInput(
-      36, 1000, "/12V_alternator/temp/analog_in/", max_analog_in_voltage);
+  const uint8_t pin = 36;
+  auto* analog_input = new RepeatSensor<float>(1000, [pin]() {
+    return analogReadMilliVolts(pin) / 1000.;
+  });
 
-  /* Translating the number returned by AnalogInput into a temperature,
-     and sending it to Signal K, requires several transforms. Wire them
-     up in sequence:
+  /* Translating the voltage into a temperature and sending it to Signal K
+     requires several transforms. Wire them up in sequence:
      - convert voltage into ohms with VoltageDividerR2()
      - find the Kelvin value for the given ohms value with
      TemperatureInterpreter()


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<ul>
<li>Replace all <code>AnalogInput</code> usages in example files with <code>RepeatSensor&#x3C;float></code> + <code>analogReadMilliVolts()</code>, as recommended by the deprecation notice</li>
<li><code>analogReadMilliVolts()</code> returns voltage directly, eliminating the need for <code>AnalogVoltage</code> transforms and <code>output_scale</code> parameters</li>
<li>The deprecated <code>AnalogInput</code> class itself is retained for backward compatibility</li>
</ul>
<h2 data-heading="Files changed (7 examples)">Files changed (7 examples)</h2>
<ul>
<li><code>examples/analog_input.cpp</code> — recalculated Linear calibration for voltage-based input</li>
<li><code>examples/lambda_transform.cpp</code> — simplified, removed config/scale</li>
<li><code>examples/hysteresis.cpp</code> — simplified, removed config/scale</li>
<li><code>examples/ssl_connection.cpp</code> — straightforward replacement</li>
<li><code>examples/temperature_sender.cpp</code> — updated comments, feeds voltage directly into VoltageDividerR2</li>
<li><code>examples/milone_level_sensor/milone_level_sensor.cpp</code> — removed AnalogVoltage intermediary, feeds voltage directly into VoltageDividerR1</li>
<li><code>examples/fuel_level_sensor/fuel_level_sensor_example.cpp</code> — recalculated scale for voltage-based input</li>
</ul>
<h2 data-heading="Test plan">Test plan</h2>
<p>All 7 modified examples were test-compiled locally with <code>pio ci</code> against <code>pioarduino_esp32</code>:</p>

Example | Result
-- | --
analog_input.cpp | SUCCESS
hysteresis.cpp | SUCCESS
lambda_transform.cpp | SUCCESS
ssl_connection.cpp | SUCCESS
temperature_sender.cpp | SUCCESS
milone_level_sensor/milone_level_sensor.cpp | SUCCESS
fuel_level_sensor/fuel_level_sensor_example.cpp | SUCCESS


<p>CI will additionally test <code>lambda_transform.cpp</code> and <code>ssl_connection.cpp</code> across the matrix (esp32/esp32c3 × arduino/pioarduino).</p><!--EndFragment-->
</body>
</html>