### PR TITLE
Fix connect_to(shared_ptr) use-after-free from weak_ptr

### DIFF
--- a/src/sensesp/system/valueproducer.h
+++ b/src/sensesp/system/valueproducer.h
@@ -51,12 +51,10 @@ class ValueProducer : virtual public Observable {
   >::type
   connect_to(std::shared_ptr<VConsumer> consumer) {
     using CInput = typename VConsumer::input_type;
-    // Capture consumer_producer as weak_ptr to avoid strong reference cycles
-    std::weak_ptr<VConsumer> weak_consumer = consumer;
-    this->attach([this, weak_consumer]() {
-      if (auto consumer = weak_consumer.lock()) {
-        consumer->set(static_cast<CInput>(this->get()));
-      }
+    // Strong reference: the observer lambda owns the shared_ptr, keeping the
+    // consumer alive. This assumes acyclic signal chains (no A→B→A loops).
+    this->attach([this, consumer]() {
+      consumer->set(static_cast<CInput>(this->get()));
     });
     return consumer;
   }

--- a/test/system/test_valueproducer/valueproducer_test.cpp
+++ b/test/system/test_valueproducer/valueproducer_test.cpp
@@ -1,0 +1,155 @@
+/**
+ * @file valueproducer_test.cpp
+ * @brief Tests for ValueProducer::connect_to() lifecycle behavior.
+ *
+ * Verifies that connect_to(shared_ptr) keeps the consumer alive and that
+ * values flow through the connection after the caller's shared_ptr goes
+ * out of scope.
+ */
+
+#include <Arduino.h>
+
+#include "sensesp/system/lambda_consumer.h"
+#include "sensesp/system/observablevalue.h"
+#include "sensesp/system/valueproducer.h"
+#include "sensesp/transforms/lambda_transform.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+// ---------------------------------------------------------------------------
+// Baseline: raw pointer connect_to works
+// ---------------------------------------------------------------------------
+
+void test_connect_to_raw_pointer() {
+  ObservableValue<int> producer(0);
+  int received = -1;
+
+  LambdaConsumer<int> consumer([&received](int v) { received = v; });
+  producer.connect_to(&consumer);
+
+  producer.set(42);
+  TEST_ASSERT_EQUAL(42, received);
+}
+
+// ---------------------------------------------------------------------------
+// Baseline: reference connect_to works
+// ---------------------------------------------------------------------------
+
+void test_connect_to_reference() {
+  ObservableValue<int> producer(0);
+  int received = -1;
+
+  LambdaConsumer<int> consumer([&received](int v) { received = v; });
+  producer.connect_to(consumer);
+
+  producer.set(99);
+  TEST_ASSERT_EQUAL(99, received);
+}
+
+// ---------------------------------------------------------------------------
+// shared_ptr consumer survives after local shared_ptr goes out of scope
+// ---------------------------------------------------------------------------
+
+void test_connect_to_shared_ptr_keeps_consumer_alive() {
+  ObservableValue<int> producer(0);
+  int received = -1;
+
+  // Create shared_ptr consumer in inner scope — it goes out of scope,
+  // but connect_to should keep it alive.
+  {
+    auto consumer = std::make_shared<LambdaConsumer<int>>(
+        [&received](int v) { received = v; });
+    producer.connect_to(consumer);
+    // consumer shared_ptr goes out of scope here
+  }
+
+  // Emit after the local shared_ptr is gone.
+  // With weak_ptr: consumer is destroyed, value is lost.
+  // With strong ref: consumer is alive, value is received.
+  producer.set(42);
+  TEST_ASSERT_EQUAL(42, received);
+}
+
+// ---------------------------------------------------------------------------
+// shared_ptr inline (make_shared in connect_to call) — the common pattern
+// ---------------------------------------------------------------------------
+
+void test_connect_to_inline_make_shared() {
+  ObservableValue<int> producer(0);
+  int received = -1;
+
+  // This is the pattern used in NMEA0183IOTask and wiring functions.
+  // The shared_ptr is a temporary — destroyed at end of statement.
+  producer.connect_to(
+      std::make_shared<LambdaConsumer<int>>(
+          [&received](int v) { received = v; }));
+
+  producer.set(77);
+  TEST_ASSERT_EQUAL(77, received);
+}
+
+// ---------------------------------------------------------------------------
+// shared_ptr chaining: producer → shared transform → raw consumer
+// ---------------------------------------------------------------------------
+
+void test_connect_to_shared_ptr_chain() {
+  ObservableValue<int> producer(0);
+  int received = -1;
+
+  LambdaConsumer<int> final_consumer([&received](int v) { received = v; });
+
+  // Create transform as shared_ptr, chain to raw pointer consumer.
+  // The transform must stay alive for the chain to work.
+  {
+    auto transform = std::make_shared<LambdaTransform<int, int>>(
+        [](int v) { return v * 2; });
+    producer.connect_to(transform)->connect_to(&final_consumer);
+    // transform shared_ptr goes out of scope here
+  }
+
+  producer.set(21);
+  TEST_ASSERT_EQUAL(42, received);
+}
+
+// ---------------------------------------------------------------------------
+// Multiple shared_ptr consumers on same producer
+// ---------------------------------------------------------------------------
+
+void test_connect_to_multiple_shared_ptr_consumers() {
+  ObservableValue<int> producer(0);
+  int received_a = -1;
+  int received_b = -1;
+
+  producer.connect_to(
+      std::make_shared<LambdaConsumer<int>>(
+          [&received_a](int v) { received_a = v; }));
+  producer.connect_to(
+      std::make_shared<LambdaConsumer<int>>(
+          [&received_b](int v) { received_b = v; }));
+
+  producer.set(55);
+  TEST_ASSERT_EQUAL(55, received_a);
+  TEST_ASSERT_EQUAL(55, received_b);
+}
+
+// ---------------------------------------------------------------------------
+// Test runner
+// ---------------------------------------------------------------------------
+
+void setup() {
+  delay(2000);
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_connect_to_raw_pointer);
+  RUN_TEST(test_connect_to_reference);
+  RUN_TEST(test_connect_to_shared_ptr_keeps_consumer_alive);
+  RUN_TEST(test_connect_to_inline_make_shared);
+  RUN_TEST(test_connect_to_shared_ptr_chain);
+  RUN_TEST(test_connect_to_multiple_shared_ptr_consumers);
+
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary

`connect_to(shared_ptr)` stored a `weak_ptr` to the consumer. When the caller's `shared_ptr` went out of scope, the consumer was destroyed — causing silent data loss or use-after-free crashes on polling events that accessed the freed object.

This affected any code using the pattern `producer.connect_to(std::make_shared<Consumer>(...))`, including:
- `NMEA0183IOTask` constructor (line 64 — `LambdaConsumer` destroyed immediately)
- `ConnectApparentWind` wiring function (`TaskQueueProducer` destroyed on return)
- Any user code passing temporary `shared_ptr`s to `connect_to`

The fix: capture the `shared_ptr` by value (strong reference) in the observer lambda instead of converting to `weak_ptr`. This is consistent with the raw pointer overload which already assumes infinite consumer lifetime — appropriate for embedded systems where signal chain objects live for the program's duration.

## Test plan

- [x] 6 unit tests verifying connect_to(shared_ptr) keeps consumers alive: raw pointer baseline, reference baseline, scoped shared_ptr, inline make_shared, chained transforms, multiple consumers
- [x] All tests pass on ESP32-C3 (HALSER hardware)
- [x] Compiles for both `pioarduino_esp32` and `pioarduino_esp32c3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)