### PR TITLE
Harden SafeQueue against mutex corruption on single-core ESP32

### DIFF
--- a/src/sensesp/system/task_queue_producer.h
+++ b/src/sensesp/system/task_queue_producer.h
@@ -12,44 +12,42 @@
 namespace sensesp {
 
 /**
- * @brief Thread-safe queue for inter-task communication. Works like std::queue.
+ * @brief Thread-safe queue for inter-task communication.
+ *
+ * Uses a statically allocated FreeRTOS mutex (no heap allocation) to avoid
+ * corruption from heap fragmentation or adjacent stack overflows.
+ *
+ * Instances must outlive all tasks that access them. Destroying a SafeQueue
+ * while another task is blocked on it is undefined behavior.
  *
  * @tparam T
  */
 template <typename T>
-class SafeQueue : public std::queue<T> {
+class SafeQueue {
  public:
-  SafeQueue() : std::queue<T>() {
-    write_lock_ = xSemaphoreCreateMutex();
-    if (write_lock_ == nullptr) {
-      // Handle semaphore creation failure
-      ESP_LOGE("SafeQueue", "Failed to create mutex semaphore");
-    }
+  SafeQueue() {
+    write_lock_ = xSemaphoreCreateMutexStatic(&write_lock_buffer_);
   }
 
-  ~SafeQueue() {
-    if (write_lock_ != nullptr) {
-      vSemaphoreDelete(write_lock_);
-    }
-  }
+  // Non-copyable, non-movable — the semaphore handle is not transferable.
+  SafeQueue(const SafeQueue&) = delete;
+  SafeQueue& operator=(const SafeQueue&) = delete;
+  SafeQueue(SafeQueue&&) = delete;
+  SafeQueue& operator=(SafeQueue&&) = delete;
 
   void push(const T& value) {
-    if (write_lock_ == nullptr) return;
     if (xSemaphoreTake(write_lock_, portMAX_DELAY) == pdTRUE) {
-      std::queue<T>::push(value);
+      queue_.push(value);
       xSemaphoreGive(write_lock_);
     }
   }
 
   bool pop(T& value, unsigned int max_duration_ms) {
-    if (write_lock_ == nullptr) {
-      return false;
-    }
     bool result = false;
     if (xSemaphoreTake(write_lock_, portMAX_DELAY) == pdTRUE) {
-      if (!std::queue<T>::empty()) {
-        value = std::queue<T>::front();
-        std::queue<T>::pop();
+      if (!queue_.empty()) {
+        value = queue_.front();
+        queue_.pop();
         result = true;
       }
       xSemaphoreGive(write_lock_);
@@ -58,31 +56,27 @@ class SafeQueue : public std::queue<T> {
   }
 
   bool empty() {
-    if (write_lock_ == nullptr) {
-      return true;
-    }
     bool result = true;
     if (xSemaphoreTake(write_lock_, portMAX_DELAY) == pdTRUE) {
-      result = std::queue<T>::empty();
+      result = queue_.empty();
       xSemaphoreGive(write_lock_);
     }
     return result;
   }
 
   size_t size() {
-    if (write_lock_ == nullptr) {
-      return 0;
-    }
     size_t result = 0;
     if (xSemaphoreTake(write_lock_, portMAX_DELAY) == pdTRUE) {
-      result = std::queue<T>::size();
+      result = queue_.size();
       xSemaphoreGive(write_lock_);
     }
     return result;
   }
 
- protected:
-  SemaphoreHandle_t write_lock_;  // Lock for writing to the queue
+ private:
+  std::queue<T> queue_;
+  StaticSemaphore_t write_lock_buffer_;
+  SemaphoreHandle_t write_lock_;
 };
 
 /**

--- a/test/system/test_task_queue_producer/task_queue_producer_test.cpp
+++ b/test/system/test_task_queue_producer/task_queue_producer_test.cpp
@@ -1,0 +1,327 @@
+/**
+ * @file task_queue_producer_test.cpp
+ * @brief Unit tests for SafeQueue and TaskQueueProducer cross-task
+ *        communication. These tests exercise the scenarios that crash
+ *        on single-core ESP32-C3.
+ */
+
+#include <Arduino.h>
+
+#include "ReactESP.h"
+#include "sensesp/system/task_queue_producer.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+// ---------------------------------------------------------------------------
+// SafeQueue basic operations
+// ---------------------------------------------------------------------------
+
+void test_safe_queue_starts_empty() {
+  SafeQueue<int> q;
+  TEST_ASSERT_TRUE(q.empty());
+  TEST_ASSERT_EQUAL(0, q.size());
+}
+
+void test_safe_queue_push_pop() {
+  SafeQueue<int> q;
+  q.push(42);
+  TEST_ASSERT_FALSE(q.empty());
+  TEST_ASSERT_EQUAL(1, q.size());
+
+  int value = 0;
+  bool got = q.pop(value, 0);
+  TEST_ASSERT_TRUE(got);
+  TEST_ASSERT_EQUAL(42, value);
+  TEST_ASSERT_TRUE(q.empty());
+}
+
+void test_safe_queue_fifo_order() {
+  SafeQueue<int> q;
+  for (int i = 0; i < 10; i++) {
+    q.push(i);
+  }
+  TEST_ASSERT_EQUAL(10, q.size());
+
+  for (int i = 0; i < 10; i++) {
+    int value = -1;
+    bool got = q.pop(value, 0);
+    TEST_ASSERT_TRUE(got);
+    TEST_ASSERT_EQUAL(i, value);
+  }
+  TEST_ASSERT_TRUE(q.empty());
+}
+
+void test_safe_queue_pop_from_empty_returns_false() {
+  SafeQueue<int> q;
+  int value = 99;
+  bool got = q.pop(value, 0);
+  TEST_ASSERT_FALSE(got);
+  TEST_ASSERT_EQUAL(99, value);  // value unchanged
+}
+
+// ---------------------------------------------------------------------------
+// SafeQueue concurrent access from two FreeRTOS tasks
+// ---------------------------------------------------------------------------
+
+static const int kConcurrentCount = 500;
+
+struct ConcurrentTestContext {
+  SafeQueue<int>* queue;
+  SemaphoreHandle_t done;
+  int produced_count;
+  int consumed_values[kConcurrentCount];
+  int consumed_count;
+};
+
+static void producer_task(void* param) {
+  auto* ctx = static_cast<ConcurrentTestContext*>(param);
+  for (int i = 0; i < kConcurrentCount; i++) {
+    ctx->queue->push(i);
+    // Yield occasionally to interleave with consumer
+    if (i % 10 == 0) {
+      vTaskDelay(1);
+    }
+  }
+  ctx->produced_count = kConcurrentCount;
+  xSemaphoreGive(ctx->done);
+  vTaskDelete(nullptr);
+}
+
+void test_safe_queue_concurrent_access() {
+  SafeQueue<int> queue;
+  ConcurrentTestContext ctx = {};
+  ctx.queue = &queue;
+  ctx.done = xSemaphoreCreateBinary();
+  ctx.produced_count = 0;
+  ctx.consumed_count = 0;
+
+  // Start producer on a separate task
+  TaskHandle_t task_handle;
+  xTaskCreate(producer_task, "producer", 4096, &ctx, 1, &task_handle);
+
+  // Consumer: poll until all values received (with timeout)
+  unsigned long start = millis();
+  while (ctx.consumed_count < kConcurrentCount && millis() - start < 5000) {
+    int value;
+    while (queue.pop(value, 0)) {
+      if (ctx.consumed_count < kConcurrentCount) {
+        ctx.consumed_values[ctx.consumed_count++] = value;
+      }
+    }
+    vTaskDelay(1);
+  }
+
+  // Wait for producer to finish
+  xSemaphoreTake(ctx.done, pdMS_TO_TICKS(2000));
+
+  TEST_ASSERT_EQUAL(kConcurrentCount, ctx.produced_count);
+  TEST_ASSERT_EQUAL(kConcurrentCount, ctx.consumed_count);
+
+  // Verify FIFO order preserved
+  for (int i = 0; i < kConcurrentCount; i++) {
+    TEST_ASSERT_EQUAL(i, ctx.consumed_values[i]);
+  }
+
+  vSemaphoreDelete(ctx.done);
+}
+
+// ---------------------------------------------------------------------------
+// SafeQueue stress test: rapid interleaved access from two tasks
+// ---------------------------------------------------------------------------
+
+static const int kStressCount = 1000;
+
+struct StressTestContext {
+  SafeQueue<int>* queue;
+  SemaphoreHandle_t done;
+  int push_count;
+};
+
+static void stress_producer_task(void* param) {
+  auto* ctx = static_cast<StressTestContext*>(param);
+  for (int i = 0; i < kStressCount; i++) {
+    ctx->queue->push(i);
+    // No delay — maximum contention
+  }
+  ctx->push_count = kStressCount;
+  xSemaphoreGive(ctx->done);
+  vTaskDelete(nullptr);
+}
+
+void test_safe_queue_stress() {
+  SafeQueue<int> queue;
+  StressTestContext ctx = {};
+  ctx.queue = &queue;
+  ctx.done = xSemaphoreCreateBinary();
+  ctx.push_count = 0;
+
+  TaskHandle_t task_handle;
+  xTaskCreate(stress_producer_task, "stress", 4096, &ctx, 1, &task_handle);
+
+  int pop_count = 0;
+  int last_value = -1;
+  unsigned long start = millis();
+
+  while (pop_count < kStressCount && millis() - start < 10000) {
+    int value;
+    while (queue.pop(value, 0)) {
+      // Values must arrive in order
+      TEST_ASSERT_GREATER_THAN(last_value, value);
+      last_value = value;
+      pop_count++;
+    }
+    // Busy-poll with minimal delay
+    taskYIELD();
+  }
+
+  xSemaphoreTake(ctx.done, pdMS_TO_TICKS(2000));
+
+  TEST_ASSERT_EQUAL(kStressCount, ctx.push_count);
+  TEST_ASSERT_EQUAL(kStressCount, pop_count);
+
+  vSemaphoreDelete(ctx.done);
+}
+
+// ---------------------------------------------------------------------------
+// TaskQueueProducer: set() from producer task, emit on consumer event loop
+// ---------------------------------------------------------------------------
+
+static const int kTQPCount = 50;
+
+struct TQPTestContext {
+  TaskQueueProducer<int>* tqp;
+  SemaphoreHandle_t done;
+};
+
+static void tqp_producer_task(void* param) {
+  auto* ctx = static_cast<TQPTestContext*>(param);
+  for (int i = 0; i < kTQPCount; i++) {
+    ctx->tqp->set(i);
+    vTaskDelay(1);
+  }
+  xSemaphoreGive(ctx->done);
+  vTaskDelete(nullptr);
+}
+
+void test_task_queue_producer_cross_task_emit() {
+  auto event_loop = std::make_shared<reactesp::EventLoop>();
+
+  // Create TQP with poll rate 0 (every tick) on our event loop
+  auto tqp = std::make_shared<TaskQueueProducer<int>>(0, event_loop, 0);
+
+  // Track emitted values
+  int received_count = 0;
+  int received_values[kTQPCount];
+  memset(received_values, -1, sizeof(received_values));
+
+  tqp->attach([&received_count, &received_values, &tqp]() {
+    if (received_count < kTQPCount) {
+      received_values[received_count++] = tqp->get();
+    }
+  });
+
+  TQPTestContext ctx = {};
+  ctx.tqp = tqp.get();
+  ctx.done = xSemaphoreCreateBinary();
+
+  TaskHandle_t task_handle;
+  xTaskCreate(tqp_producer_task, "tqp_prod", 4096, &ctx, 1, &task_handle);
+
+  // Run the consumer event loop until all values received or timeout
+  unsigned long start = millis();
+  while (received_count < kTQPCount && millis() - start < 5000) {
+    event_loop->tick();
+    vTaskDelay(1);
+  }
+
+  xSemaphoreTake(ctx.done, pdMS_TO_TICKS(2000));
+
+  TEST_ASSERT_EQUAL(kTQPCount, received_count);
+
+  // Verify values arrived in order
+  for (int i = 0; i < kTQPCount; i++) {
+    TEST_ASSERT_EQUAL(i, received_values[i]);
+  }
+
+  vSemaphoreDelete(ctx.done);
+}
+
+// ---------------------------------------------------------------------------
+// TaskQueueProducer: multiple rapid sets without yielding
+// ---------------------------------------------------------------------------
+
+static void tqp_burst_producer_task(void* param) {
+  auto* ctx = static_cast<TQPTestContext*>(param);
+  // Burst all values without yielding — stresses the queue
+  for (int i = 0; i < kTQPCount; i++) {
+    ctx->tqp->set(i);
+  }
+  xSemaphoreGive(ctx->done);
+  vTaskDelete(nullptr);
+}
+
+void test_task_queue_producer_burst() {
+  auto event_loop = std::make_shared<reactesp::EventLoop>();
+  auto tqp = std::make_shared<TaskQueueProducer<int>>(0, event_loop, 0);
+
+  int received_count = 0;
+  int received_values[kTQPCount];
+  memset(received_values, -1, sizeof(received_values));
+
+  tqp->attach([&received_count, &received_values, &tqp]() {
+    if (received_count < kTQPCount) {
+      received_values[received_count++] = tqp->get();
+    }
+  });
+
+  TQPTestContext ctx = {};
+  ctx.tqp = tqp.get();
+  ctx.done = xSemaphoreCreateBinary();
+
+  TaskHandle_t task_handle;
+  xTaskCreate(tqp_burst_producer_task, "burst", 4096, &ctx, 1, &task_handle);
+
+  unsigned long start = millis();
+  while (received_count < kTQPCount && millis() - start < 5000) {
+    event_loop->tick();
+    vTaskDelay(1);
+  }
+
+  xSemaphoreTake(ctx.done, pdMS_TO_TICKS(2000));
+
+  TEST_ASSERT_EQUAL(kTQPCount, received_count);
+  for (int i = 0; i < kTQPCount; i++) {
+    TEST_ASSERT_EQUAL(i, received_values[i]);
+  }
+
+  vSemaphoreDelete(ctx.done);
+}
+
+// ---------------------------------------------------------------------------
+// Test runner
+// ---------------------------------------------------------------------------
+
+void setup() {
+  delay(2000);  // Allow serial connection to stabilize
+
+  UNITY_BEGIN();
+
+  // SafeQueue basics
+  RUN_TEST(test_safe_queue_starts_empty);
+  RUN_TEST(test_safe_queue_push_pop);
+  RUN_TEST(test_safe_queue_fifo_order);
+  RUN_TEST(test_safe_queue_pop_from_empty_returns_false);
+
+  // SafeQueue cross-task
+  RUN_TEST(test_safe_queue_concurrent_access);
+  RUN_TEST(test_safe_queue_stress);
+
+  // TaskQueueProducer cross-task
+  RUN_TEST(test_task_queue_producer_cross_task_emit);
+  RUN_TEST(test_task_queue_producer_burst);
+
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary

- **SafeQueue**: Replace heap-allocated mutex with `xSemaphoreCreateMutexStatic` (inline `StaticSemaphore_t`), switch from public `std::queue` inheritance to composition, delete copy/move constructors
- **connect_to(shared_ptr)**: Change from `weak_ptr` to strong reference capture — the `weak_ptr` caused consumers to be destroyed when the caller's `shared_ptr` went out of scope, leading to silent data loss or use-after-free crashes
- **Tests**: 8 SafeQueue/TaskQueueProducer tests (concurrent access, stress, cross-task emit) + 6 ValueProducer connect_to lifecycle tests

The `connect_to` fix is critical: on embedded systems, signal chain objects live for the program's lifetime. The raw pointer overload already assumes infinite lifetime — the `shared_ptr` overload should too.

## Test plan

- [x] All 14 unit tests pass on ESP32-C3 (HALSER hardware)
- [x] Compiles for both `pioarduino_esp32` and `pioarduino_esp32c3`
- [ ] Run existing test suites (`test_crgb`, `test_offline`) to verify no regression
- [ ] End-to-end test with NMEA0183 wind sensor

🤖 Generated with [Claude Code](https://claude.com/claude-code)