### PR TITLE
fix(signalk): fix detect_ssl() crash and harden websocket send calls

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -23,7 +23,8 @@
 
 namespace sensesp {
 
-constexpr int kWsClientTaskStackSize = 8192;  // Reduced from 16KB to save heap
+constexpr int kWsClientTaskStackSize = 8192;  // Stack for ExecuteWebSocketTask
+constexpr int kWsTransportTaskStackSize = 6144;  // Stack for esp_websocket_client internal task
 constexpr TickType_t kWsSendTimeoutTicks = pdMS_TO_TICKS(5000);
 
 SKWSClient* ws_client;
@@ -987,7 +988,7 @@ void SKWSClient::connect_ws(const String& host, const uint16_t port) {
   // Configure WebSocket client
   esp_websocket_client_config_t config = {};
   config.uri = url.c_str();
-  config.task_stack = 6144;
+  config.task_stack = kWsTransportTaskStackSize;
   config.buffer_size = 1024;
   if (auth_header.length() > 0) {
     config.headers = auth_header.c_str();


### PR DESCRIPTION
## Summary

- Fix double-free heap corruption crash in `detect_ssl()` when server returns HTTP→HTTPS redirect
- Fix broken SSL redirect detection (`esp_http_client_get_header` reads request headers, not response headers)
- Replace `portMAX_DELAY` with finite timeout on all remaining `esp_websocket_client_send_text` calls
- Fix use-after-free race in `restart()` by setting disconnected state before destroying the client

## Context

When a Signal K server uses TLS termination with HTTP→HTTPS redirect on the same port (e.g., via Traefik), `detect_ssl()` crashes with `assert failed: multi_heap_free multi_heap_poisoning.c:279 (head != NULL)`. Tested on ESP32-C3 (HALSER board).

The crash had two root causes:
1. `esp_http_client_get_header("Location")` always returned NULL because it reads *request* headers, not response headers. This caused the redirect branch to clean up the client, then fall through to a second cleanup — **double free**.
2. Even if the header was found, the original code read it after `esp_http_client_cleanup()` — **use-after-free**.

The fix uses an `HTTP_EVENT_ON_HEADER` event handler to correctly capture the `Location` response header.

While investigating, two additional pre-existing issues were identified and fixed:
- Three websocket send calls used `portMAX_DELAY`, which can block the task forever if the connection dies silently (closes #862)
- `restart()` destroyed `client_` before setting the disconnected state, creating a race with event handler callbacks (closes #863)

## Test plan

- [x] Build for ESP32-C3 (HALSER board) — succeeds
- [x] Flash and verify `detect_ssl()` correctly detects HTTP 301→HTTPS redirect
- [x] Verify TOFU TLS handshake succeeds with Signal K server behind Traefik proxy
- [x] Verify no crash on repeated connection cycles
- [ ] Verify websocket data flow after Signal K server approves access request

🤖 Generated with [Claude Code](https://claude.com/claude-code)