### PR TITLE
fix: Fix deprecated volatile increment operator warnings

### DIFF
--- a/src/sensesp/sensors/digital_input.cpp
+++ b/src/sensesp/sensors/digital_input.cpp
@@ -41,7 +41,7 @@ bool DigitalInputCounter::from_json(const JsonObject& config) {
 
 void DigitalInputDebounceCounter::handleInterrupt() {
   if (since_last_event_ > ignore_interval_ms_) {
-    counter_++;
+    counter_ = counter_ + 1;
     since_last_event_ = 0;
   }
 }

--- a/src/sensesp/sensors/digital_input.h
+++ b/src/sensesp/sensors/digital_input.h
@@ -95,7 +95,7 @@ class DigitalInputCounter : public DigitalInput, public Sensor<int> {
   DigitalInputCounter(uint8_t pin, int pin_mode, int interrupt_type,
                       unsigned int read_delay, String config_path = "")
       : DigitalInputCounter(pin, pin_mode, interrupt_type, read_delay,
-                            config_path, [this]() { this->counter_++; }) {
+                            config_path, [this]() { this->counter_ = this->counter_ + 1; }) {
     event_loop()->onInterrupt(pin_, interrupt_type_, interrupt_handler_);
 
     event_loop()->onRepeat(read_delay_, [this]() {


### PR DESCRIPTION
## Summary

- Replace `counter_++` with `counter_ = counter_ + 1` for the volatile-qualified `counter_` member
- The `++` operator on volatile types is deprecated in C++20, causing compiler warnings

## Files changed

- `src/sensesp/sensors/digital_input.h` — lambda in `DigitalInputCounter` constructor
- `src/sensesp/sensors/digital_input.cpp` — `DigitalInputDebounceCounter::handleInterrupt()`

## Test plan

- Compiled `rpm_counter.cpp` example (uses `DigitalInputCounter`) with `pio ci` against `pioarduino_esp32` — no volatile warnings