### PR TITLE
fix(types): Nullable JSON deserialization uses wrong invalid type

### DIFF
--- a/src/sensesp/types/nullable.h
+++ b/src/sensesp/types/nullable.h
@@ -57,7 +57,7 @@ typedef Nullable<bool> NullableBool;
 template <typename T>
 void convertFromJson(JsonVariantConst src, Nullable<T> &dst) {
   if (src.isNull()) {
-    dst = NullableInt::invalid();
+    dst = Nullable<T>::invalid();
   } else {
     dst = src.as<T>();
   }


### PR DESCRIPTION
## Summary

Fix `convertFromJson` template to use `Nullable<T>::invalid()` instead of hardcoded `NullableInt::invalid()`.

`Nullable<float>` deserialized from JSON `null` was getting the int sentinel (2147483647) instead of the float sentinel (-1e9).

Fixes #873

## Test plan

- [x] CI passes (17/17)