### PR TITLE
Fix spurious EmptyInput errors from websocket control frames

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -126,7 +126,11 @@ static void websocket_event_handler(void* handler_args,
       ws_client->on_disconnected();
       break;
     case WEBSOCKET_EVENT_DATA:
-      ws_client->on_receive_delta((uint8_t*)data->data_ptr, data->data_len);
+      // Only process text frames (opcode 0x1) and continuation frames (0x0).
+      // Control frames (ping/pong/close: 0x8-0xA) have no JSON payload.
+      if (data->op_code <= 0x2) {
+        ws_client->on_receive_delta((uint8_t*)data->data_ptr, data->data_len);
+      }
       break;
     case WEBSOCKET_EVENT_ERROR:
       ws_client->on_error();


### PR DESCRIPTION
## Summary

- Filter websocket control frames (ping/pong/close) in the event handler before they reach `on_receive_delta`, stopping spurious `deserializeJson error: EmptyInput` log errors
- Only text frames (opcode 0x1) and continuation frames (0x0) are forwarded to the JSON parser

## Context

The ESP-IDF websocket client fires `WEBSOCKET_EVENT_DATA` for all frame types. Control frames have empty payloads, which `deserializeJson` rejects with `EmptyInput` at `ESP_LOGE` level — noisy and misleading.

## Test plan

- [x] `pio run -e halser` builds successfully (verified against HALSER-ais-interface)
- [ ] Flash and confirm `deserializeJson error: EmptyInput` messages no longer appear in serial output

🤖 Generated with [Claude Code](https://claude.com/claude-code)