### PR TITLE
fix(ci): trigger CI on pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: SensESP CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Add `pull_request` to the CI workflow trigger so PRs from forks get CI checks

Previously the workflow only triggered on `push`, which meant PRs from external forks never had checks run against them.

## Test plan
- [ ] Verify this PR itself triggers CI (it will, since it's a push to the upstream repo)
- [ ] After merging, verify that fork PRs (e.g. #940) trigger CI on rebase/push

🤖 Generated with [Claude Code](https://claude.com/claude-code)