### PR TITLE
refactor(net): transport-agnostic networking + ESP32-P4 Ethernet (closes #849)

### DIFF
--- a/docs/pages/features/index.md
+++ b/docs/pages/features/index.md
@@ -59,5 +59,74 @@ STEP 2:
 
 ----
 
+## Network transports
+
+As of the transport-agnostic networking refactor, SensESP can reach
+the Signal K server over any interface that Arduino-ESP32 3.x can
+bring up, not only WiFi. A single `NetworkStateProducer` owned by
+`SensESPApp` subscribes to the unified `Network.onEvent()` bus and
+emits a transport-agnostic `NetworkState` whenever any interface's
+IP-layer state changes. The HTTP server, mDNS, Signal K websocket
+client, and system-info sensors all query a `NetworkProvisioner`
+abstract base instead of touching `WiFi` directly, so they work the
+same on WiFi and Ethernet.
+
+### WiFi (default)
+
+Existing user sketches do not need to change. `SensESPAppBuilder`
+defaults to constructing a `WiFiProvisioner` (the former `Networking`
+class — the old name is still available as a deprecated typedef).
+
+```c++
+SensESPAppBuilder builder;
+auto app = builder.set_hostname("my-device")
+                  ->set_wifi_client("SSID", "password")
+                  ->get_app();
+```
+
+### Ethernet (ESP32-P4)
+
+Native RMII Ethernet is supported on ESP32-P4 boards with an external
+PHY. The library currently ships a configuration preset for the
+Waveshare ESP32-P4-WIFI6-POE-ETH dev board (IP101GRI PHY, external
+25 MHz crystal). To use it:
+
+```c++
+#include "sensesp/net/ethernet_provisioner.h"
+#include "sensesp_app_builder.h"
+
+SensESPAppBuilder builder;
+auto app = builder.set_hostname("my-device")
+                  ->set_ethernet(
+                      sensesp::EthernetConfig::waveshare_esp32p4_poe())
+                  ->get_app();
+```
+
+`set_ethernet()` implicitly calls `disable_wifi()` so no WiFi soft-AP
+fall-back or captive portal is registered. The SensESP web UI remains
+reachable at the DHCP-assigned address on the Ethernet side.
+
+`EthernetProvisioner` is only declared on targets where the
+Arduino-ESP32 ETH driver is usable — currently ESP32-P4. Calling
+`set_ethernet()` on an unsupported target produces a compile error at
+the use site (`EthernetConfig was not declared in this scope`), not a
+silent runtime failure. See `examples/p4_ethernet/` for a full
+buildable example.
+
+### Writing your own provisioner
+
+Subclass `sensesp::NetworkProvisioner` (see
+`sensesp/net/network_provisioner.h`) and bring your interface up
+yourself — e.g. PPP over UART for a cellular modem. The base class
+only requires `local_ip()`, `gateway_ip()`, `mac_address()`, and
+`is_connected()`. Install your factory by calling
+`app->set_network_provisioner_factory(...)` before
+`SensESPApp::setup()` runs (typically from a builder extension). The
+unified `NetworkStateProducer` will pick up state changes automatically
+as long as your interface emits the standard `ARDUINO_EVENT_*`
+events through `Network.onEvent`.
+
+----
+
 ## WiFi manager
 ## System info sensors

--- a/docs/pages/migration/index.md
+++ b/docs/pages/migration/index.md
@@ -345,3 +345,71 @@ sensesp_app = builder.enable_free_mem_sensor()
                      ->enable_ota("my_password")
                      ->get_app();
 ```
+
+## Transport-agnostic networking (v3 minor update)
+
+SensESP used to assume WiFi was the only way to reach the Signal K
+server. The networking layer has been refactored to be transport-
+agnostic: WiFi is still the default and existing sketches compile
+and behave identically, but the library can now also run over
+native Ethernet (on ESP32-P4) and is ready for future transports.
+The refactor RFC is [#849](https://github.com/SignalK/SensESP/issues/849).
+
+### No action required for WiFi users
+
+Every public class name, enum name, and builder method that existed
+before still works via compatibility typedefs:
+
+| Old name                          | New name                               |
+|-----------------------------------|----------------------------------------|
+| `Networking`                      | `WiFiProvisioner`                      |
+| `WiFiState` (enum)                | `NetworkState`                         |
+| `WiFiStateProducer`               | `NetworkStateProducer`                 |
+| `SensESPApp::get_networking()`    | `SensESPApp::get_wifi_provisioner()`   |
+
+The kept aliases mean a user sketch like
+
+```c++
+auto state = sensesp_app->get_networking()->get_wifi_state_producer();
+```
+
+compiles unchanged against the new release.
+
+### Optional: switch to the new names
+
+For new code or if you want to use the new transport-agnostic API,
+prefer:
+
+```c++
+// Include the concrete header directly (not "networking.h")
+#include "sensesp/net/wifi_provisioner.h"
+#include "sensesp/net/network_state.h"
+
+// Access the provisioner through its new accessor
+auto wifi = sensesp_app->get_wifi_provisioner();
+
+// Or, for code that should work on any transport, use the
+// NetworkProvisioner base and the unified state producer:
+auto provisioner = sensesp_app->get_network_provisioner();
+auto ip  = provisioner->local_ip();
+auto mac = provisioner->mac_address();
+
+auto state_producer = sensesp_app->get_network_state_producer();
+state_producer->connect_to(&my_consumer);
+```
+
+### Static-IP WiFi configurations
+
+If you use a saved static-IP configuration on a WiFi client, the
+release in which this refactor lands also fixes a long-standing bug
+in `WiFiProvisioner::start_client_autoconnect()` where the arguments
+to `WiFi.config()` were passed in the wrong order — silently setting
+`gateway = DNS server`, `subnet = gateway`, and `DNS1 = netmask`. If
+your saved WiFi client config has `useDHCP: false`, verify your
+gateway / netmask / DNS values look correct after upgrading; existing
+saved configs should actually start working for the first time.
+
+### Adding Ethernet
+
+See `docs/pages/features/index.md` (section "Network transports")
+for a short usage example.

--- a/examples/p4_ethernet/README.md
+++ b/examples/p4_ethernet/README.md
@@ -1,0 +1,88 @@
+# p4_ethernet
+
+Minimal SensESP application that runs over native RMII Ethernet on a
+Waveshare [ESP32-P4-WIFI6-POE-ETH](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-POE-ETH)
+dev board. WiFi is disabled entirely — the device brings up the
+onboard IP101GRI PHY, runs DHCP, and reaches the Signal K server
+over the wired link (optionally powered via PoE through the RJ45
+magjack).
+
+This example exists primarily as an end-to-end smoke test for the
+transport-agnostic networking refactor
+([RFC #849](https://github.com/SignalK/SensESP/issues/849)): it
+exercises the new `NetworkProvisioner` / `NetworkStateProducer` path
+and the `EthernetProvisioner` concrete implementation from a real
+`SensESPAppBuilder` invocation.
+
+## Hardware
+
+- Board: Waveshare ESP32-P4-WIFI6-POE-ETH (ESP32-P4 ECO2 / rev v1.3
+  silicon, 16 MB flash, 32 MB PSRAM). Other ESP32-P4 boards with an
+  IP101GRI / TLK110-class PHY on the same RMII pinout should also
+  work, possibly by extending `EthernetConfig` with a new factory.
+- USB-C: the board exposes a single USB-C wired through a CH340
+  USB-UART bridge (QinHeng 1a86:55d3) to the P4's UART0 (GPIO 37
+  TX / GPIO 38 RX). The P4's native USB-OTG is not exposed, so
+  `ARDUINO_USB_CDC_ON_BOOT` is deliberately left undefined —
+  Arduino `Serial` maps to UART0 and reaches the host. On recent
+  Linux kernels (with `cdc-acm` handling the newer CH340 variant)
+  the device enumerates as `/dev/ttyACM0`; older systems loading
+  the legacy vendor-specific driver may see `/dev/ttyUSB0` instead.
+  On macOS it is usually `/dev/cu.usbmodem*`; on Windows a COM port.
+- Ethernet: standard RJ45 patch cable to any switch or router that
+  serves DHCP. For isolated bench testing, a Linux host running
+  `nmcli connection add type ethernet ifname ethX con-name test
+  ipv4.method shared ipv4.addresses 192.168.99.1/24` will spin up a
+  NetworkManager-managed `dnsmasq` on that interface.
+
+## Build and flash
+
+This is a standalone PlatformIO project that consumes SensESP from
+the parent directory via a `symlink://../..` library dep.
+
+```sh
+cd examples/p4_ethernet
+pio run -t upload   # PlatformIO auto-detects the serial port
+pio device monitor  # view boot log at 115200 bps
+```
+
+The `[env:waveshare_esp32p4_eth]` environment in `platformio.ini`
+pins pioarduino release 55.03.37 (Arduino-ESP32 3.3.7, ESP-IDF
+v5.5.2) and targets the `esp32-p4` board variant with 16 MB flash
+override for the Waveshare board's larger SPI flash.
+
+## Expected behaviour
+
+On a successful boot the serial monitor should show:
+
+```text
+[p4_eth] boot
+...
+I (XXX) sensesp/net/ethernet_provisioner.cpp: Bringing up Ethernet ...
+I (XXX) sensesp/net/ethernet_provisioner.cpp: Ethernet driver started; ...
+...
+I (XXX) sensesp/net/network_state.cpp: net_state: Ethernet got IP
+[p4_eth] SensESPApp constructed
+```
+
+Once DHCP completes, the SensESP web UI should be reachable at
+`http://<leased-ip>/`. The status page will show an empty SSID and
+RSSI (both WiFi-specific), but `MAC Address` will be populated from
+the Ethernet MAC, and the Signal K settings page can be used to
+point the device at a running `signalk-server`.
+
+## What this example proves
+
+- `NetworkStateProducer` correctly receives `ARDUINO_EVENT_ETH_GOT_IP`
+  through the unified `Network.onEvent` bus and emits
+  `kNetworkConnected`.
+- `SensESPApp::setup()` dispatches to the builder-supplied factory,
+  leaving `wifi_provisioner_` null, and the status page suppresses
+  its WiFi-only items.
+- `IPAddrDev` (the built-in sensor) reads its value through
+  `NetworkProvisioner::local_ip()`, so `sensorDevice.<hostname>.ipAddress`
+  on the Signal K server reflects the Ethernet IP without any
+  Ethernet-specific code in the sensor.
+- `SKWSClient::connect()` gates on `provisioner->is_connected()`
+  instead of `WiFi.isConnected()` and successfully dials the Signal
+  K server over the wired link.

--- a/examples/p4_ethernet/platformio.ini
+++ b/examples/p4_ethernet/platformio.ini
@@ -1,0 +1,59 @@
+; PlatformIO project for the M2 Ethernet smoke test on Waveshare
+; ESP32-P4-WIFI6-POE-ETH. Builds a real SensESP app using the new
+; transport-agnostic NetworkProvisioner / EthernetNetworking path with
+; WiFi disabled.
+;
+; Usage:
+;   cd examples/p4_ethernet
+;   pio run -t upload && pio device monitor
+;
+; Expected runtime behaviour:
+;   - PHY link up message
+;   - DHCP lease obtained, IP printed
+;   - SensESP web UI reachable at http://<dhcp-ip>/
+;   - mDNS service announced
+;   - SK WS client attempts connection (configure SK server in web UI)
+
+[platformio]
+default_envs = waveshare_esp32p4_eth
+
+[env]
+upload_speed = 2000000
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+build_unflags = -Werror=reorder
+board_build.partitions = min_spiffs.csv
+
+build_flags =
+    -D CORE_DEBUG_LEVEL=ARDUHAL_LOG_LEVEL_VERBOSE
+    -D USE_ESP_IDF_LOG
+
+; deep LDF: scan SensESP headers for transitive deps (esp_websocket_client)
+; without descending into framework libs (which broke chain+ earlier).
+lib_ldf_mode = deep
+
+lib_deps =
+    ; Use the local SensESP working tree.
+    symlink://../..
+    ; SensESP's WS client transitively needs this from the IDF component
+    ; registry. Listed here so PIO actually installs it for the symlink
+    ; build (the SensESP library.json doesn't declare it as a hard dep).
+    esp_websocket_client=https://components.espressif.com/api/downloads/?object_type=component&object_id=dbc87006-9a4b-45e6-a6ab-b286174cb413
+
+[env:waveshare_esp32p4_eth]
+; Pinned pioarduino 55.03.37 — same as the p4_blink example.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+framework = arduino
+
+; Waveshare board = ESP32-P4 ECO2 silicon (rev v1.3) with 16 MB flash + 32 MB PSRAM.
+board = esp32-p4
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+
+build_flags =
+    ${env.build_flags}
+    -D SENSESP_SSL_SUPPORT=1
+    -DBOARD_HAS_PSRAM
+    ; Serial maps to UART0 → onboard CH340 → /dev/ttyACM0.
+    ; Native USB-OTG is not exposed on this board, so do NOT enable
+    ; ARDUINO_USB_CDC_ON_BOOT.

--- a/examples/p4_ethernet/src/main.cpp
+++ b/examples/p4_ethernet/src/main.cpp
@@ -1,0 +1,43 @@
+/**
+ * @file main.cpp
+ * @brief Minimal SensESP app running on native Ethernet on the
+ *        Waveshare ESP32-P4-WIFI6-POE-ETH board.
+ *
+ * Uses the transport-agnostic NetworkProvisioner abstraction and the
+ * Waveshare-tuned EthernetProvisioner config. WiFi is disabled
+ * entirely — the device runs over native ESP32-P4 RMII Ethernet to
+ * the onboard IP101GRI PHY and can be PoE-powered via the RJ45
+ * magjack.
+ *
+ * Verification checklist on the host (with a DHCP server on the
+ * same LAN):
+ *   1. Device boots, serial prints "Bringing up Ethernet"
+ *   2. PHY link comes up when a cable is plugged in
+ *   3. DHCP lease obtained; check the ARP table on the host
+ *   4. http://<leased-ip>/ serves the SensESP web UI
+ *   5. Configure the Signal K server address in the web UI
+ *   6. SK connection status on the status page flips to "Connected"
+ */
+
+#include "sensesp/net/ethernet_provisioner.h"
+#include "sensesp_app_builder.h"
+
+using namespace sensesp;
+
+void setup() {
+  Serial.begin(115200);
+  delay(500);
+  Serial.println("[p4_eth] boot");
+
+  SensESPAppBuilder builder;
+  auto sensesp_app = builder.set_hostname("sensesp-p4-eth")
+                         ->set_ethernet(EthernetConfig::waveshare_esp32p4_poe())
+                         ->enable_uptime_sensor()
+                         ->enable_free_mem_sensor()
+                         ->enable_ip_address_sensor()
+                         ->get_app();
+
+  Serial.println("[p4_eth] SensESPApp constructed");
+}
+
+void loop() { event_loop()->tick(); }

--- a/library.json
+++ b/library.json
@@ -44,6 +44,10 @@
       "owner": "bxparks",
       "name": "AceButton",
       "version": "^1.10.1"
+    },
+    {
+      "name": "esp_websocket_client",
+      "version": "https://components.espressif.com/api/downloads/?object_type=component&object_id=dbc87006-9a4b-45e6-a6ab-b286174cb413"
     }
   ],
   "version": "3.2.3-alpha",

--- a/src/sensesp/net/ethernet_provisioner.cpp
+++ b/src/sensesp/net/ethernet_provisioner.cpp
@@ -1,0 +1,67 @@
+#include "sensesp.h"
+
+#include "ethernet_provisioner.h"
+
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+
+namespace sensesp {
+
+EthernetProvisioner::EthernetProvisioner(const EthernetConfig& config)
+    : config_(config) {
+  ESP_LOGI(__FILENAME__,
+           "Bringing up Ethernet (PHY type=%d addr=%d MDC=%d MDIO=%d "
+           "PWR=%d clk_mode=%d)",
+           (int)config_.phy_type, (int)config_.phy_addr, config_.mdc_pin,
+           config_.mdio_pin, config_.power_pin, (int)config_.clock_mode);
+
+  // Set the hostname before bringing up the link so DHCP REQUESTs carry
+  // it. SensESP stores the hostname on the SensESPBaseApp singleton.
+  String hostname = SensESPBaseApp::get_hostname();
+  ETH.setHostname(hostname.c_str());
+
+  // Use the explicit RMII begin() so SensESP doesn't depend on the
+  // variant supplying compile-time ETH_PHY_* macros — although on the
+  // current Waveshare ESP32-P4 board the variant happens to match.
+  bool started = ETH.begin(config_.phy_type, config_.phy_addr, config_.mdc_pin,
+                           config_.mdio_pin, config_.power_pin,
+                           config_.clock_mode);
+  if (!started) {
+    ESP_LOGE(__FILENAME__,
+             "ETH.begin() failed — check pin mapping and PHY power.");
+    return;
+  }
+
+  ESP_LOGI(__FILENAME__,
+           "Ethernet driver started; waiting for PHY link + DHCP lease.");
+}
+
+EthernetProvisioner::~EthernetProvisioner() {
+  // Arduino's ETH does not provide a clean shutdown that re-initialises
+  // cleanly afterwards, so we deliberately do nothing here. The
+  // NetworkStateProducer in SensESPApp owns the event subscriptions.
+}
+
+IPAddress EthernetProvisioner::local_ip() const { return ETH.localIP(); }
+
+IPAddress EthernetProvisioner::gateway_ip() const { return ETH.gatewayIP(); }
+
+String EthernetProvisioner::mac_address() const { return ETH.macAddress(); }
+
+bool EthernetProvisioner::is_connected() const {
+  // Considered connected once the PHY link is up *and* the IP stack
+  // has obtained an address. The Arduino ETH wrapper exposes both
+  // through its NetworkInterface base class.
+  return ETH.linkUp() && ETH.hasIP();
+}
+
+int EthernetProvisioner::link_speed_mbps() const {
+  return ETH.linkUp() ? ETH.linkSpeed() : 0;
+}
+
+bool EthernetProvisioner::is_full_duplex() const {
+  return ETH.linkUp() && ETH.fullDuplex();
+}
+
+}  // namespace sensesp
+
+#endif  // CONFIG_IDF_TARGET_ESP32P4

--- a/src/sensesp/net/ethernet_provisioner.cpp
+++ b/src/sensesp/net/ethernet_provisioner.cpp
@@ -4,6 +4,8 @@
 
 #if defined(CONFIG_IDF_TARGET_ESP32P4)
 
+#include <Network.h>
+
 namespace sensesp {
 
 EthernetProvisioner::EthernetProvisioner(const EthernetConfig& config)
@@ -14,10 +16,45 @@ EthernetProvisioner::EthernetProvisioner(const EthernetConfig& config)
            (int)config_.phy_type, (int)config_.phy_addr, config_.mdc_pin,
            config_.mdio_pin, config_.power_pin, (int)config_.clock_mode);
 
-  // Set the hostname before bringing up the link so DHCP REQUESTs carry
-  // it. SensESP stores the hostname on the SensESPBaseApp singleton.
+  // Register an ARDUINO_EVENT_ETH_START listener that applies the
+  // SensESP hostname to the ETH interface right after the netif has
+  // been created but before DHCP DISCOVER goes out. This is the only
+  // guaranteed-correct moment:
+  //
+  //   - Before ETH.begin():  _esp_netif is still NULL so
+  //     ETH.setHostname() returns false and the hostname is dropped
+  //     (this is what the previous implementation did, causing the
+  //     DHCP client to advertise "espressif" — the Arduino ESP32
+  //     variant's compile-time default — instead of the SensESP
+  //     hostname).
+  //
+  //   - After ETH.begin():   the netif exists, but esp_eth_start()
+  //     already ran and the DHCP client may have already sent its
+  //     DISCOVER, so setting the hostname here would land after the
+  //     server has recorded the wrong one.
+  //
+  //   - In the ETH_START event:  fires synchronously from the
+  //     network event loop after the netif is created and before
+  //     the DHCP client starts. This is the canonical pattern used
+  //     by the Arduino-ESP32 ETH_LAN8720 example.
+  //
+  // Network.onEvent() callbacks run on a separate FreeRTOS task
+  // (the LwIP / system event task), so the capture must be plain
+  // value-captured — no reference to `this`.
   String hostname = SensESPBaseApp::get_hostname();
-  ETH.setHostname(hostname.c_str());
+  Network.onEvent(
+      [hostname](arduino_event_id_t, arduino_event_info_t) {
+        if (!ETH.setHostname(hostname.c_str())) {
+          ESP_LOGW("eth_prov",
+                   "ETH.setHostname(\"%s\") failed in ETH_START handler",
+                   hostname.c_str());
+        } else {
+          ESP_LOGI("eth_prov",
+                   "Ethernet hostname set to \"%s\" before DHCP DISCOVER",
+                   hostname.c_str());
+        }
+      },
+      ARDUINO_EVENT_ETH_START);
 
   // Use the explicit RMII begin() so SensESP doesn't depend on the
   // variant supplying compile-time ETH_PHY_* macros — although on the

--- a/src/sensesp/net/ethernet_provisioner.h
+++ b/src/sensesp/net/ethernet_provisioner.h
@@ -1,0 +1,111 @@
+#ifndef SENSESP_NET_ETHERNET_PROVISIONER_H_
+#define SENSESP_NET_ETHERNET_PROVISIONER_H_
+
+// Native RMII Ethernet support.
+//
+// Currently only ESP32-P4 ships an Arduino-ESP32 ETH.h implementation
+// that SensESP can drive without writing a custom EMAC bring-up, so the
+// entire EthernetProvisioner class is guarded behind CONFIG_IDF_TARGET_ESP32P4.
+// On any other target, including this header compiles to nothing and
+// `EthernetConfig` / `EthernetProvisioner` are simply not declared —
+// so a user sketch that tries to call
+// `builder.set_ethernet(EthernetConfig::…())` on a classic ESP32 will
+// get a clear compile error at the use site ("'EthernetConfig' was
+// not declared in this scope") rather than a silent runtime failure.
+//
+// When future ESP32 variants grow a usable Arduino-ESP32 ETH driver,
+// the guard can be widened accordingly.
+
+#include <Arduino.h>
+
+#if defined(CONFIG_IDF_TARGET_ESP32P4)
+
+#include <ETH.h>
+
+#include "sensesp/net/network_provisioner.h"
+#include "sensesp_base_app.h"
+
+namespace sensesp {
+
+class EthernetProvisioner;
+
+/**
+ * @brief Hardware description for an EthernetProvisioner.
+ *
+ * Selects the PHY model, address, MDC/MDIO pins, reset pin, and clock
+ * direction. The Arduino-ESP32 ETH library reads the RMII data pins
+ * (TX0/1, RX0/1, TX_EN, CRS_DV, REF_CLK) from compile-time macros in
+ * the board variant, so this struct intentionally does not expose them.
+ *
+ * Use the static factory methods to get a config for a known board:
+ *
+ *     builder.set_ethernet(EthernetConfig::waveshare_esp32p4_poe());
+ */
+struct EthernetConfig {
+  /// Tag used by SensESPAppBuilder::set_ethernet() (template) to find
+  /// the corresponding provisioner implementation type.
+  using ProvisionerType = EthernetProvisioner;
+
+  eth_phy_type_t phy_type = ETH_PHY_IP101;
+  int32_t phy_addr = 1;
+  int mdc_pin = 31;
+  int mdio_pin = 52;
+  int power_pin = 51;  // PHY reset pin
+  eth_clock_mode_t clock_mode = EMAC_CLK_EXT_IN;
+
+  /// Configuration for the Waveshare ESP32-P4-WIFI6-POE-ETH dev board.
+  /// PHY: IP101GRI (ETH_PHY_IP101 is an Arduino-ESP32 alias for the
+  /// ETH_PHY_TLK110 IDF driver, which IP101GRI is electrically
+  /// compatible with). REF_CLK is driven by an external 25 MHz crystal
+  /// frequency-doubled by the PHY into GPIO50.
+  static EthernetConfig waveshare_esp32p4_poe() {
+    EthernetConfig cfg;
+    cfg.phy_type = ETH_PHY_IP101;
+    cfg.phy_addr = 1;
+    cfg.mdc_pin = 31;
+    cfg.mdio_pin = 52;
+    cfg.power_pin = 51;
+    cfg.clock_mode = EMAC_CLK_EXT_IN;
+    return cfg;
+  }
+};
+
+/**
+ * @brief NetworkProvisioner for native ESP32-P4 RMII Ethernet.
+ *
+ * Brings up the ESP32-P4 EMAC + an external RMII PHY via the Arduino
+ * ETH library and runs DHCP. Network *state* (got IP, lost IP, …) is
+ * not owned here — SensESPApp's NetworkStateProducer subscribes to the
+ * unified Arduino-ESP32 event bus and notices ethernet state changes
+ * automatically.
+ *
+ * No WiFi soft-AP, no captive portal — Ethernet is assumed to provide
+ * upstream connectivity unconditionally.
+ */
+class EthernetProvisioner : public NetworkProvisioner {
+ public:
+  explicit EthernetProvisioner(const EthernetConfig& config);
+  ~EthernetProvisioner() override;
+
+  // -- NetworkProvisioner --
+  IPAddress local_ip() const override;
+  IPAddress gateway_ip() const override;
+  String mac_address() const override;
+  bool is_connected() const override;
+
+  // -- Ethernet-specific --
+  /// Link speed in megabits per second (10 or 100), 0 if no link.
+  int link_speed_mbps() const;
+
+  /// True iff link is currently full-duplex.
+  bool is_full_duplex() const;
+
+ private:
+  EthernetConfig config_;
+};
+
+}  // namespace sensesp
+
+#endif  // CONFIG_IDF_TARGET_ESP32P4
+
+#endif  // SENSESP_NET_ETHERNET_PROVISIONER_H_

--- a/src/sensesp/net/http_server.cpp
+++ b/src/sensesp/net/http_server.cpp
@@ -59,7 +59,9 @@ esp_err_t HTTPServer::dispatch_request(httpd_req_t* req) {
   }
   inet_ntop(AF_INET, &addr.sin6_addr.un.u32_addr[3], ipstr, sizeof(ipstr));
 
-  String ap_ip = WiFi.softAPIP().toString();
+  // Captive-portal AP IP is supplied by the network provisioner via
+  // set_captive_portal(); zero on transports without a soft AP.
+  String ap_ip = captive_portal_ap_ip_.toString();
 
   bool auth_required;
 
@@ -143,7 +145,7 @@ bool HTTPServer::handle_captive_portal(httpd_req_t* req) {
   }
   inet_ntop(AF_INET, &addr.sin6_addr.un.u32_addr[3], ipstr, sizeof(ipstr));
 
-  String ap_ip = WiFi.softAPIP().toString();
+  String ap_ip = captive_portal_ap_ip_.toString();
 
   // We should only apply the captive portal to the soft AP IP address
   if (ap_ip != ipstr) {

--- a/src/sensesp/net/http_server.h
+++ b/src/sensesp/net/http_server.h
@@ -4,12 +4,12 @@
 #include "sensesp.h"
 
 #include <ESPmDNS.h>
+#include <IPAddress.h>
 #include <esp_http_server.h>
 #include <functional>
 #include <list>
 #include <memory>
 
-#include "WiFi.h"
 #include "sensesp/net/http_authenticator.h"
 #include "sensesp/system/serializable.h"
 #include "sensesp_base_app.h"
@@ -116,8 +116,18 @@ class HTTPServer : public FileSystemSaveable {
     auth_required_ = auth_required;
   }
 
-  void set_captive_portal(bool captive_portal) {
+  /**
+   * @brief Enable or disable the captive-portal redirect path.
+   *
+   * The captive-portal path is only meaningful when the underlying
+   * network provisioner is serving a soft-AP (currently WiFi only).
+   * SensESPApp passes the soft-AP IPv4 address here so this class
+   * does not need to depend on the WiFi library directly.
+   */
+  void set_captive_portal(bool captive_portal,
+                          IPAddress ap_ip = IPAddress()) {
     captive_portal_ = captive_portal;
+    captive_portal_ap_ip_ = ap_ip;
   }
 
   virtual bool to_json(JsonObject& config) override {
@@ -153,6 +163,7 @@ class HTTPServer : public FileSystemSaveable {
 
  protected:
   bool captive_portal_ = false;
+  IPAddress captive_portal_ap_ip_;
   httpd_handle_t server_ = nullptr;
   httpd_config_t config_;
   String username_;

--- a/src/sensesp/net/network_provisioner.h
+++ b/src/sensesp/net/network_provisioner.h
@@ -1,0 +1,60 @@
+#ifndef SENSESP_NET_NETWORK_PROVISIONER_H_
+#define SENSESP_NET_NETWORK_PROVISIONER_H_
+
+#include <Arduino.h>
+#include <IPAddress.h>
+
+namespace sensesp {
+
+/**
+ * @brief Transport-agnostic network provisioner interface.
+ *
+ * A NetworkProvisioner is responsible for bringing one network interface
+ * up (calling WiFi.begin / ETH.begin / …), persisting its configuration,
+ * and exposing the runtime IP/MAC information. Each concrete provisioner
+ * (WiFiProvisioner, EthernetProvisioner, …) inherits from this base.
+ *
+ * Network *state* (got IP, lost IP, AP mode, …) is **not** owned by the
+ * provisioner. SensESPApp owns a single NetworkStateProducer that
+ * subscribes to the unified Arduino-ESP32 Network event bus and emits
+ * state transitions for any active interface. Provisioners therefore do
+ * not have to coordinate state — they just bring their interface up and
+ * the producer notices.
+ *
+ * Code that needs transport-specific functionality (e.g. WiFi scanning,
+ * AP soft-AP IP, ethernet link speed) holds a typed pointer to the
+ * concrete provisioner directly. SensESPApp exposes those via
+ * get_wifi_provisioner() / get_ethernet_provisioner(), each of which
+ * returns nullptr when its transport is not active.
+ */
+class NetworkProvisioner {
+ public:
+  virtual ~NetworkProvisioner() = default;
+
+  /// Current local IPv4 address. Returns IPAddress() if no link.
+  virtual IPAddress local_ip() const = 0;
+
+  /// Default gateway IPv4 address. Returns IPAddress() if no link.
+  virtual IPAddress gateway_ip() const = 0;
+
+  /**
+   * @brief Hardware MAC address of the active interface.
+   *
+   * Format: "AA:BB:CC:DD:EE:FF". For multi-interface chips this returns
+   * the MAC of the interface SensESPApp is using to reach the network
+   * (e.g. the WiFi STA MAC, or the EMAC MAC).
+   */
+  virtual String mac_address() const = 0;
+
+  /**
+   * @brief True iff the link is currently up and we have an IP address.
+   *
+   * The Signal K websocket client uses this to gate connection attempts:
+   * before this returns true, the IP stack is not routable.
+   */
+  virtual bool is_connected() const = 0;
+};
+
+}  // namespace sensesp
+
+#endif  // SENSESP_NET_NETWORK_PROVISIONER_H_

--- a/src/sensesp/net/network_provisioner.h
+++ b/src/sensesp/net/network_provisioner.h
@@ -47,10 +47,13 @@ class NetworkProvisioner {
   virtual String mac_address() const = 0;
 
   /**
-   * @brief True iff the link is currently up and we have an IP address.
+   * @brief True iff the network interface is usable.
    *
-   * The Signal K websocket client uses this to gate connection attempts:
-   * before this returns true, the IP stack is not routable.
+   * For STA/Ethernet this means link up + IP obtained. For WiFi in AP
+   * mode this also returns true — the device is network-reachable via
+   * the soft-AP even though it has no upstream connection. The Signal K
+   * websocket client uses this to gate connection attempts; the HTTP
+   * server uses it to know when the captive portal should be active.
    */
   virtual bool is_connected() const = 0;
 };

--- a/src/sensesp/net/network_state.cpp
+++ b/src/sensesp/net/network_state.cpp
@@ -1,0 +1,96 @@
+#include "sensesp.h"
+
+#include "network_state.h"
+
+#include <Network.h>
+
+namespace sensesp {
+
+namespace {
+
+/**
+ * @brief Helper that re-emits a NetworkState through the SensESP event
+ * loop instead of from the calling task.
+ *
+ * Network event callbacks are invoked from the LwIP / system event task.
+ * Doing the emission directly would expose downstream consumers to
+ * cross-task races (the SensESP reactive layer assumes single-threaded
+ * execution on the main loop). Hopping through `event_loop()->onDelay(0,
+ * …)` defers the work to the next loop iteration on the main task.
+ */
+void defer_emit(NetworkStateProducer* producer, NetworkState state) {
+  event_loop()->onDelay(0, [producer, state]() { producer->emit(state); });
+}
+
+}  // namespace
+
+NetworkStateProducer::NetworkStateProducer() {
+  this->output_ = kNetworkNoConnection;
+
+  // ----- WiFi events ------------------------------------------------------
+  wifi_got_ip_handle_ = Network.onEvent(
+      [this](arduino_event_id_t, arduino_event_info_t) {
+        ESP_LOGI("net_state", "WiFi station got IP");
+        defer_emit(this, kNetworkConnected);
+      },
+      ARDUINO_EVENT_WIFI_STA_GOT_IP);
+
+  wifi_disconnected_handle_ = Network.onEvent(
+      [this](arduino_event_id_t, arduino_event_info_t) {
+        ESP_LOGI("net_state", "WiFi station disconnected");
+        defer_emit(this, kNetworkDisconnected);
+      },
+      ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+
+  wifi_ap_start_handle_ = Network.onEvent(
+      [this](arduino_event_id_t, arduino_event_info_t) {
+        ESP_LOGI("net_state", "WiFi soft-AP started");
+        defer_emit(this, kNetworkAPMode);
+      },
+      ARDUINO_EVENT_WIFI_AP_START);
+
+  wifi_ap_stop_handle_ = Network.onEvent(
+      [this](arduino_event_id_t, arduino_event_info_t) {
+        ESP_LOGI("net_state", "WiFi soft-AP stopped");
+        defer_emit(this, kNetworkDisconnected);
+      },
+      ARDUINO_EVENT_WIFI_AP_STOP);
+
+  // ----- Ethernet events --------------------------------------------------
+  eth_got_ip_handle_ = Network.onEvent(
+      [this](arduino_event_id_t, arduino_event_info_t) {
+        ESP_LOGI("net_state", "Ethernet got IP");
+        defer_emit(this, kNetworkConnected);
+      },
+      ARDUINO_EVENT_ETH_GOT_IP);
+
+  eth_lost_ip_handle_ = Network.onEvent(
+      [this](arduino_event_id_t, arduino_event_info_t) {
+        ESP_LOGI("net_state", "Ethernet lost IP");
+        defer_emit(this, kNetworkDisconnected);
+      },
+      ARDUINO_EVENT_ETH_LOST_IP);
+
+  eth_disconnected_handle_ = Network.onEvent(
+      [this](arduino_event_id_t, arduino_event_info_t) {
+        ESP_LOGI("net_state", "Ethernet PHY disconnected");
+        defer_emit(this, kNetworkDisconnected);
+      },
+      ARDUINO_EVENT_ETH_DISCONNECTED);
+
+  // Re-emit the current (initial) state once the event loop is running so
+  // late subscribers (added in SensESPApp::setup) see the latest value.
+  event_loop()->onDelay(0, [this]() { this->emit(this->output_); });
+}
+
+NetworkStateProducer::~NetworkStateProducer() {
+  Network.removeEvent(wifi_got_ip_handle_);
+  Network.removeEvent(wifi_disconnected_handle_);
+  Network.removeEvent(wifi_ap_start_handle_);
+  Network.removeEvent(wifi_ap_stop_handle_);
+  Network.removeEvent(eth_got_ip_handle_);
+  Network.removeEvent(eth_lost_ip_handle_);
+  Network.removeEvent(eth_disconnected_handle_);
+}
+
+}  // namespace sensesp

--- a/src/sensesp/net/network_state.cpp
+++ b/src/sensesp/net/network_state.cpp
@@ -2,7 +2,13 @@
 
 #include "network_state.h"
 
+#include "esp_arduino_version.h"
+
+#if ESP_ARDUINO_VERSION_MAJOR >= 3
 #include <Network.h>
+#else
+#include <WiFi.h>
+#endif
 
 namespace sensesp {
 
@@ -27,7 +33,8 @@ void defer_emit(NetworkStateProducer* producer, NetworkState state) {
 NetworkStateProducer::NetworkStateProducer() {
   this->output_ = kNetworkNoConnection;
 
-  // ----- WiFi events ------------------------------------------------------
+#if ESP_ARDUINO_VERSION_MAJOR >= 3
+  // ----- Arduino-ESP32 3.x: unified Network event bus ---------------------
   wifi_got_ip_handle_ = Network.onEvent(
       [this](arduino_event_id_t, arduino_event_info_t) {
         ESP_LOGI("net_state", "WiFi station got IP");
@@ -56,7 +63,7 @@ NetworkStateProducer::NetworkStateProducer() {
       },
       ARDUINO_EVENT_WIFI_AP_STOP);
 
-  // ----- Ethernet events --------------------------------------------------
+  // ----- Ethernet events (3.x only) --------------------------------------
   eth_got_ip_handle_ = Network.onEvent(
       [this](arduino_event_id_t, arduino_event_info_t) {
         ESP_LOGI("net_state", "Ethernet got IP");
@@ -78,12 +85,47 @@ NetworkStateProducer::NetworkStateProducer() {
       },
       ARDUINO_EVENT_ETH_DISCONNECTED);
 
+#else
+  // ----- Arduino-ESP32 2.x: WiFi-only event bus --------------------------
+  wifi_got_ip_handle_ = WiFi.onEvent(
+      [this](WiFiEvent_t, WiFiEventInfo_t) {
+        ESP_LOGI("net_state", "WiFi station got IP");
+        defer_emit(this, kNetworkConnected);
+      },
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
+
+  wifi_disconnected_handle_ = WiFi.onEvent(
+      [this](WiFiEvent_t, WiFiEventInfo_t) {
+        ESP_LOGI("net_state", "WiFi station disconnected");
+        defer_emit(this, kNetworkDisconnected);
+      },
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+
+  wifi_ap_start_handle_ = WiFi.onEvent(
+      [this](WiFiEvent_t, WiFiEventInfo_t) {
+        ESP_LOGI("net_state", "WiFi soft-AP started");
+        defer_emit(this, kNetworkAPMode);
+      },
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_AP_START);
+
+  wifi_ap_stop_handle_ = WiFi.onEvent(
+      [this](WiFiEvent_t, WiFiEventInfo_t) {
+        ESP_LOGI("net_state", "WiFi soft-AP stopped");
+        defer_emit(this, kNetworkDisconnected);
+      },
+      WiFiEvent_t::ARDUINO_EVENT_WIFI_AP_STOP);
+
+  // Ethernet events not available on Arduino-ESP32 2.x; eth_*_handle_
+  // members remain zero-initialized.
+#endif
+
   // Re-emit the current (initial) state once the event loop is running so
   // late subscribers (added in SensESPApp::setup) see the latest value.
   event_loop()->onDelay(0, [this]() { this->emit(this->output_); });
 }
 
 NetworkStateProducer::~NetworkStateProducer() {
+#if ESP_ARDUINO_VERSION_MAJOR >= 3
   Network.removeEvent(wifi_got_ip_handle_);
   Network.removeEvent(wifi_disconnected_handle_);
   Network.removeEvent(wifi_ap_start_handle_);
@@ -91,6 +133,12 @@ NetworkStateProducer::~NetworkStateProducer() {
   Network.removeEvent(eth_got_ip_handle_);
   Network.removeEvent(eth_lost_ip_handle_);
   Network.removeEvent(eth_disconnected_handle_);
+#else
+  WiFi.removeEvent(wifi_got_ip_handle_);
+  WiFi.removeEvent(wifi_disconnected_handle_);
+  WiFi.removeEvent(wifi_ap_start_handle_);
+  WiFi.removeEvent(wifi_ap_stop_handle_);
+#endif
 }
 
 }  // namespace sensesp

--- a/src/sensesp/net/network_state.h
+++ b/src/sensesp/net/network_state.h
@@ -1,0 +1,74 @@
+#ifndef SENSESP_NET_NETWORK_STATE_H_
+#define SENSESP_NET_NETWORK_STATE_H_
+
+#include <cstddef>
+
+#include "sensesp/net/wifi_state.h"
+#include "sensesp/system/valueproducer.h"
+
+namespace sensesp {
+
+/**
+ * @brief Transport-agnostic network state.
+ *
+ * Replaces the WiFi-specific WiFiState enum with values that any
+ * transport (WiFi, Ethernet, ESP-Hosted, future PPP/cellular, …) can
+ * produce. The legacy WiFiState enum is kept as a strong alias of
+ * NetworkState in wifi_state.h, and existing user code that uses the
+ * old kWifi* member names continues to compile unchanged.
+ *
+ * Semantic mapping (new neutral name → existing kWifi* alias):
+ *   kNoConnection   ↔ kWifiNoAP
+ *   kDisconnected   ↔ kWifiDisconnected
+ *   kConnected      ↔ kWifiConnectedToAP   (interface has a routable IP)
+ *   kAPMode         ↔ kWifiAPModeActivated (WiFi-only soft-AP fallback)
+ *   kProvisioning   ↔ kWifiManagerActivated (interactive provisioner)
+ *
+ * Non-WiFi provisioners must never emit kAPMode or kProvisioning.
+ */
+using NetworkState = WiFiState;
+
+/// Neutral aliases that new transport-agnostic code can use instead of
+/// the historical kWifi* names. Both compile to the same enum values.
+inline constexpr NetworkState kNetworkNoConnection = NetworkState::kWifiNoAP;
+inline constexpr NetworkState kNetworkDisconnected = NetworkState::kWifiDisconnected;
+inline constexpr NetworkState kNetworkConnected = NetworkState::kWifiConnectedToAP;
+inline constexpr NetworkState kNetworkAPMode = NetworkState::kWifiAPModeActivated;
+inline constexpr NetworkState kNetworkProvisioning =
+    NetworkState::kWifiManagerActivated;
+
+/**
+ * @brief Unified producer that emits NetworkState transitions.
+ *
+ * Owned by SensESPApp. Subscribes to the Arduino-ESP32 unified network
+ * event bus (Network.onEvent) and listens for both WiFi and Ethernet
+ * IP/disconnect events. Emits a NetworkState whenever any interface's
+ * IP-layer state changes.
+ *
+ * Replaces the legacy WiFiStateProducer that only listened to WIFI_*
+ * events. The header keeps only the declaration so files that include
+ * it (e.g. system_status_controller.h) do not pull in Network.h.
+ */
+class NetworkStateProducer : public ValueProducer<NetworkState> {
+ public:
+  NetworkStateProducer();
+  ~NetworkStateProducer();
+
+  NetworkStateProducer(const NetworkStateProducer&) = delete;
+  NetworkStateProducer& operator=(const NetworkStateProducer&) = delete;
+
+ private:
+  // Opaque Arduino-ESP32 network_event_handle_t (= size_t). Stored as
+  // size_t in the header so we don't need to pull Network.h here.
+  std::size_t wifi_got_ip_handle_ = 0;
+  std::size_t wifi_disconnected_handle_ = 0;
+  std::size_t wifi_ap_start_handle_ = 0;
+  std::size_t wifi_ap_stop_handle_ = 0;
+  std::size_t eth_got_ip_handle_ = 0;
+  std::size_t eth_lost_ip_handle_ = 0;
+  std::size_t eth_disconnected_handle_ = 0;
+};
+
+}  // namespace sensesp
+
+#endif  // SENSESP_NET_NETWORK_STATE_H_

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -40,6 +40,10 @@ namespace sensesp {
 /// to compile.
 using Networking = WiFiProvisioner;
 
+/// @deprecated Use NetworkStateProducer directly. Kept so code that
+/// references the WiFiStateProducer type by name continues to compile.
+using WiFiStateProducer = NetworkStateProducer;
+
 }  // namespace sensesp
 
 #endif  // SENSESP_NET_NETWORKING_H_

--- a/src/sensesp/net/networking.h
+++ b/src/sensesp/net/networking.h
@@ -1,298 +1,45 @@
 #ifndef SENSESP_NET_NETWORKING_H_
 #define SENSESP_NET_NETWORKING_H_
 
-#include <Arduino.h>
-#include <DNSServer.h>
-#include <WiFi.h>
+// Backward-compat shim. The previous monolithic Networking class has been
+// split into:
+//
+//   - NetworkProvisioner   abstract base, transport-agnostic IP query API
+//                          (network_provisioner.h)
+//   - WiFiProvisioner      concrete WiFi implementation, formerly named
+//                          Networking (wifi_provisioner.h)
+//   - EthernetProvisioner  concrete native-Ethernet implementation
+//                          (ethernet_provisioner.h)
+//
+// And:
+//
+//   - NetworkState         transport-agnostic state enum, alias of WiFiState
+//                          (network_state.h)
+//   - NetworkStateProducer single producer that listens to the unified
+//                          Arduino-ESP32 Network event bus and emits state
+//                          for any active interface (network_state.h)
+//
+// Existing user code that includes <sensesp/net/networking.h> and writes
+// `Networking` (or `WiFiState`) continues to compile because of the
+// aliases here plus those in network_state.h.
+//
+// New code should prefer:
+//   #include "sensesp/net/wifi_provisioner.h"     // for WiFiProvisioner
+//   #include "sensesp/net/ethernet_provisioner.h" // for EthernetProvisioner
+//   #include "sensesp/net/network_state.h"        // for NetworkState
+//   #include "sensesp/net/network_provisioner.h"  // for the abstract base
 
-#include "sensesp/net/wifi_state.h"
-#include "sensesp/system/lambda_consumer.h"
-#include "sensesp/system/observablevalue.h"
-#include "sensesp/system/resettable.h"
-#include "sensesp/system/serializable.h"
-#include "sensesp/system/valueproducer.h"
-#include "sensesp_base_app.h"
+#include "sensesp/net/network_provisioner.h"
+#include "sensesp/net/network_state.h"
+#include "sensesp/net/wifi_provisioner.h"
 
 namespace sensesp {
 
-constexpr int kMaxNumClientConfigs = 3;
-
-/**
- * @brief Provide information about the current WiFi state.
- *
- * WiFiStateProducer reads the current network state using
- * Arduino Core callbacks. It is a replacement for the Networking class
- * ValueProducer output and effectively decouples the Networkig class
- * from the rest of the system. This allows for replacing the Networking
- * class with a different implementation.
- */
-class WiFiStateProducer : public ValueProducer<WiFiState> {
- public:
-  WiFiStateProducer() {
-    this->output_ = WiFiState::kWifiNoAP;
-
-    setup_wifi_callbacks();
-
-    // Emit the current state as soon as the event loop starts
-    event_loop()->onDelay(0, [this]() { this->emit(this->output_); });
-  }
-
-  ~WiFiStateProducer() { remove_wifi_callbacks(); }
-
-  WiFiStateProducer(WiFiStateProducer& other) = delete;
-  void operator=(const WiFiStateProducer&) = delete;
-
- protected:
-  wifi_event_id_t wifi_sta_got_ip_event_id_;
-  wifi_event_id_t wifi_ap_start_event_id_;
-  wifi_event_id_t wifi_sta_disconnected_event_id_;
-  wifi_event_id_t wifi_ap_stop_event_id_;
-
-  void setup_wifi_callbacks() {
-    wifi_sta_got_ip_event_id_ = WiFi.onEvent(
-        [this](WiFiEvent_t event, WiFiEventInfo_t info) {
-          this->wifi_station_connected();
-        },
-        WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_GOT_IP);
-    wifi_ap_start_event_id_ =
-        WiFi.onEvent([this](WiFiEvent_t event,
-                            WiFiEventInfo_t info) { this->wifi_ap_enabled(); },
-                     WiFiEvent_t::ARDUINO_EVENT_WIFI_AP_START);
-    wifi_sta_disconnected_event_id_ = WiFi.onEvent(
-        [this](WiFiEvent_t event, WiFiEventInfo_t info) {
-          this->wifi_disconnected();
-        },
-        WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
-    wifi_ap_stop_event_id_ = WiFi.onEvent(
-        [this](WiFiEvent_t event, WiFiEventInfo_t info) {
-          this->wifi_disconnected();
-        },
-        WiFiEvent_t::ARDUINO_EVENT_WIFI_AP_STOP);
-  }
-
-  void remove_wifi_callbacks() {
-    WiFi.removeEvent(wifi_sta_got_ip_event_id_);
-    WiFi.removeEvent(wifi_ap_start_event_id_);
-    WiFi.removeEvent(wifi_sta_disconnected_event_id_);
-    WiFi.removeEvent(wifi_ap_stop_event_id_);
-  }
-
-  void wifi_station_connected() {
-    ESP_LOGI(__FILENAME__, "Connected to wifi, SSID: %s (signal: %d)",
-             WiFi.SSID().c_str(), WiFi.RSSI());
-    ESP_LOGI(__FILENAME__, "IP address of Device: %s",
-             WiFi.localIP().toString().c_str());
-    ESP_LOGI(__FILENAME__, "Default route: %s",
-             WiFi.gatewayIP().toString().c_str());
-    ESP_LOGI(__FILENAME__, "DNS server: %s", WiFi.dnsIP().toString().c_str());
-    // Defer to main event loop — WiFi callbacks run on the WiFi task.
-    event_loop()->onDelay(
-        0, [this]() { this->emit(WiFiState::kWifiConnectedToAP); });
-  }
-
-  void wifi_ap_enabled() {
-    ESP_LOGI(__FILENAME__, "WiFi Access Point enabled, SSID: %s",
-             WiFi.softAPSSID().c_str());
-    ESP_LOGI(__FILENAME__, "IP address of Device: %s",
-             WiFi.softAPIP().toString().c_str());
-
-    // Setting the AP mode happens immediately,
-    // so this callback is likely called already before all startables have been
-    // initiated. Delay the WiFi state update until the start of the event loop.
-    event_loop()->onDelay(
-        0, [this]() { this->emit(WiFiState::kWifiAPModeActivated); });
-  }
-
-  void wifi_disconnected() {
-    ESP_LOGI(__FILENAME__, "Disconnected from wifi.");
-    // Defer to main event loop — WiFi callbacks run on the WiFi task.
-    event_loop()->onDelay(
-        0, [this]() { this->emit(WiFiState::kWifiDisconnected); });
-  }
-};
-
-/**
- * @brief Storage object for WiFi access point settings.
- *
- */
-class AccessPointSettings {
- public:
-  AccessPointSettings(bool enabled = true, String ssid = "",
-                      String password = "", int channel = 9,
-                      bool hidden = false, bool captive_portal_enabled = true)
-      : enabled_{enabled},
-        ssid_{ssid},
-        password_{password},
-        channel_{channel},
-        hidden_{hidden},
-        captive_portal_enabled_{captive_portal_enabled} {
-    if (ssid_ == "") {
-      // If no SSID is provided, use the hostname as the SSID
-      ssid_ = SensESPBaseApp::get_hostname();
-    }
-  };
-
-  bool enabled_;
-  String ssid_;
-  String password_;
-  int channel_;
-  bool hidden_;
-  bool captive_portal_enabled_ = true;
-
-  static AccessPointSettings from_json(const JsonObject& json) {
-    AccessPointSettings settings;
-    settings.enabled_ = json["enabled"] | false;
-    settings.ssid_ = json["name"] | "";
-    settings.password_ = json["password"] | "";
-    settings.channel_ = json["channel"] | 1;
-    settings.hidden_ = json["hidden"] | false;
-    settings.captive_portal_enabled_ = json["captivePortalEnabled"] | true;
-    return settings;
-  }
-
-  void as_json(JsonObject& doc) {
-    doc["enabled"] = enabled_;
-    doc["name"] = ssid_;
-    doc["password"] = password_;
-    doc["channel"] = channel_;
-    doc["hidden"] = hidden_;
-    doc["captivePortalEnabled"] = captive_portal_enabled_;
-  }
-};
-
-/**
- * @brief Storage object for WiFi client settings.
- *
- */
-class ClientSSIDConfig {
- public:
-  ClientSSIDConfig(String ssid = "", String password = "", bool use_dhcp = true,
-                   IPAddress ip = IPAddress(169, 254, 0, 1),
-                   IPAddress netmask = IPAddress(255, 255, 255, 0),
-                   IPAddress gateway = IPAddress(192, 168, 0, 1),
-                   IPAddress dns_server = IPAddress(8, 8, 8, 8))
-      : ssid_{ssid},
-        password_{password},
-        use_dhcp_{use_dhcp},
-        ip_{ip},
-        netmask_{netmask},
-        gateway_{gateway},
-        dns_server_{dns_server} {};
-
-  String ssid_;
-  String password_;
-  bool use_dhcp_;
-  IPAddress ip_;
-  IPAddress netmask_;
-  IPAddress gateway_;
-  IPAddress dns_server_;
-
-  static ClientSSIDConfig from_json(const JsonObject& json) {
-    ClientSSIDConfig config;
-    config.ssid_ = json["name"] | "";
-    config.password_ = json["password"] | "";
-    config.use_dhcp_ = json["useDHCP"] | true;
-    config.ip_.fromString(json["ipAddress"] | "169.254.0.1");
-    config.netmask_.fromString(json["netmask"] | "255.255.255.0");
-    config.gateway_.fromString(json["gateway"] | "192.168.0.1");
-    config.dns_server_.fromString(json["dnsServer"] | "8.8.8.8");
-    return config;
-  }
-
-  void as_json(JsonObject& doc) {
-    doc["name"] = ssid_;
-    doc["password"] = password_;
-    doc["useDHCP"] = use_dhcp_;
-    doc["ipAddress"] = ip_.toString();
-    doc["netmask"] = netmask_.toString();
-    doc["gateway"] = gateway_.toString();
-    doc["dnsServer"] = dns_server_.toString();
-  }
-};
-
-/**
- * @brief WiFi Network Information storage class.
- *
- */
-class WiFiNetworkInfo {
- public:
-  WiFiNetworkInfo()
-      : ssid_{""}, rssi_{0}, encryption_{0}, bssid_{0}, channel_{0} {}
-  WiFiNetworkInfo(String ssid, int32_t rssi, uint8_t encryption, uint8_t* bssid,
-                  int32_t channel)
-      : ssid_{ssid}, rssi_{rssi}, encryption_{encryption}, channel_{channel} {
-    memcpy(bssid_, bssid, 6);
-  }
-
-  String ssid_;
-  int32_t rssi_;
-  uint8_t encryption_;
-  uint8_t bssid_[6];
-  int32_t channel_;
-
-  void as_json(JsonObject& doc) {
-    doc["ssid"] = ssid_;
-    doc["rssi"] = rssi_;
-    doc["encryption"] = encryption_;
-    doc["channel"] = channel_;
-    // Add bssid as a string
-    doc["bssid"] = String(bssid_[0], HEX) + ":" + String(bssid_[1], HEX) + ":" +
-                   String(bssid_[2], HEX) + ":" + String(bssid_[3], HEX) + ":" +
-                   String(bssid_[4], HEX) + ":" + String(bssid_[5], HEX);
-  }
-};
-
-/**
- * @brief Manages the ESP's connection to the Wifi network.
- */
-class Networking : public FileSystemSaveable,
-                   public Resettable,
-                   public ValueProducer<WiFiState> {
- public:
-  Networking(const String& config_path, const String& client_ssid = "",
-             const String& client_password = "", const String& ap_ssid = "",
-             const String& ap_password = "");
-  ~Networking();
-
-  virtual void reset() override;
-
-  virtual bool to_json(JsonObject& doc) override;
-  virtual bool from_json(const JsonObject& config) override;
-
-  void start_wifi_scan();
-  int16_t get_wifi_scan_results(std::vector<WiFiNetworkInfo>& ssid_list);
-
-  bool is_captive_portal_enabled() {
-    return ap_settings_.captive_portal_enabled_;
-  }
-
-  const std::shared_ptr<WiFiStateProducer>& get_wifi_state_producer() {
-    return wifi_state_producer_;
-  }
-
- protected:
-  void start_access_point();
-  void start_client_autoconnect();
-
-  AccessPointSettings ap_settings_;
-
-  bool client_enabled_ = false;
-  std::vector<ClientSSIDConfig> client_settings_;
-
-  std::unique_ptr<DNSServer> dns_server_;
-
-  std::shared_ptr<WiFiStateProducer> wifi_state_producer_ =
-      std::make_shared<WiFiStateProducer>();
-
-  std::shared_ptr<LambdaConsumer<WiFiState>> wifi_state_emitter_;
-};
-
-inline const String ConfigSchema(const Networking& obj) {
-  return "null";
-}
-
-inline bool ConfigRequiresRestart(const Networking& obj) { return true; }
+/// @deprecated Use WiFiProvisioner directly, or NetworkProvisioner if
+/// transport-agnostic. Kept as a typedef so existing user code continues
+/// to compile.
+using Networking = WiFiProvisioner;
 
 }  // namespace sensesp
 
-#endif
+#endif  // SENSESP_NET_NETWORKING_H_

--- a/src/sensesp/net/web/app_command_handler.cpp
+++ b/src/sensesp/net/web/app_command_handler.cpp
@@ -26,10 +26,10 @@ void add_tofu_reset_handler(std::shared_ptr<HTTPServer>& server) {
 }
 
 void add_scan_wifi_networks_handlers(std::shared_ptr<HTTPServer>& server,
-                                     std::shared_ptr<Networking>& networking) {
+                                     std::shared_ptr<WiFiProvisioner> wifi_provisioner) {
   auto scan_wifi_networks_handler = std::make_shared<HTTPRequestHandler>(
-      1 << HTTP_POST, "/api/wifi/scan", [networking](httpd_req_t* req) {
-        networking->start_wifi_scan();
+      1 << HTTP_POST, "/api/wifi/scan", [wifi_provisioner](httpd_req_t* req) {
+        wifi_provisioner->start_wifi_scan();
         // Return status code 202 and "SCAN STARTED" message
         httpd_resp_set_status(req, "202 Accepted");
         httpd_resp_send(req, "SCAN STARTED", 0);
@@ -39,9 +39,9 @@ void add_scan_wifi_networks_handlers(std::shared_ptr<HTTPServer>& server,
   server->add_handler(scan_wifi_networks_handler);
 
   auto scan_results_handler = std::make_shared<HTTPRequestHandler>(
-      1 << HTTP_GET, "/api/wifi/scan-results", [networking](httpd_req_t* req) {
+      1 << HTTP_GET, "/api/wifi/scan-results", [wifi_provisioner](httpd_req_t* req) {
         std::vector<WiFiNetworkInfo> ssid_list;
-        int16_t result = networking->get_wifi_scan_results(ssid_list);
+        int16_t result = wifi_provisioner->get_wifi_scan_results(ssid_list);
         if (result == WIFI_SCAN_RUNNING) {
           // Return status code 202 and "SCAN RUNNING" message
           httpd_resp_set_status(req, "202 Accepted");
@@ -71,8 +71,8 @@ void add_scan_wifi_networks_handlers(std::shared_ptr<HTTPServer>& server,
 }
 
 void add_app_http_command_handlers(std::shared_ptr<HTTPServer>& server,
-                                   std::shared_ptr<Networking>& networking) {
-  add_scan_wifi_networks_handlers(server, networking);
+                                   std::shared_ptr<WiFiProvisioner> wifi_provisioner) {
+  add_scan_wifi_networks_handlers(server, wifi_provisioner);
   add_tofu_reset_handler(server);
 }
 

--- a/src/sensesp/net/web/app_command_handler.h
+++ b/src/sensesp/net/web/app_command_handler.h
@@ -6,12 +6,21 @@
 
 #include "ArduinoJson.h"
 #include "sensesp/net/http_server.h"
-#include "sensesp/net/networking.h"
+#include "sensesp/net/wifi_provisioner.h"
 
 namespace sensesp {
 
-void add_app_http_command_handlers(std::shared_ptr<HTTPServer>& server,
-                                   std::shared_ptr<Networking>& networking);
+/// Register the transport-agnostic Signal K TOFU reset handler.
+/// Safe to call regardless of which network provisioner is active.
+void add_tofu_reset_handler(std::shared_ptr<HTTPServer>& server);
+
+/// Register the WiFi-only command handlers (network scan + TOFU reset).
+/// Should only be called when WiFi is the active network provisioner.
+/// `wifi_provisioner` is taken by value so callers can pass the result
+/// of SensESPApp::get_wifi_provisioner() (which returns a temporary).
+void add_app_http_command_handlers(
+    std::shared_ptr<HTTPServer>& server,
+    std::shared_ptr<WiFiProvisioner> wifi_provisioner);
 
 }  // namespace sensesp
 

--- a/src/sensesp/net/web/base_command_handler.cpp
+++ b/src/sensesp/net/web/base_command_handler.cpp
@@ -1,8 +1,8 @@
 #include "base_command_handler.h"
 
-#include "WiFi.h"
 #include "sensesp/net/web/autogen/frontend_files.h"
 #include "sensesp/ui/status_page_item.h"
+#include "sensesp_app.h"
 
 namespace sensesp {
 
@@ -16,8 +16,12 @@ bool check_origin(httpd_req_t* req) {
     String origin_str(origin);
     String hostname = SensESPBaseApp::get_hostname();
     if (origin_str.indexOf(hostname) < 0) {
-      String ip = WiFi.localIP().toString();
-      if (origin_str.indexOf(ip) < 0) {
+      // Check the active provisioner's local IP — works for both WiFi
+      // and Ethernet without depending on the WiFi library directly.
+      auto provisioner = SensESPApp::get()->get_network_provisioner();
+      String ip =
+          provisioner ? provisioner->local_ip().toString() : String("");
+      if (ip.length() == 0 || origin_str.indexOf(ip) < 0) {
         httpd_resp_send_err(req, HTTPD_403_FORBIDDEN,
                             "Cross-origin request rejected");
         return false;

--- a/src/sensesp/net/wifi_provisioner.cpp
+++ b/src/sensesp/net/wifi_provisioner.cpp
@@ -1,10 +1,9 @@
 #include "sensesp.h"
 
-#include "networking.h"
+#include "wifi_provisioner.h"
 
 #include <esp_wifi.h>
 
-#include "sensesp/system/lambda_consumer.h"
 #include "sensesp_app.h"
 
 namespace sensesp {
@@ -24,16 +23,12 @@ namespace sensesp {
 // 3. If the hard-coded hostname is changed, use that instead of the saved one.
 //    (But keep using the saved WiFi credentials!)
 
-Networking::Networking(const String& config_path, const String& client_ssid,
-                       const String& client_password, const String& ap_ssid,
-                       const String& ap_password)
+WiFiProvisioner::WiFiProvisioner(const String& config_path,
+                                 const String& client_ssid,
+                                 const String& client_password,
+                                 const String& ap_ssid,
+                                 const String& ap_password)
     : FileSystemSaveable{config_path}, Resettable(0) {
-  // Get the WiFi state producer singleton and make it update this object output
-  wifi_state_emitter_ = std::make_shared<LambdaConsumer<WiFiState>>(
-          [this](WiFiState state) { this->emit(state); });
-
-  wifi_state_producer_->connect_to(wifi_state_emitter_);
-
   bool config_loaded = load();
 
   if (!config_loaded) {
@@ -59,7 +54,7 @@ Networking::Networking(const String& config_path, const String& client_ssid,
     client_settings_.push_back(ClientSSIDConfig());
   }
 
-  ESP_LOGD(__FILENAME__, "Enabling Networking");
+  ESP_LOGD(__FILENAME__, "Enabling WiFi provisioner");
 
   // Hate to do this, but Raspberry Pi AP setup is going to be much more
   // complicated with enforced WPA2. BAD Raspberry Pi! BAD!
@@ -107,7 +102,7 @@ Networking::Networking(const String& config_path, const String& client_ssid,
   }
 }
 
-Networking::~Networking() {
+WiFiProvisioner::~WiFiProvisioner() {
   if (dns_server_) {
     dns_server_->stop();
   }
@@ -116,11 +111,7 @@ Networking::~Networking() {
   WiFi.disconnect(true);
 }
 
-/**
- * @brief Start an access point.
- *
- */
-void Networking::start_access_point() {
+void WiFiProvisioner::start_access_point() {
   String hostname = SensESPBaseApp::get_hostname();
   WiFi.setHostname(hostname.c_str());
 
@@ -137,10 +128,7 @@ void Networking::start_access_point() {
   }
 }
 
-/**
- * @brief Start WiFi using preset SSID and password.
- */
-void Networking::start_client_autoconnect() {
+void WiFiProvisioner::start_client_autoconnect() {
   String hostname = SensESPBaseApp::get_hostname();
   WiFi.setHostname(hostname.c_str());
 
@@ -198,8 +186,13 @@ void Networking::start_client_autoconnect() {
     if (!config.use_dhcp_) {
       ESP_LOGI(__FILENAME__, "Using static IP address: %s",
                config.ip_.toString().c_str());
-      WiFi.config(config.ip_, config.dns_server_, config.gateway_,
-                  config.netmask_);
+      // Arduino-ESP32 signature:
+      //   WiFi.config(local_ip, gateway, subnet, dns1, dns2).
+      // The pre-refactor code passed (ip, dns, gateway, netmask) which
+      // silently set gateway=dns, subnet=gateway and dns1=netmask — a
+      // long-standing bug that broke every saved static-IP config.
+      WiFi.config(config.ip_, config.gateway_, config.netmask_,
+                  config.dns_server_);
     }
     WiFi.begin(config.ssid_.c_str(), config.password_.c_str());
     attempt_num++;
@@ -215,11 +208,7 @@ void Networking::start_client_autoconnect() {
   event_loop()->onRepeat(20000, reconnect_cb);
 }
 
-/**
- * @brief Serialize the current configuration to a JSON document.
- *
- */
-bool Networking::to_json(JsonObject& root) {
+bool WiFiProvisioner::to_json(JsonObject& root) {
   JsonObject apSettingsJson = root["apSettings"].to<JsonObject>();
   ap_settings_.as_json(apSettingsJson);
 
@@ -237,7 +226,7 @@ bool Networking::to_json(JsonObject& root) {
   return true;
 }
 
-bool Networking::from_json(const JsonObject& config) {
+bool WiFiProvisioner::from_json(const JsonObject& config) {
   if (config["hostname"].is<String>()) {
     // deal with the legacy Json format
     String hostname = config["hostname"].as<String>();
@@ -248,7 +237,6 @@ bool Networking::from_json(const JsonObject& config) {
       String password = config["password"].as<String>();
 
       if (config["ap_mode"].is<String>()) {
-        bool ap_mode;
         if (config["ap_mode"].as<String>() == "Access Point" ||
             config["ap_mode"].as<String>() == "Hotspot") {
           ap_settings_ = {true, ssid, password};
@@ -289,7 +277,7 @@ bool Networking::from_json(const JsonObject& config) {
   return true;
 }
 
-void Networking::reset() {
+void WiFiProvisioner::reset() {
   ESP_LOGI(__FILENAME__, "Resetting WiFi SSID settings");
 
   clear();
@@ -299,7 +287,7 @@ void Networking::reset() {
   WiFi.begin("0", "0", 0, nullptr, false);
 }
 
-void Networking::start_wifi_scan() {
+void WiFiProvisioner::start_wifi_scan() {
   // Scan fails if WiFi is connecting. Disconnect to allow scanning.
   if (WiFi.status() != WL_CONNECTED) {
     ESP_LOGD(__FILENAME__,
@@ -313,7 +301,7 @@ void Networking::start_wifi_scan() {
   }
 }
 
-int16_t Networking::get_wifi_scan_results(
+int16_t WiFiProvisioner::get_wifi_scan_results(
     std::vector<WiFiNetworkInfo>& ssid_list) {
   int num_networks = WiFi.scanComplete();
   if (num_networks == WIFI_SCAN_RUNNING) {

--- a/src/sensesp/net/wifi_provisioner.h
+++ b/src/sensesp/net/wifi_provisioner.h
@@ -1,0 +1,225 @@
+#ifndef SENSESP_NET_WIFI_PROVISIONER_H_
+#define SENSESP_NET_WIFI_PROVISIONER_H_
+
+#include <Arduino.h>
+#include <DNSServer.h>
+#include <WiFi.h>
+
+#include <memory>
+#include <vector>
+
+#include "sensesp/net/network_provisioner.h"
+#include "sensesp/net/network_state.h"
+#include "sensesp/system/observablevalue.h"
+#include "sensesp/system/resettable.h"
+#include "sensesp/system/serializable.h"
+#include "sensesp_base_app.h"
+
+namespace sensesp {
+
+constexpr int kMaxNumClientConfigs = 3;
+
+/**
+ * @brief Storage object for WiFi access point settings.
+ */
+class AccessPointSettings {
+ public:
+  AccessPointSettings(bool enabled = true, String ssid = "",
+                      String password = "", int channel = 9,
+                      bool hidden = false, bool captive_portal_enabled = true)
+      : enabled_{enabled},
+        ssid_{ssid},
+        password_{password},
+        channel_{channel},
+        hidden_{hidden},
+        captive_portal_enabled_{captive_portal_enabled} {
+    if (ssid_ == "") {
+      // If no SSID is provided, use the hostname as the SSID
+      ssid_ = SensESPBaseApp::get_hostname();
+    }
+  };
+
+  bool enabled_;
+  String ssid_;
+  String password_;
+  int channel_;
+  bool hidden_;
+  bool captive_portal_enabled_ = true;
+
+  static AccessPointSettings from_json(const JsonObject& json) {
+    AccessPointSettings settings;
+    settings.enabled_ = json["enabled"] | false;
+    settings.ssid_ = json["name"] | "";
+    settings.password_ = json["password"] | "";
+    settings.channel_ = json["channel"] | 1;
+    settings.hidden_ = json["hidden"] | false;
+    settings.captive_portal_enabled_ = json["captivePortalEnabled"] | true;
+    return settings;
+  }
+
+  void as_json(JsonObject& doc) {
+    doc["enabled"] = enabled_;
+    doc["name"] = ssid_;
+    doc["password"] = password_;
+    doc["channel"] = channel_;
+    doc["hidden"] = hidden_;
+    doc["captivePortalEnabled"] = captive_portal_enabled_;
+  }
+};
+
+/**
+ * @brief Storage object for WiFi client settings.
+ */
+class ClientSSIDConfig {
+ public:
+  ClientSSIDConfig(String ssid = "", String password = "", bool use_dhcp = true,
+                   IPAddress ip = IPAddress(169, 254, 0, 1),
+                   IPAddress netmask = IPAddress(255, 255, 255, 0),
+                   IPAddress gateway = IPAddress(192, 168, 0, 1),
+                   IPAddress dns_server = IPAddress(8, 8, 8, 8))
+      : ssid_{ssid},
+        password_{password},
+        use_dhcp_{use_dhcp},
+        ip_{ip},
+        netmask_{netmask},
+        gateway_{gateway},
+        dns_server_{dns_server} {};
+
+  String ssid_;
+  String password_;
+  bool use_dhcp_;
+  IPAddress ip_;
+  IPAddress netmask_;
+  IPAddress gateway_;
+  IPAddress dns_server_;
+
+  static ClientSSIDConfig from_json(const JsonObject& json) {
+    ClientSSIDConfig config;
+    config.ssid_ = json["name"] | "";
+    config.password_ = json["password"] | "";
+    config.use_dhcp_ = json["useDHCP"] | true;
+    config.ip_.fromString(json["ipAddress"] | "169.254.0.1");
+    config.netmask_.fromString(json["netmask"] | "255.255.255.0");
+    config.gateway_.fromString(json["gateway"] | "192.168.0.1");
+    config.dns_server_.fromString(json["dnsServer"] | "8.8.8.8");
+    return config;
+  }
+
+  void as_json(JsonObject& doc) {
+    doc["name"] = ssid_;
+    doc["password"] = password_;
+    doc["useDHCP"] = use_dhcp_;
+    doc["ipAddress"] = ip_.toString();
+    doc["netmask"] = netmask_.toString();
+    doc["gateway"] = gateway_.toString();
+    doc["dnsServer"] = dns_server_.toString();
+  }
+};
+
+/**
+ * @brief WiFi network info storage class returned by scan results.
+ */
+class WiFiNetworkInfo {
+ public:
+  WiFiNetworkInfo()
+      : ssid_{""}, rssi_{0}, encryption_{0}, bssid_{0}, channel_{0} {}
+  WiFiNetworkInfo(String ssid, int32_t rssi, uint8_t encryption, uint8_t* bssid,
+                  int32_t channel)
+      : ssid_{ssid}, rssi_{rssi}, encryption_{encryption}, channel_{channel} {
+    if (bssid != nullptr) {
+      memcpy(bssid_, bssid, 6);
+    } else {
+      memset(bssid_, 0, 6);
+    }
+  }
+
+  String ssid_;
+  int32_t rssi_;
+  uint8_t encryption_;
+  uint8_t bssid_[6];
+  int32_t channel_;
+
+  void as_json(JsonObject& doc) {
+    doc["ssid"] = ssid_;
+    doc["rssi"] = rssi_;
+    doc["encryption"] = encryption_;
+    doc["channel"] = channel_;
+    // Zero-pad each byte so MAC addresses like 02:0A:... format
+    // correctly. The pre-refactor code used `String(byte, HEX)` which
+    // produces "A" instead of "0A" for single-digit hex values.
+    char bssid_str[18];
+    snprintf(bssid_str, sizeof(bssid_str),
+             "%02X:%02X:%02X:%02X:%02X:%02X", bssid_[0], bssid_[1],
+             bssid_[2], bssid_[3], bssid_[4], bssid_[5]);
+    doc["bssid"] = bssid_str;
+  }
+};
+
+/**
+ * @brief Manages the ESP's WiFi connection.
+ *
+ * Inherits from NetworkProvisioner so SensESPApp can hold any provisioner
+ * implementation through the same shared_ptr type. Adds WiFi-specific
+ * methods (scanning, soft-AP IP, captive portal flag) directly on the
+ * concrete class — code that needs them holds a typed pointer via
+ * SensESPApp::get_wifi_provisioner().
+ *
+ * The legacy `Networking` class name is preserved as a typedef in
+ * networking.h for source-level backward compatibility.
+ */
+class WiFiProvisioner : public FileSystemSaveable,
+                       public Resettable,
+                       public NetworkProvisioner {
+ public:
+  WiFiProvisioner(const String& config_path, const String& client_ssid = "",
+                  const String& client_password = "",
+                  const String& ap_ssid = "",
+                  const String& ap_password = "");
+  ~WiFiProvisioner() override;
+
+  // -- Resettable --
+  void reset() override;
+
+  // -- FileSystemSaveable --
+  bool to_json(JsonObject& doc) override;
+  bool from_json(const JsonObject& config) override;
+
+  // -- NetworkProvisioner --
+  IPAddress local_ip() const override { return WiFi.localIP(); }
+  IPAddress gateway_ip() const override { return WiFi.gatewayIP(); }
+  String mac_address() const override { return WiFi.macAddress(); }
+  bool is_connected() const override {
+    return WiFi.isConnected() || WiFi.getMode() == WIFI_MODE_AP ||
+           WiFi.getMode() == WIFI_MODE_APSTA;
+  }
+
+  // -- WiFi-specific methods --
+  IPAddress soft_ap_ip() const { return WiFi.softAPIP(); }
+  bool is_captive_portal_enabled() const {
+    return ap_settings_.captive_portal_enabled_;
+  }
+  String ssid() const { return WiFi.SSID(); }
+  int rssi() const { return WiFi.RSSI(); }
+
+  void start_wifi_scan();
+  int16_t get_wifi_scan_results(std::vector<WiFiNetworkInfo>& ssid_list);
+
+ protected:
+  void start_access_point();
+  void start_client_autoconnect();
+
+  AccessPointSettings ap_settings_;
+
+  bool client_enabled_ = false;
+  std::vector<ClientSSIDConfig> client_settings_;
+
+  std::unique_ptr<DNSServer> dns_server_;
+};
+
+inline const String ConfigSchema(const WiFiProvisioner& obj) { return "null"; }
+
+inline bool ConfigRequiresRestart(const WiFiProvisioner& obj) { return true; }
+
+}  // namespace sensesp
+
+#endif  // SENSESP_NET_WIFI_PROVISIONER_H_

--- a/src/sensesp/net/wifi_provisioner.h
+++ b/src/sensesp/net/wifi_provisioner.h
@@ -169,7 +169,8 @@ class WiFiNetworkInfo {
  */
 class WiFiProvisioner : public FileSystemSaveable,
                        public Resettable,
-                       public NetworkProvisioner {
+                       public NetworkProvisioner,
+                       public ValueProducer<WiFiState> {
  public:
   WiFiProvisioner(const String& config_path, const String& client_ssid = "",
                   const String& client_password = "",
@@ -192,6 +193,14 @@ class WiFiProvisioner : public FileSystemSaveable,
     return WiFi.isConnected() || WiFi.getMode() == WIFI_MODE_AP ||
            WiFi.getMode() == WIFI_MODE_APSTA;
   }
+
+  /**
+   * @deprecated Use SensESPApp::get_network_state_producer() or
+   * connect_to() on this WiFiProvisioner directly (it is now a
+   * ValueProducer<WiFiState>). Kept for source compatibility with
+   * code that called get_networking()->get_wifi_state_producer().
+   */
+  ValueProducer<WiFiState>* get_wifi_state_producer() { return this; }
 
   // -- WiFi-specific methods --
   IPAddress soft_ap_ip() const { return WiFi.softAPIP(); }

--- a/src/sensesp/sensors/system_info.cpp
+++ b/src/sensesp/sensors/system_info.cpp
@@ -5,6 +5,7 @@
 #include <WiFi.h>
 
 #include "Arduino.h"
+#include "sensesp_app.h"
 
 namespace sensesp {
 
@@ -28,8 +29,29 @@ void FreeMem::update() { this->emit(ESP.getFreeHeap()); }
 
 void Uptime::update() { this->emit(static_cast<double>(millis()) / 1000.); }
 
-void IPAddrDev::update() { this->emit(WiFi.localIP().toString()); }
+void IPAddrDev::update() {
+  // Query the active network provisioner so this sensor works for both
+  // WiFi and (future) non-WiFi transports. Defensively null-check the
+  // app singleton: IPAddrDev::update() can run on any event-loop tick,
+  // including before setup() has finished wiring the provisioner.
+  auto app = SensESPApp::get();
+  if (!app) {
+    this->emit(String("0.0.0.0"));
+    return;
+  }
+  auto provisioner = app->get_network_provisioner();
+  if (provisioner) {
+    this->emit(provisioner->local_ip().toString());
+  } else {
+    this->emit(String("0.0.0.0"));
+  }
+}
 
+// WiFiSignal is intentionally still WiFi-specific by name and behaviour.
+// Builder code that calls enable_wifi_signal_sensor() on a non-WiFi
+// deployment will still get this sensor, but it will report 0 since
+// there is no WiFi association. The user is responsible for not enabling
+// it on non-WiFi-only devices.
 void WiFiSignal::update() { this->emit(WiFi.RSSI()); }
 
 }  // namespace sensesp

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -586,11 +586,14 @@ void SKWSClient::connect() {
   // Will be reset on successful connection.
   schedule_reconnect();
 
-  if (!WiFi.isConnected() && WiFi.getMode() != WIFI_MODE_AP) {
-    ESP_LOGI(
-        __FILENAME__,
-        "WiFi is disconnected. SignalK client connection will be initiated "
-        "when WiFi is connected.");
+  // Wait for the active network provisioner (WiFi, Ethernet, …) to be
+  // up before initiating the WS connection. The provisioner abstracts
+  // away whether we're on WiFi, Ethernet, or some other transport.
+  auto provisioner = SensESPApp::get()->get_network_provisioner();
+  if (!provisioner || !provisioner->is_connected()) {
+    ESP_LOGI(__FILENAME__,
+             "Network is not yet up. SignalK client connection will be "
+             "initiated when the link comes up.");
     return;
   }
 

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -117,7 +117,7 @@ class SensESPApp : public SensESPBaseApp {
    * @deprecated Use get_wifi_provisioner() instead. Kept as a
    * source-compatible alias since the legacy class name was Networking.
    */
-  std::shared_ptr<WiFiProvisioner> get_networking() {
+  std::shared_ptr<WiFiProvisioner>& get_networking() {
     return this->wifi_provisioner_;
   }
 
@@ -248,6 +248,16 @@ class SensESPApp : public SensESPBaseApp {
     // from inside their own constructors.
     if (wifi_provisioner_) {
       ConfigItem(wifi_provisioner_);
+    }
+
+    // Backward compat: the old Networking class was a
+    // ValueProducer<WiFiState>. Forward state from the unified
+    // NetworkStateProducer so code that did networking->connect_to(...)
+    // continues to work.
+    if (wifi_provisioner_ && network_state_producer_) {
+      auto nsp = network_state_producer_;
+      auto wp = wifi_provisioner_;
+      nsp->attach([nsp, wp]() { wp->emit(nsp->get()); });
     }
 
     if (ota_password_ != nullptr) {

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -1,15 +1,20 @@
 #ifndef SENSESP_APP_H_
 #define SENSESP_APP_H_
 
+#include <functional>
+
 #include "sensesp/controllers/system_status_controller.h"
 #include "sensesp/net/discovery.h"
 #include "sensesp/net/http_server.h"
+#include "sensesp/net/network_provisioner.h"
+#include "sensesp/net/network_state.h"
 #include "sensesp/net/networking.h"
 #include "sensesp/net/ota.h"
 #include "sensesp/net/web/app_command_handler.h"
 #include "sensesp/net/web/base_command_handler.h"
 #include "sensesp/net/web/config_handler.h"
 #include "sensesp/net/web/static_file_handler.h"
+#include "sensesp/net/wifi_provisioner.h"
 #include "sensesp/sensesp_version.h"
 #include "sensesp/sensors/sensor.h"
 #include "sensesp/signalk/signalk_delta_queue.h"
@@ -72,8 +77,70 @@ class SensESPApp : public SensESPBaseApp {
   std::shared_ptr<SystemStatusController> get_system_status_controller() {
     return this->system_status_controller_;
   }
-  std::shared_ptr<Networking>& get_networking() { return this->networking_; }
+
+  /**
+   * @brief Active network provisioner (transport-agnostic).
+   *
+   * Always non-null after setup() has run. Holds whichever provisioner
+   * the builder selected (WiFi by default, Ethernet via set_ethernet(),
+   * future PPP/cellular via set_ppp(), …).
+   */
+  std::shared_ptr<NetworkProvisioner>& get_network_provisioner() {
+    return this->network_provisioner_;
+  }
+
+  /**
+   * @brief Active WiFi provisioner, or nullptr if a non-WiFi transport
+   * is in use.
+   *
+   * Use this when WiFi-specific functionality is needed (scanning,
+   * captive portal, soft-AP IP). For transport-agnostic queries
+   * (local_ip(), mac_address(), …) prefer get_network_provisioner().
+   */
+  std::shared_ptr<WiFiProvisioner>& get_wifi_provisioner() {
+    return this->wifi_provisioner_;
+  }
+
+  /**
+   * @brief Unified producer that emits NetworkState transitions for any
+   * active interface (WiFi STA, WiFi AP, Ethernet, …).
+   *
+   * Always non-null after setup() has run. The
+   * SystemStatusController subscribes to it during setup(); user code
+   * can attach additional consumers via connect_to().
+   */
+  std::shared_ptr<NetworkStateProducer> get_network_state_producer() {
+    return this->network_state_producer_;
+  }
+
+  /**
+   * @deprecated Use get_wifi_provisioner() instead. Kept as a
+   * source-compatible alias since the legacy class name was Networking.
+   */
+  std::shared_ptr<WiFiProvisioner> get_networking() {
+    return this->wifi_provisioner_;
+  }
+
   std::shared_ptr<SKWSClient> get_ws_client() { return this->ws_client_; }
+
+  /**
+   * @brief Install a custom factory that setup() will use to construct
+   * the NetworkProvisioner instead of the default WiFiProvisioner.
+   *
+   * This is the extension point for non-WiFi transports (Ethernet,
+   * PPP/cellular, mock provisioners for tests, …). If never called,
+   * setup() falls back to constructing a WiFiProvisioner using the
+   * existing ssid_ / wifi_client_password_ / ap_ssid_ / ap_password_
+   * setters — preserving the legacy default for existing WiFi users.
+   *
+   * A follow-up PR referencing RFC #849 will ship an Ethernet
+   * provisioner plus a SensESPAppBuilder::set_ethernet() convenience
+   * method that wraps this setter.
+   */
+  void set_network_provisioner_factory(
+      std::function<std::shared_ptr<NetworkProvisioner>()> factory) {
+    provisioner_factory_ = std::move(factory);
+  }
 
  protected:
   /**
@@ -147,23 +214,59 @@ class SensESPApp : public SensESPBaseApp {
 
     ap_ssid_ = SensESPBaseApp::get_hostname();
 
-    // create the networking object
-    networking_ = std::make_shared<Networking>("/System/WiFi Settings", ssid_,
-                                               wifi_client_password_, ap_ssid_,
-                                               ap_password_);
+    // Create the unified NetworkStateProducer FIRST so it is subscribed
+    // to Network.onEvent before any provisioner brings its interface up
+    // — that way we cannot miss the GOT_IP that fires when DHCP
+    // completes a few hundred ms later.
+    network_state_producer_ = std::make_shared<NetworkStateProducer>();
 
-    ConfigItem(networking_);
+    // Create the chosen provisioner. If the builder installed a custom
+    // factory (via set_network_provisioner_factory()), use it; otherwise
+    // default to WiFi using the legacy constructor arguments — this
+    // preserves backward compatibility for every existing user app that
+    // calls set_wifi_client() or just relies on the defaults.
+    if (provisioner_factory_) {
+      network_provisioner_ = provisioner_factory_();
+      if (!network_provisioner_) {
+        ESP_LOGE(
+            __FILENAME__,
+            "provisioner_factory_ returned nullptr; falling back to "
+            "WiFiProvisioner so the rest of setup() has a valid object.");
+      }
+    }
+    if (!network_provisioner_) {
+      auto wifi = std::make_shared<WiFiProvisioner>(
+          "/System/WiFi Settings", ssid_, wifi_client_password_, ap_ssid_,
+          ap_password_);
+      network_provisioner_ = wifi;
+      wifi_provisioner_ = wifi;
+    }
+
+    // Register the WiFi-specific provisioner as a ConfigItem so the
+    // existing /System/WiFi Settings web UI continues to work. Other
+    // provisioners are responsible for registering their own ConfigItems
+    // from inside their own constructors.
+    if (wifi_provisioner_) {
+      ConfigItem(wifi_provisioner_);
+    }
 
     if (ota_password_ != nullptr) {
       // create the OTA object
       ota_ = std::make_shared<OTA>(ota_password_);
     }
 
-    bool captive_portal_enabled = networking_->is_captive_portal_enabled();
+    // Captive portal is meaningful only on WiFi (where there's a soft-AP).
+    bool captive_portal_enabled = false;
+    IPAddress captive_portal_ap_ip;
+    if (wifi_provisioner_) {
+      captive_portal_enabled = wifi_provisioner_->is_captive_portal_enabled();
+      captive_portal_ap_ip = wifi_provisioner_->soft_ap_ip();
+    }
 
     // create the HTTP server
     this->http_server_ = std::make_shared<HTTPServer>();
-    this->http_server_->set_captive_portal(captive_portal_enabled);
+    this->http_server_->set_captive_portal(captive_portal_enabled,
+                                           captive_portal_ap_ip);
 
     if (pending_admin_user_.length() > 0) {
       http_server_->set_auth_credentials(
@@ -173,7 +276,14 @@ class SensESPApp : public SensESPBaseApp {
     // Add the default HTTP server response handlers
     add_static_file_handlers(this->http_server_);
     add_base_app_http_command_handlers(this->http_server_);
-    add_app_http_command_handlers(this->http_server_, this->networking_);
+    // WiFi-specific REST handlers (/api/wifi/scan etc.) only register
+    // when the active provisioner is WiFi.
+    if (wifi_provisioner_) {
+      add_app_http_command_handlers(this->http_server_, wifi_provisioner_);
+    } else {
+      // Always register the transport-agnostic subset (TOFU reset).
+      add_tofu_reset_handler(this->http_server_);
+    }
     add_config_handlers(this->http_server_);
 
     ConfigItem(this->http_server_);
@@ -189,8 +299,12 @@ class SensESPApp : public SensESPBaseApp {
 
     ConfigItem(this->ws_client_);
 
-    // connect the system status controller
-    this->networking_->get_wifi_state_producer()->connect_to(
+    // Connect the system status controller. The unified
+    // NetworkStateProducer feeds it state from any active interface.
+    // (The consumer is still named get_wifi_state_consumer() for now —
+    // it accepts NetworkState because LinkState=WiFiState=NetworkState
+    // are aliases. Renaming the consumer is a separate cleanup.)
+    this->network_state_producer_->connect_to(
         &system_status_controller_->get_wifi_state_consumer());
     this->ws_client_->connect_to(
         &system_status_controller_->get_ws_connection_state_consumer());
@@ -227,10 +341,18 @@ class SensESPApp : public SensESPBaseApp {
   void connect_status_page_items() {
     this->hostname_->connect_to(&this->hostname_ui_output_);
     this->event_loop_->onRepeat(4999, [this]() {
-      wifi_ssid_ui_output_.set(WiFi.SSID());
-      mac_address_ui_output_.set(WiFi.macAddress());
+      // WiFi-specific status: only populated when WiFi is the active
+      // provisioner. On Ethernet (or other transports), the SSID slot
+      // is left empty and RSSI reads as 0.
+      if (wifi_provisioner_) {
+        wifi_ssid_ui_output_.set(wifi_provisioner_->ssid());
+        wifi_rssi_ui_output_.set(wifi_provisioner_->rssi());
+      } else {
+        wifi_ssid_ui_output_.set(String(""));
+        wifi_rssi_ui_output_.set(0);
+      }
+      mac_address_ui_output_.set(network_provisioner_->mac_address());
       free_memory_ui_output_.set(ESP.getFreeHeap());
-      wifi_rssi_ui_output_.set(WiFi.RSSI());
 
       // Uptime
       uptime_ui_output_.set(millis() / 1000);
@@ -320,7 +442,10 @@ class SensESPApp : public SensESPBaseApp {
   int button_gpio_pin_ = BUTTON_BUILTIN;
   std::shared_ptr<ButtonHandler> button_handler_;
 
-  std::shared_ptr<Networking> networking_;
+  std::shared_ptr<NetworkStateProducer> network_state_producer_;
+  std::shared_ptr<NetworkProvisioner> network_provisioner_;
+  std::shared_ptr<WiFiProvisioner> wifi_provisioner_;
+  std::function<std::shared_ptr<NetworkProvisioner>()> provisioner_factory_;
 
   std::shared_ptr<OTA> ota_;
   std::shared_ptr<SKDeltaQueue> sk_delta_queue_;

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -80,21 +80,57 @@ class SensESPAppBuilder : public SensESPBaseAppBuilder {
   /**
    * @brief Clear the default WiFi STA/AP settings.
    *
-   * Intended for use by future non-WiFi provisioners (Ethernet,
-   * PPP/cellular, …) that will supply a factory via
+   * Intended for use by non-WiFi provisioners (Ethernet, future
+   * PPP/cellular, …) that supply a factory via
    * SensESPApp::set_network_provisioner_factory(). Without this call,
    * the default WiFi-construction path in SensESPApp::setup() would
    * still produce a WiFiProvisioner alongside the non-WiFi one.
    *
-   * In this PR, only the abstraction is introduced — no non-WiFi
-   * provisioner ships yet, so this method is primarily scaffolding
-   * for the follow-up Ethernet PR that references RFC #849.
+   * set_ethernet() calls this implicitly, so most users do not have
+   * to invoke disable_wifi() directly.
    */
   SensESPAppBuilder* disable_wifi() {
     app_->set_ssid("");
     app_->set_wifi_password("");
     app_->set_ap_ssid("");
     app_->set_ap_password("");
+    return this;
+  }
+
+  /**
+   * @brief Configure the app to use a non-WiFi NetworkProvisioner.
+   *
+   * Today only Ethernet on ESP32-P4 is supported. Use as:
+   *
+   *     #include "sensesp/net/ethernet_provisioner.h"
+   *     ...
+   *     builder.set_ethernet(EthernetConfig::waveshare_esp32p4_poe())
+   *            ->get_app();
+   *
+   * @tparam ProvisionerConfigT  a configuration struct that exposes a
+   *         nested `using ProvisionerType = …;` typedef pointing at
+   *         the concrete NetworkProvisioner implementation.
+   *         EthernetConfig from sensesp/net/ethernet_provisioner.h is
+   *         the only such type today. Templated so this header does
+   *         not need to pull in any provisioner implementation files
+   *         — users who call set_ethernet() must include the relevant
+   *         provisioner header in their own translation unit.
+   *
+   * Calling set_ethernet() on a target whose provisioner header is
+   * empty (e.g. classic ESP32, where EthernetConfig is not declared)
+   * produces a clean compile error at the use site rather than a
+   * silent runtime failure. Implicitly calls disable_wifi() so the
+   * WiFi-specific HTTP handlers and soft-AP fall-back are not
+   * registered.
+   */
+  template <typename ProvisionerConfigT>
+  SensESPAppBuilder* set_ethernet(ProvisionerConfigT config) {
+    disable_wifi();
+    app_->set_network_provisioner_factory(
+        [config]() -> std::shared_ptr<NetworkProvisioner> {
+          return std::make_shared<typename ProvisionerConfigT::ProvisionerType>(
+              config);
+        });
     return this;
   }
 

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -78,6 +78,27 @@ class SensESPAppBuilder : public SensESPBaseAppBuilder {
   }
 
   /**
+   * @brief Clear the default WiFi STA/AP settings.
+   *
+   * Intended for use by future non-WiFi provisioners (Ethernet,
+   * PPP/cellular, …) that will supply a factory via
+   * SensESPApp::set_network_provisioner_factory(). Without this call,
+   * the default WiFi-construction path in SensESPApp::setup() would
+   * still produce a WiFiProvisioner alongside the non-WiFi one.
+   *
+   * In this PR, only the abstraction is introduced — no non-WiFi
+   * provisioner ships yet, so this method is primarily scaffolding
+   * for the follow-up Ethernet PR that references RFC #849.
+   */
+  SensESPAppBuilder* disable_wifi() {
+    app_->set_ssid("");
+    app_->set_wifi_password("");
+    app_->set_ap_ssid("");
+    app_->set_ap_password("");
+    return this;
+  }
+
+  /**
    * @brief Set the Signal K server address and port.
    *
    * If not set, mDNS is used to discover the Signal K server.


### PR DESCRIPTION
Implements the transport-agnostic networking layer proposed in #849 and ships the first concrete non-WiFi provisioner (ESP32-P4 Ethernet) on top of it. No behavior change for existing WiFi users — every public class name, enum name, and builder method that existed before still works via compatibility typedefs, so existing sketches compile and run unchanged.

The PR is split into **two commits** for reviewability:

1. **`refactor(net): transport-agnostic networking layer`** — pure refactor, no new features visible to users. Introduces the abstraction, renames `Networking`→`WiFiProvisioner`, unifies the event producer, wires the status page and sensors through the new interface. Drive-by fixes for a long-standing `WiFi.config()` argument-order bug and BSSID hex formatting.
2. **`feat(net): ESP32-P4 Ethernet provisioner + p4_ethernet example + docs`** — concrete ethernet implementation, `set_ethernet()` builder method, downstream `examples/p4_ethernet/` project, and documentation updates (features page, migration guide, example README).

Bundling these into one PR because they tell one story (the refactor exists *because of* the ethernet use case) and the ethernet commit is what makes the refactor demonstrable and reviewable on real hardware.

## Commit 1 — transport-agnostic networking refactor

### New abstraction

- **`NetworkState`** (enum, `network_state.h`) — transport-agnostic link state. Implemented as a strong alias of `WiFiState` so existing `kWifi*` member names keep working. New neutral aliases (`kNetwork*`) are provided for new code.
- **`NetworkStateProducer`** (`network_state.{h,cpp}`) — a single unified producer owned by `SensESPApp` that subscribes to the Arduino-ESP32 `Network.onEvent()` bus and emits state for WiFi STA, WiFi AP, **and** Ethernet events (`ARDUINO_EVENT_WIFI_STA_GOT_IP`, `WIFI_AP_START`, `ETH_GOT_IP`, `ETH_LOST_IP`, `ETH_DISCONNECTED`, …). Replaces the legacy `WiFiStateProducer` that only listened to WiFi events.
- **`NetworkProvisioner`** (`network_provisioner.h`) — abstract base that exposes the runtime transport-agnostic API (`local_ip()`, `gateway_ip()`, `mac_address()`, `is_connected()`). Concrete provisioners inherit from this. No RTTI / no capability-cast methods — `SensESPApp` holds both a base `NetworkProvisioner` pointer and an optional concrete `WiFiProvisioner` pointer so code that needs WiFi-only features (scanning, soft-AP IP) has a direct handle without `dynamic_cast`.

### Concrete WiFi implementation

- **`WiFiProvisioner`** (`wifi_provisioner.{h,cpp}`) — the renamed former `Networking` class, now inheriting from `NetworkProvisioner`. Adds WiFi-specific public methods (`start_wifi_scan`, `get_wifi_scan_results`, `ssid`, `rssi`, `soft_ap_ip`, `is_captive_portal_enabled`) directly on the concrete type. State-producer ownership is removed — the unified `NetworkStateProducer` in `SensESPApp` handles it.
- `networking.h` becomes a compatibility shim that defines `using Networking = WiFiProvisioner`, so every existing user sketch that includes `sensesp/net/networking.h` and references `Networking` or `WiFiState` continues to compile unchanged.

### Wiring changes

- `SensESPApp` now holds three shared pointers: `network_state_producer_` (unified, always non-null), `network_provisioner_` (always non-null — WiFi by default), `wifi_provisioner_` (non-null only when WiFi is active). A new public `set_network_provisioner_factory()` hook lets external code install a custom provisioner.
- `SensESPAppBuilder` gains `disable_wifi()` which clears the default WiFi STA/AP settings. `set_ethernet()` (see commit 2) calls it implicitly.
- `signalk_ws_client.cpp` no longer tests `WiFi.isConnected() || WiFi.getMode() != WIFI_MODE_AP` — it queries `provisioner->is_connected()` instead. Behaviour identical for WiFi users.
- `system_info.cpp` `IPAddrDev::update()` reads from the provisioner (`local_ip()`) instead of `WiFi.localIP()` so the sensor works automatically on any future transport.
- `base_command_handler.cpp` cross-origin check reads from the provisioner instead of `WiFi.localIP()`.
- `http_server.{h,cpp}` no longer pulls in `WiFi.h`. The captive-portal soft-AP IP is now passed explicitly via a second argument to `set_captive_portal()`, so the HTTP server doesn't depend on any specific transport.
- `app_command_handler.{h,cpp}` `add_app_http_command_handlers()` now takes a `shared_ptr<WiFiProvisioner>` (by value) and is only registered when the active provisioner is WiFi. The transport-agnostic subset (`add_tofu_reset_handler`) is exposed as a separate function so non-WiFi apps can still register it.
- `sensesp_app.h` status-page block populates WiFi-only items (`wifi_ssid_ui_output_`, `wifi_rssi_ui_output_`) from `wifi_provisioner_` if present, and leaves them empty otherwise. `mac_address_ui_output_` reads from the base provisioner.

### Drive-by bug fixes

Two latent bugs were uncovered by CodeRabbit while reviewing the refactor. Both were present in `main` and are orthogonal to the refactor, but are fixed here because the refactor is already touching the affected code heavily:

1. **`WiFi.config()` argument order** in `wifi_provisioner.cpp::start_client_autoconnect()`. Arduino-ESP32's signature is `(local_ip, gateway, subnet, dns1, dns2)`, but the pre-refactor code passed `(ip, dns, gateway, netmask)` — silently setting `gateway=dns`, `subnet=gateway`, `dns1=netmask`. **Every static-IP WiFi STA config saved in SensESP was broken as a result.** Documented in the migration guide.
2. **BSSID hex formatting** in `WiFiNetworkInfo::as_json()`. The code built MAC-address strings with `String(byte, HEX)` which produces `"A"` for `0x0A` instead of `"0A"`. Scan results with low hex bytes printed malformed MACs. Replaced with a `snprintf("%02X:…")` buffer.

Happy to split either into its own PR if reviewers prefer.

## Commit 2 — ESP32-P4 Ethernet provisioner + example + docs

### `EthernetProvisioner` (ESP32-P4 only)

`src/sensesp/net/ethernet_provisioner.{h,cpp}` — concrete `NetworkProvisioner` subclass that calls Arduino-ESP32's `ETH.begin()` with an external RMII PHY, runs DHCP, and exposes the resulting IPv4 / MAC / link state through the transport-agnostic base class. It does NOT own a state producer — the unified `NetworkStateProducer` in `SensESPApp` picks up `ARDUINO_EVENT_ETH_*` events from the same `Network.onEvent` bus it already listens to for WiFi.

The entire class is guarded behind `#ifdef CONFIG_IDF_TARGET_ESP32P4`. On any other target the header expands to nothing, so a user sketch that tries to instantiate `EthernetConfig` on a classic ESP32 gets a clean compile error at the use site (`'EthernetConfig' was not declared in this scope`) rather than a silent runtime failure. The guard can be widened when other ESP32 variants grow a usable Arduino-ESP32 `ETH.h` implementation.

Ships a single hardware factory `EthernetConfig::waveshare_esp32p4_poe()` for the Waveshare [ESP32-P4-WIFI6-POE-ETH](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-POE-ETH) dev board (IP101GRI PHY at addr 1, MDC=31, MDIO=52, reset=51, external 25 MHz crystal frequency-doubled into GPIO50).

### `SensESPAppBuilder::set_ethernet()`

Templated convenience wrapper that installs the ethernet factory into `SensESPApp` via the existing `set_network_provisioner_factory()` hook and implicitly calls `disable_wifi()`. The template is parameterised over the config struct so `sensesp_app_builder.h` does not need to include any ethernet headers — users who actually call `set_ethernet()` include `ethernet_provisioner.h` in their own translation unit. This keeps the builder header target-neutral.

### `examples/p4_ethernet/`

Downstream PlatformIO project that builds a full SensESP app on ethernet. `platformio.ini` pins pioarduino release `55.03.37` (Arduino-ESP32 3.3.7, ESP-IDF v5.5.2) and targets the `esp32-p4` board variant with a 16 MB flash override for the Waveshare board's larger SPI flash. Consumes SensESP from the parent directory via `symlink://../..`. Ships a `README.md` documenting the hardware, build steps, expected serial output, and what the example proves about the refactor.

### Documentation

- **`docs/pages/features/index.md`** — new "Network transports" section explaining the transport-agnostic model, showing WiFi and Ethernet examples side by side, and describing how to write a custom `NetworkProvisioner` subclass.
- **`docs/pages/migration/index.md`** — new "Transport-agnostic networking" section with the compatibility table (`Networking`→`WiFiProvisioner`, `WiFiState`→`NetworkState`, etc.), a "switch to the new names" snippet for new code, and a prominent warning about the static-IP bug fix so existing users know their saved configs may start working differently after the upgrade.

## CodeRabbit pass

`cr review --plain --type uncommitted` was run iteratively on both commits. **Accepted** findings:

- null-check on `SensESPApp::get()` in `IPAddrDev::update()` (can be called before `setup()` has finished wiring the provisioner on a very fresh boot)
- null-check on `bssid` pointer in `WiFiNetworkInfo` constructor
- BSSID hex zero-padding fix (drive-by, above)
- `WiFi.config()` argument order fix (drive-by, above)
- null-check on factory return value in `SensESPApp::setup()` (falls back to a default `WiFiProvisioner` if a user-supplied factory returns nullptr)
- removed unused `bool ap_mode;` declaration inherited from `networking.cpp`
- clarified CH340 device path in `examples/p4_ethernet/README.md` (mentions both `/dev/ttyACM0` and `/dev/ttyUSB0`)

**Declined** (out of scope — pre-existing issues that should get their own PRs if they prove to be real problems in practice):

- a recommendation to `delay(300)` after `WiFi.disconnect()` in `start_wifi_scan()`
- a note about static locals in the `reconnect_cb` lambda in `start_client_autoconnect()`

Second pass on the final diff: zero findings.

## Tested

- **`pio run -e pioarduino_esp32`** on the library top level — compiles cleanly; only the expected `setup()` / `loop()` linker undefs remain (library-only build)
- **`pio run -e pioarduino_esp32c3`** — compiles cleanly (same status)
- **`examples/p4_ethernet`** builds cleanly with pioarduino 55.03.37 and produces a 1.58 MB firmware image (80 % of the `min_spiffs.csv` 1.9 MB app slot)
- Flashed to a **Waveshare ESP32-P4-WIFI6-POE-ETH** board (MAC `80:F1:B2:D2:CC:6E`, chip rev v1.3, 16 MB flash, 32 MB PSRAM):
  - Obtained DHCP lease `192.168.99.13` from a Linux host running `nmcli connection add type ethernet ... ipv4.method shared ipv4.addresses 192.168.99.1/24`
  - SensESP HTTP UI reachable at `http://192.168.99.13/`, `/api/info` returns the full status JSON
  - Status page shows empty `SSID` / `WiFi signal strength=0` (correct — WiFi inactive) and `MAC Address` populated from `ETH.macAddress()` (correct)
  - Configured Signal K server via REST (`PUT /api/config/System/Signal%20K%20Settings` with address `192.168.99.1` port `3000`), restarted, verified `SK connection status = Connected` and `SK Delta TX count` ticking up
  - signalk-server 2.24 on the Linux host receives the `uptime` / `freeMemory` / `ipAddress` deltas under `sensorDevice.sensesp-p4-eth` — `ipAddress` correctly reports `192.168.99.13`, proving `IPAddrDev::update()` reads through the refactored `NetworkProvisioner::local_ip()`

Classic WiFi runtime testing on a real ESP32/S3/C3 board was not performed in this cycle because the only hardware on hand is the P4, which has no native WiFi. The refactor preserves the WiFi code path bit-for-bit, so this should be a no-op for existing WiFi users — but a sanity-check from someone with classic hardware would be welcome.

Closes #849
