### PR TITLE
fix(signalk): clear stale polling href on 404 response

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -977,11 +977,14 @@ void SKWSClient::poll_access_request(const String server_address,
       }
     }
   } else {
-    if (http_code == 500) {
-      // this is probably the server barfing due to
-      // us polling a non-existing request. Just
-      // delete the polling href.
-      ESP_LOGD(__FILENAME__, "Got 500, probably a non-existing request.");
+    if (http_code == 404 || http_code == 500) {
+      // Server doesn't recognize this request (stale href after
+      // server restart, different server, or security disabled).
+      // Clear the polling href so the next connect cycle starts
+      // a fresh access-request flow.
+      ESP_LOGD(__FILENAME__,
+               "Got %d polling access request — clearing stale href.",
+               http_code);
       polling_href_ = "";
       save();
       set_connection_state(SKWSConnectionState::kSKWSDisconnected);


### PR DESCRIPTION
## Summary

- When polling a persisted access-request href, a 404 means the server doesn't recognize the request (server restarted, device moved to a different server, or security disabled)
- Previously the client retried the stale href indefinitely, preventing connection
- Now 404 is treated the same as 500: clear `polling_href_` and start a fresh access-request flow on the next connect cycle

## Test plan

- [x] Device with stale `polling_href` pointing to a server with security disabled reconnects after one retry cycle instead of looping forever
- [x] Device moved to a different server recovers without manual NVS clear