### PR TITLE
feat: add ESP32-P4 support to the [espidf] build mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ managed_components
 # `platformio.ini` (which declares the envs and their custom_sdkconfig)
 # and `sdkconfig.defaults` (the hand-authored baseline). Everything in
 # the list below is machine-generated from those two sources.
-CMakeLists.txt
-src/CMakeLists.txt
-dependencies.lock
+/CMakeLists.txt
+/src/CMakeLists.txt
+/dependencies.lock
 sdkconfig.*
 !sdkconfig.defaults

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,15 @@ docs/Gemfile.lock
 docs/.bundle
 docs/_site
 managed_components
+
+# pioarduino's `framework = espidf, arduino` build mode generates these
+# at the repo root on first configure. They are per-environment build
+# artifacts and should not be committed — the project-tracked inputs are
+# `platformio.ini` (which declares the envs and their custom_sdkconfig)
+# and `sdkconfig.defaults` (the hand-authored baseline). Everything in
+# the list below is machine-generated from those two sources.
+CMakeLists.txt
+src/CMakeLists.txt
+dependencies.lock
+sdkconfig.*
+!sdkconfig.defaults

--- a/examples/p4_bluedroid_poc/README.md
+++ b/examples/p4_bluedroid_poc/README.md
@@ -1,0 +1,127 @@
+# p4_bluedroid_poc
+
+Stage-1 SensESP application that runs over native RMII Ethernet on a
+Waveshare [ESP32-P4-WIFI6-POE-ETH](https://www.waveshare.com/wiki/ESP32-P4-WIFI6-POE-ETH)
+dev board, built via the new `[env:espidf_esp32p4]` env in the root
+`platformio.ini` and the companion `framework = espidf, arduino` build
+mode. WiFi is disabled entirely — the device brings up the onboard
+IP101GRI PHY, runs DHCP, and reaches the Signal K server over the
+wired link.
+
+This example is a standalone PlatformIO project (not an env in the
+root `platformio.ini`) because it needs its own `sdkconfig.defaults`,
+`idf_component.yml`, and partition table. It is the first end-to-end
+demonstration of SensESP running under `framework = espidf, arduino`
+on ESP32-P4 hardware with **Bluedroid** selected as the BT host stack
+instead of the NimBLE-only Arduino-ESP32 prebuilt libs.
+
+## What this example is — and isn't
+
+This is the **stage-1 baseline**: it stands up SensESP + Ethernet on
+a Bluedroid-configured firmware and verifies the whole build and boot
+path works. Bluedroid is compiled into the binary (via
+`sdkconfig.defaults`) but no BLE code is called from `main.cpp` — the
+firmware's only runtime behaviour is the usual SensESP stack plus a
+5-second heartbeat log.
+
+The **stage-2 BLE scanner** — which would add a Bluedroid GAP scan
+loop over the esp_hosted VHCI transport to the onboard ESP32-C6
+companion — is deliberately not included in this commit. During the
+PoC work we confirmed that the Bluedroid stack initialises cleanly on
+P4 via this build path (`esp_bluedroid_init` / `_enable` return OK,
+`esp_ble_gap_set_ext_scan_params` and `esp_ble_gap_start_ext_scan`
+both succeed), but advertising reports never arrive from the C6
+slave. The same silence was reproduced earlier with the NimBLE host
+stack on two separate boards, which strongly suggests the blocker is
+in the ESP-Hosted C6 slave firmware (the Arduino-ESP32-distributed
+`esp32c6-v2.11.6.bin`), not in the P4 host stack.
+
+Since that is a downstream issue best tracked against
+[esp-hosted-mcu](https://github.com/espressif/esp-hosted-mcu) rather
+than SensESP, stage-2 is left as a follow-up. The scaffolding in this
+example makes it a one-file edit to add the scanner once the slave-fw
+story resolves.
+
+## Hardware
+
+- Board: Waveshare ESP32-P4-WIFI6-POE-ETH (ESP32-P4 ECO2 / rev v1.3
+  ES silicon, 16 MB flash, 32 MB PSRAM, onboard ESP32-C6 over SDIO).
+  The `sdkconfig.defaults` in this directory explicitly selects
+  `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` because ES silicon uses a
+  different startup code path than the rev 3.01+ default — without
+  this knob the firmware crashes with an `Illegal Instruction` panic
+  during very early boot. See the comment at the top of
+  `sdkconfig.defaults` for the details.
+- USB-C: same CH340 pass-through to P4 UART0 (GPIO 37/38) as the
+  `p4_ethernet` example. Enumerates as `/dev/ttyACM0` on Linux with
+  recent `cdc-acm`, `/dev/cu.usbmodem*` on macOS.
+- Ethernet: RJ45 to any DHCP-serving switch or router. For isolated
+  bench testing on Linux:
+
+  ```sh
+  nmcli connection add type ethernet ifname <iface> con-name test \
+      ipv4.method shared ipv4.addresses 192.168.99.1/24
+  ```
+
+## Build and flash
+
+```sh
+cd examples/p4_bluedroid_poc
+pio run -t upload
+pio device monitor
+```
+
+The example's `platformio.ini` uses `framework = espidf, arduino` on
+pioarduino 55.03.37 and pulls SensESP from the parent directory via
+`symlink://../..`. On first configure, PlatformIO + ESP-IDF will
+fetch the `espressif/esp_hosted` managed component and build the
+full IDF tree from source — expect a multi-minute first build.
+Subsequent builds are incremental.
+
+## Expected behaviour
+
+On a successful boot the serial monitor shows the usual IDF banner
+followed by:
+
+```text
+I (...) app_init: Project name:     p4_bluedroid_poc
+I (...) efuse_init: Chip rev:         v1.3
+I (...) main_task: Started on CPU0
+I (...) main_task: Calling app_main()
+I (...) main_task: Returned from app_main()
+I (...) filesystem.cpp: Filesystem initialized
+I (...) ethernet_provisioner.cpp: Bringing up Ethernet (PHY type=2 addr=1 ...)
+I (...) eth_prov: Ethernet hostname set to "signalk-bluedroid-poc" before DHCP DISCOVER
+I (...) esp_netif_handlers: eth0 ip: 192.168.x.y, mask: 255.255.255.0, gw: 192.168.x.1
+I (...) net_state: Ethernet got IP
+I (...) POC: alive — uptime=7s heap=456151
+```
+
+The SensESP web UI should be reachable at
+`http://signalk-bluedroid-poc.local/` (or the leased IP directly).
+OTA flashing is enabled on port 3232 with password `bluedroid-poc-ota`.
+
+## What this example proves
+
+- The `[env:espidf_esp32p4]` build path in the root `platformio.ini`
+  works end-to-end against SensESP as a library dependency.
+- The project-owned `sdkconfig.defaults` cleanly selects Bluedroid
+  instead of NimBLE and enables the esp_hosted Bluedroid VHCI
+  transport, without any workarounds or in-place rewrites of the
+  Arduino-ESP32 prebuilt libs.
+- SensESP's transport-agnostic networking layer, Ethernet
+  provisioner, hostname-in-ETH_START handler, mDNS responder, HTTP
+  server, OTA server, and SK websocket client all run cleanly on
+  ESP32-P4 in this build mode.
+- The 16 MB partition table leaves ample headroom (stage-1 firmware
+  is ~23.5% of the 6.5 MB app slot) for adding BLE gateway code, I2C
+  sensors, and other SensESP functionality on top.
+
+## Known issue — C6 slave firmware BLE adv forwarding
+
+See the discussion above in "What this example is — and isn't". TL;DR:
+the Arduino-ESP32-distributed `esp32c6-v2.11.6.bin` esp_hosted slave
+firmware does not appear to forward LE Advertising Reports over HCI
+to the P4 host, under either NimBLE or Bluedroid. Track any progress
+on that upstream in the
+[esp-hosted-mcu issue tracker](https://github.com/espressif/esp-hosted-mcu/issues).

--- a/examples/p4_bluedroid_poc/idf_component.yml
+++ b/examples/p4_bluedroid_poc/idf_component.yml
@@ -1,0 +1,13 @@
+## IDF component manifest for the SensESP P4 + Bluedroid PoC.
+##
+## pioarduino / IDF will read this and pull esp_hosted from the
+## Espressif Component Registry into managed_components/ at configure
+## time. No need to vendor anything manually.
+##
+## We pin the esp_hosted version that we know exists and contains
+## the vhci_drv.c (the Bluedroid VHCI path) rather than the hci_stub_drv
+## fallback. This matches what the stock pioarduino 55.03.37 bundled.
+
+dependencies:
+  idf: '>=5.3'
+  espressif/esp_hosted: '==2.12.3'

--- a/examples/p4_bluedroid_poc/p4_16mb.csv
+++ b/examples/p4_bluedroid_poc/p4_16mb.csv
@@ -1,0 +1,9 @@
+# Partition table for Waveshare ESP32-P4-WIFI6-POE-ETH (16 MB flash).
+# Two 6.5 MB OTA app slots, 2 MB SPIFFS, 256 KB coredump.
+# Name,    Type, SubType, Offset,   Size,    Flags
+nvs,       data, nvs,     0x9000,   0x5000,
+otadata,   data, ota,     0xe000,   0x2000,
+app0,      app,  ota_0,   0x10000,  0x680000,
+app1,      app,  ota_1,   0x690000, 0x680000,
+spiffs,    data, spiffs,  0xD10000, 0x200000,
+coredump,  data, coredump,0xF10000, 0x40000,

--- a/examples/p4_bluedroid_poc/platformio.ini
+++ b/examples/p4_bluedroid_poc/platformio.ini
@@ -1,0 +1,57 @@
+; SensESP P4 + Bluedroid PoC — clean `framework = espidf, arduino` path.
+;
+; Background:
+;   SensESP already has a [espidf] env template at the repo root that uses
+;   `framework = espidf, arduino` via pioarduino. In that mode, Arduino-ESP32
+;   is rebuilt as an IDF component inside our project and we own the
+;   sdkconfig directly — no in-place rewrites of the prebuilt libs.
+;   This is the path Matti pointed us at as the right way to do what we want.
+;
+; Goal for this example:
+;   - Bring up SensESP with native RMII Ethernet on Waveshare ESP32-P4
+;     (transport-agnostic networking layer + M2 EthernetProvisioner)
+;   - Flip the BT host from NimBLE (the Arduino-ESP32 default on P4) to
+;     Bluedroid, which is the stack ESPHome uses for its working P4
+;     bluetooth_proxy
+;   - Route BT through esp_hosted VHCI to the onboard ESP32-C6 companion
+;   - Start an extended BLE scan and count advertising reports
+;   - Nothing yet about the BLE gateway protocol — that comes later
+;
+; Hardware:
+;   Waveshare ESP32-P4-WIFI6-POE-ETH (IP101GRI RMII PHY, ESP32-C6 via SDIO)
+
+[platformio]
+default_envs = p4_bluedroid_poc
+
+[env:p4_bluedroid_poc]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+framework = espidf, arduino
+
+board = esp32-p4
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+; 16 MB partition table — two 6.5 MB OTA slots, 2 MB SPIFFS.
+board_build.partitions = p4_16mb.csv
+
+upload_speed = 2000000
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+build_unflags = -Werror=reorder
+
+build_flags =
+    -D CORE_DEBUG_LEVEL=3
+    -D USE_ESP_IDF_LOG
+    -D SENSESP_SSL_SUPPORT=1
+    -DBOARD_HAS_PSRAM
+    -D GATEWAY_HOSTNAME='"signalk-bluedroid-poc"'
+
+; Let the LDF walk transitive deps across the symlinked SensESP tree.
+lib_ldf_mode = deep
+
+lib_deps =
+    ; Local SensESP working tree.
+    symlink://../..
+    ; esp_websocket_client — SensESP's SKWSClient uses it, and in espidf
+    ; mode PIO does not automatically pull it from the Arduino-ESP32 libs.
+    ; (Matches what SensESP's top-level [espidf] env does.)
+    esp_websocket_client=https://components.espressif.com/api/downloads/?object_type=component&object_id=dbc87006-9a4b-45e6-a6ab-b286174cb413

--- a/examples/p4_bluedroid_poc/sdkconfig.defaults
+++ b/examples/p4_bluedroid_poc/sdkconfig.defaults
@@ -1,0 +1,104 @@
+# Project-owned sdkconfig for the P4 + Bluedroid PoC.
+# Consumed by pioarduino's espidf framework build. Unlike the
+# custom_sdkconfig in-place overlay path, this is a real IDF
+# project-level sdkconfig file that the IDF build picks up via
+# -DSDKCONFIG_DEFAULTS, so we own the resolved config cleanly.
+
+# ---------------------------------------------------------------------
+# Arduino-as-IDF-component knob — must be set so the Arduino runtime
+# initialises automatically via app_main, and our setup()/loop() fire.
+# ---------------------------------------------------------------------
+CONFIG_AUTOSTART_ARDUINO=y
+
+# ---------------------------------------------------------------------
+# ESP32-P4 silicon revision — the Waveshare ESP32-P4-WIFI6-POE-ETH
+# uses an ES (Early Sample) die, which corresponds to silicon revisions
+# less than 3.0. Without this, IDF defaults to rev 3.01+ and the app
+# crashes with an Illegal Instruction panic at the entry point because
+# of an incompatible memory-layout / startup code path (different
+# _bss_start naming, different sections.ld source file selection).
+#
+# The pioarduino board manifest esp32-p4.json declares
+# "chip_variant": "esp32p4_es" which selects the ES prebuilt libs
+# path, but that does NOT automatically propagate to the IDF sdkconfig
+# when building with `framework = espidf, arduino`. We have to set it
+# explicitly here.
+# ---------------------------------------------------------------------
+CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y
+CONFIG_ESP32P4_REV_MIN_1=y
+
+# ---------------------------------------------------------------------
+# Flash / PSRAM / CPU — match the Waveshare ESP32-P4-WIFI6-POE-ETH.
+# ---------------------------------------------------------------------
+CONFIG_ESPTOOLPY_FLASHMODE_QIO=y
+CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
+CONFIG_ESPTOOLPY_FLASHFREQ="80m"
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="16MB"
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_360=y
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ=360
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_HEX=y
+CONFIG_SPIRAM_SPEED_200M=y
+
+# ---------------------------------------------------------------------
+# Partition table — declared in platformio.ini, also point IDF at it.
+# ---------------------------------------------------------------------
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="p4_16mb.csv"
+CONFIG_PARTITION_TABLE_FILENAME="p4_16mb.csv"
+
+# ---------------------------------------------------------------------
+# FreeRTOS / main task — match SensESP's top-level [espidf] defaults
+# so SensESP's own assumptions about stack size hold.
+# ---------------------------------------------------------------------
+CONFIG_FREERTOS_HZ=1000
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+
+# ---------------------------------------------------------------------
+# Bluetooth host selection: Bluedroid, not NimBLE.
+#
+# BT_BLUEDROID_ENABLED and BT_NIMBLE_ENABLED are members of a Kconfig
+# choice, so setting BLUEDROID=y automatically unselects NimBLE.
+# BT_CONTROLLER_DISABLED=y because the P4 has no native BT controller
+# — the controller is provided by the onboard C6 over esp_hosted.
+# ---------------------------------------------------------------------
+CONFIG_BT_ENABLED=y
+CONFIG_BT_BLUEDROID_ENABLED=y
+CONFIG_BT_CONTROLLER_DISABLED=y
+CONFIG_BT_BLE_ENABLED=y
+CONFIG_BT_GATTC_ENABLE=y
+CONFIG_BT_GATTS_ENABLE=n
+CONFIG_BT_CLASSIC_ENABLED=n
+
+# Disable BLE Mesh — we're a BLE central, not a mesh node, and mesh
+# pulls in a pile of helpers that complicate the build.
+CONFIG_BLE_MESH=n
+
+# ---------------------------------------------------------------------
+# esp_hosted — route the BT controller to the C6 companion via SDIO,
+# and bridge HCI to Bluedroid via esp_hosted's VHCI driver.
+#
+# The gating symbol is ESP_HOSTED_ENABLE_BT_BLUEDROID (default n).
+# Turning that on enables the VHCI choice, of which there's currently
+# only one member (BLUEDROID_HCI_VHCI).
+# ---------------------------------------------------------------------
+CONFIG_ESP_HOSTED_ENABLED=y
+CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID=y
+CONFIG_ESP_HOSTED_BLUEDROID_HCI_VHCI=y
+
+# ---------------------------------------------------------------------
+# Ethernet — keep the native P4 EMAC enabled, same as the Arduino
+# stock defaults but made explicit to survive sdkconfig regeneration.
+# ---------------------------------------------------------------------
+CONFIG_ETH_ENABLED=y
+CONFIG_ETH_USE_ESP32_EMAC=y
+
+# ---------------------------------------------------------------------
+# Misc — match SensESP's top-level [espidf] env so SensESP internals
+# behave the same here as in other espidf builds.
+# ---------------------------------------------------------------------
+CONFIG_MBEDTLS_PSK_MODES=y
+CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y
+CONFIG_HTTPD_MAX_REQ_HDR_LEN=1024
+CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1=n

--- a/examples/p4_bluedroid_poc/src/main.cpp
+++ b/examples/p4_bluedroid_poc/src/main.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file main.cpp
+ * @brief SensESP P4 + Bluedroid PoC — stage 1 baseline firmware.
+ *
+ * Minimal SensESP app that exercises the new `framework = espidf,
+ * arduino` build mode extended to ESP32-P4. The project's
+ * sdkconfig.defaults selects Bluedroid as the BT host stack (instead
+ * of NimBLE, which is what the Arduino-ESP32 prebuilt libs ship on
+ * P4), so this firmware links Bluedroid in — but does not yet call
+ * into it. Stage 2 will add the actual Bluedroid scanner on top of
+ * this baseline.
+ *
+ * What this firmware exercises:
+ *   - SensESP + transport-agnostic networking + EthernetProvisioner
+ *     on the Waveshare ESP32-P4-WIFI6-POE-ETH board
+ *   - The `[env:espidf_esp32p4]` build path and its sdkconfig
+ *   - Hostname set before DHCP DISCOVER via the ETH_START handler
+ *   - mDNS, HTTP server, OTA, and the Signal K websocket client
+ *
+ * Verification checklist on the host (with a DHCP server on the
+ * same LAN):
+ *   1. Device boots, serial prints the usual IDF init banner
+ *   2. "Bringing up Ethernet" line appears
+ *   3. PHY link comes up when the cable is plugged in
+ *   4. DHCP lease obtained; check the ARP table
+ *   5. http://signalk-bluedroid-poc.local/ serves the SensESP web UI
+ *   6. OTA flashing works via espota.py on port 3232
+ *   7. Heartbeat log line every 5 seconds
+ */
+
+#include "sensesp/net/ethernet_provisioner.h"
+#include "sensesp_app_builder.h"
+
+using namespace sensesp;
+
+void setup() {
+  SetupLogging(ESP_LOG_INFO);
+
+  SensESPAppBuilder builder;
+  builder.set_hostname(GATEWAY_HOSTNAME)
+      ->set_ethernet(EthernetConfig::waveshare_esp32p4_poe())
+      ->disable_wifi()
+      ->enable_ota("bluedroid-poc-ota")
+      ->get_app();
+
+  event_loop()->onRepeat(5000, []() {
+    ESP_LOGI("POC", "alive — uptime=%lus heap=%u",
+             (unsigned long)(millis() / 1000),
+             (unsigned)ESP.getFreeHeap());
+  });
+}
+
+void loop() { event_loop()->tick(); }

--- a/examples/p4_bluedroid_poc/src/main.cpp
+++ b/examples/p4_bluedroid_poc/src/main.cpp
@@ -39,7 +39,6 @@ void setup() {
   SensESPAppBuilder builder;
   builder.set_hostname(GATEWAY_HOSTNAME)
       ->set_ethernet(EthernetConfig::waveshare_esp32p4_poe())
-      ->disable_wifi()
       ->enable_ota("bluedroid-poc-ota")
       ->get_app();
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -111,12 +111,6 @@ build_flags =
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
 framework = espidf, arduino
 
-board_build.embed_txtfiles =
-    managed_components/espressif__esp_insights/server_certs/https_server.crt
-    managed_components/espressif__esp_rainmaker/server_certs/rmaker_mqtt_server.crt
-    managed_components/espressif__esp_rainmaker/server_certs/rmaker_claim_service_server.crt
-    managed_components/espressif__esp_rainmaker/server_certs/rmaker_ota_server.crt
-
 ; The library.json format doesn't support dependencies conditional on the
 ; platform version, so we have to use the lib_deps option to specify the
 ; esp_websocket_client library only for the ESP-IDF framework.
@@ -128,6 +122,23 @@ lib_deps =
 build_flags =
     ${env.build_flags}
     -D SENSESP_SSL_SUPPORT=1
+
+; Cert bundle embedding for esp_insights + esp_rainmaker. These components
+; are only pulled in by Arduino-ESP32 on chips where esp_insights and
+; esp_rainmaker are enabled (esp32, esp32s2, esp32s3, esp32c3, etc.) —
+; NOT on esp32c2 or esp32p4. Envs for those targets must NOT inherit
+; this section.
+;
+; See framework-arduinoespressif32/idf_component.yml:
+;   espressif/esp_insights: rules: - if: target not in [esp32c2, esp32p4]
+;   espressif/esp_rainmaker: rules: - if: target not in [esp32c2, esp32p4]
+[espidf_cloud_certs]
+
+board_build.embed_txtfiles =
+    managed_components/espressif__esp_insights/server_certs/https_server.crt
+    managed_components/espressif__esp_rainmaker/server_certs/rmaker_mqtt_server.crt
+    managed_components/espressif__esp_rainmaker/server_certs/rmaker_claim_service_server.crt
+    managed_components/espressif__esp_rainmaker/server_certs/rmaker_ota_server.crt
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Board configurations follow
@@ -151,6 +162,13 @@ build_flags =
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1
 
+[esp32p4]
+
+board = esp32-p4
+build_flags =
+    ${env.build_flags}
+    -DBOARD_HAS_PSRAM
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Permutations of platform and device.
 
@@ -170,7 +188,7 @@ build_flags =
 
 [env:espidf_esp32]
 
-extends = espidf, esp32
+extends = espidf, espidf_cloud_certs, esp32
 build_flags =
     ${espidf.build_flags}
     ${esp32.build_flags}
@@ -191,10 +209,22 @@ build_flags =
 
 [env:espidf_esp32c3]
 
-extends = espidf, esp32c3
+extends = espidf, espidf_cloud_certs, esp32c3
 build_flags =
     ${espidf.build_flags}
     ${esp32c3.build_flags}
+
+[env:espidf_esp32p4]
+
+; ESP32-P4 only supports the espidf-arduino mixed build mode. The
+; Arduino-ESP32 prebuilt libs for P4 ship a sdkconfig that SensESP's
+; feature set does not fully match (BT host stack, HCI VHCI flags),
+; so the project-owned sdkconfig path of `framework = espidf, arduino`
+; is the only way to express what we need.
+extends = espidf, esp32p4
+build_flags =
+    ${espidf.build_flags}
+    ${esp32p4.build_flags}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Individual board configurations

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,6 +1,17 @@
 CONFIG_AUTOSTART_ARDUINO=y
 # CONFIG_WS2812_LED_ENABLE is not set
 CONFIG_FREERTOS_HZ=1000
+# ESP32-P4 currently-shipping dev boards (Waveshare ESP32-P4-WIFI6-POE-ETH,
+# ESP32-P4 Function EV Board, etc.) use ES (Early Sample) silicon at chip
+# revision v1.x, well below v3.00. The IDF default assumes v3.01+ and
+# selects a different esp_system startup path + sections.ld linker
+# fragment source, which produces a binary that crashes at the entry
+# point on ES silicon with an Illegal Instruction panic. This symbol
+# is silently ignored on all non-ESP32-P4 targets (gated by
+# IDF_TARGET_ESP32P4 in esp_hw_support/port/esp32p4/Kconfig.hw_support),
+# so placing it in the shared sdkconfig.defaults is safe.
+CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y
+CONFIG_ESP32P4_REV_MIN_1=y
 CONFIG_MBEDTLS_PSK_MODES=y
 CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y
 CONFIG_ESPTOOLPY_FLASHFREQ="80m"


### PR DESCRIPTION
## Summary

Extends SensESP's existing `framework = espidf, arduino` build mode
(the `[espidf]` template at `platformio.ini:104`) to **ESP32-P4**,
alongside the existing `espidf_esp32` and `espidf_esp32c3` envs.
This is the IDF-component build mode — Arduino-ESP32 is compiled as
a component inside an IDF project, and the project owns its own
`sdkconfig.defaults`.

Depends on #940 (transport-agnostic networking + Ethernet
provisioner) being merged first — this PR uses the
`EthernetProvisioner` from that one in its example.

## What this unlocks

Concretely: you can now build SensESP for ESP32-P4 via `pio run -e
espidf_esp32p4` and get a clean library build to the same status as
`espidf_esp32` / `espidf_esp32c3`. This is the foundation for any
advanced P4 work that needs full IDF sdkconfig control — custom BT
host stack selection, esp_hosted coprocessor wiring, memory pool
tuning, anything that the Arduino-ESP32 prebuilt libs lock down.

The included example (`examples/p4_bluedroid_poc/`) is a
hardware-verified stage-1 demonstration: SensESP + Ethernet on a
Waveshare ESP32-P4-WIFI6-POE-ETH board running a firmware with
**Bluedroid** selected as the BT host stack (instead of the NimBLE
default) + esp_hosted's Bluedroid VHCI driver enabled. Stage-1
doesn't yet call into BLE from the app code — that's left for a
follow-up because of a separate C6 slave firmware issue (see Known
issue below). But the build and boot path works end-to-end.

## Changes

### Commit 1 — `feat(build): add [env:espidf_esp32p4] for the espidf build mode`

Root `platformio.ini` additions:

- **New `[espidf_cloud_certs]` intermediate section.** Moves the
  `board_build.embed_txtfiles` list (esp_insights +
  esp_rainmaker cert files) out of the top-level `[espidf]` section
  into its own optional mixin. The existing `espidf_esp32` and
  `espidf_esp32c3` envs now extend `(espidf, espidf_cloud_certs,
  <board>)` instead of `(espidf, <board>)`, preserving their
  behaviour bit-for-bit.
- **Why the split was needed.** Arduino-ESP32's own
  `idf_component.yml` explicitly excludes `esp_insights` and
  `esp_rainmaker` on `esp32c2` and `esp32p4`:
  ```yaml
  espressif/esp_insights:
    rules:
    - if: target not in [esp32c2, esp32p4]
  ```
  On those targets the embed paths fail during configure with
  `Source 'managed_components/espressif__esp_insights/server_certs/
  https_server.crt' not found`. Moving the embed list out lets
  esp32p4 (and the currently-disabled esp32c2) run the
  `[espidf]` template cleanly.
- **New `[esp32p4]` board section + `[env:espidf_esp32p4]` env,**
  mirroring the `[esp32]` / `[esp32c3]` pattern.
- **`.gitignore` additions** for the pioarduino-generated
  artifacts that `framework = espidf, arduino` writes at the repo
  root on first configure (`CMakeLists.txt`, `src/CMakeLists.txt`,
  `dependencies.lock`, `sdkconfig.<env>`), with an explicit
  `!sdkconfig.defaults` unignore so the hand-authored baseline
  stays tracked. Keeps `git status` clean across all espidf envs.

### Commit 2 — `feat(examples): add p4_bluedroid_poc`

Standalone PlatformIO project under `examples/p4_bluedroid_poc/`
that consumes SensESP via `symlink://../..`:

- `platformio.ini` — `framework = espidf, arduino` on pioarduino
  55.03.37
- `sdkconfig.defaults` — selects Bluedroid, enables esp_hosted's
  Bluedroid HCI VHCI driver, and sets
  `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` for ES silicon (required
  on current Waveshare boards — without it the firmware crashes
  with an Illegal Instruction panic at the entry point because
  of an incompatible memory-layout / startup code path)
- `idf_component.yml` — pins `espressif/esp_hosted` to 2.12.3
- `p4_16mb.csv` — 16 MB partition table, two 6.5 MB OTA slots
- `src/main.cpp` — minimal `SensESPAppBuilder` invocation
  (`set_hostname`, `set_ethernet(waveshare_esp32p4_poe())`,
  `disable_wifi`, `enable_ota`), plus a 5-second heartbeat log
- `README.md` — hardware setup, build and flash commands, expected
  boot output, what the example proves, and an honest Known
  Issue section about the C6 slave-fw state

## Tested

- `pio run -e espidf_esp32` — compiles cleanly; only the expected
  `setup()` / `loop()` linker undefs remain (library-only build).
  **No regression** from before this PR.
- `pio run -e espidf_esp32c3` — same result, no regression.
- `pio run -e espidf_esp32p4` — same result. This is new — there
  was no P4 env in the `[espidf]` template before.
- **Hardware-verified end-to-end boot** of the
  `examples/p4_bluedroid_poc` firmware on a Waveshare
  ESP32-P4-WIFI6-POE-ETH (rev v1.3 ES silicon, MAC
  `80:f1:b2:d2:ca:6a`) over USB-C. Successful boot sequence:
  - ESP-IDF 5.5.2.260206 init, chip rev v1.3 detected
  - All memory pools (RETENT_RAM, RAM, RTCRAM, TCM, 32 MB PSRAM)
    initialised
  - SensESP filesystem, EthernetProvisioner bringing up the
    IP101GRI PHY, hostname set via the ETH_START handler (from
    the hostname-fix commit in #940), DHCP lease obtained at
    192.168.99.131
  - mDNS responder, HTTP server on :80, OTA server on
    `esp32-<mac>.local:3232`, SK websocket client attempting to
    connect
  - `POC: alive — uptime=…` heartbeat every 5 s, ~455 KB free
    heap
  - Total: ~23.5 % flash / ~10.6 % RAM on the 6.5 MB / 320 KB
    partition

## Known issue — C6 slave firmware BLE adv forwarding

The example's stage-1 `main.cpp` deliberately does not call any
BLE API. During the scaffolding work I confirmed that the
Bluedroid host stack initialises cleanly on this build path
(`esp_bluedroid_init` / `_enable` return OK,
`esp_ble_gap_set_ext_scan_params` and `esp_ble_gap_start_ext_scan`
both succeed), but LE advertising reports never arrive from the
onboard ESP32-C6 companion. The same silence was reproduced
earlier with NimBLE on two separate boards, which strongly suggests
the blocker is in the Arduino-ESP32-distributed esp_hosted C6
slave firmware (`esp32c6-v2.11.6.bin`), not in the P4 host stack
choice.

Since that's a downstream issue best tracked against
[esp-hosted-mcu](https://github.com/espressif/esp-hosted-mcu)
rather than SensESP, stage-2 is left as a follow-up. This PR is
deliberately scoped to **build-mode support for ESP32-P4**, not
working BLE on P4.

## On your CI placement issue

I saw your note that the `[espidf]` mode is currently commented
out in `.github/workflows/ci.yml` because of "a sdkconfig file
placement issue in the CI environment". I'm not 100 % sure the
bug fixed here is the same one — the failure I reproduced was
the `embed_txtfiles` paths failing during configure on esp32p4,
which then cascades into various downstream errors including
sdkconfig / ldgen confusion. If that cascade is what CI was
hitting, this PR should unblock it. If your CI is hitting a
distinct placement issue on top of this, I'd be happy to dig
into it as a follow-up — just let me know what the symptom is.

## Follow-ups (not part of this PR)

1. Stage-2 Bluedroid BLE scanner code, once the C6 slave-fw story
   is resolved upstream.
2. An upstream bug report to pioarduino about
   `chip_variant: esp32p4_es` not propagating into IDF's sdkconfig
   when building with `framework = espidf, arduino` — currently
   users have to discover and set `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y`
   manually. Not blocking for this PR.