### PR TITLE
Remove esp_websocket_client from library.json PlatformIO manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -44,10 +44,6 @@
       "owner": "bxparks",
       "name": "AceButton",
       "version": "^1.10.1"
-    },
-    {
-      "name": "esp_websocket_client",
-      "version": "https://components.espressif.com/api/downloads/?object_type=component&object_id=dbc87006-9a4b-45e6-a6ab-b286174cb413"
     }
   ],
   "version": "3.3.1-alpha",


### PR DESCRIPTION
## Summary
- Remove `esp_websocket_client` dependency from `library.json`

The `esp_websocket_client` is an Espressif component that PlatformIO downloads via URL in `lib_deps` (declared in `platformio.ini` for the pioarduino and espidf build environments). It was added to `library.json` during the transport-agnostic networking refactor (#940), but it can't be expressed there because PlatformIO's manifest validation limits version strings to 100 characters, and the component registry URL is 113 characters.

Downstream projects that use SensESP need to declare this dependency in their own `platformio.ini` `lib_deps` — the `library.json` entry wouldn't help them anyway since PlatformIO can't resolve the overlong URL from the manifest.

This had to be manually worked around during the 3.3.0 PlatformIO publish.

## Test plan
- [ ] CI passes
- [ ] `pio package pack` succeeds without manifest validation errors