### PR TITLE
Fix Clear Token button not clearing the auth token

### DIFF
--- a/frontend/src/pages/SignalK/SignalKSettingsPanel.tsx
+++ b/frontend/src/pages/SignalK/SignalKSettingsPanel.tsx
@@ -85,6 +85,7 @@ function SKConnectionSettings({
   setConfig,
   onSave,
 }: SKConnectionSettingsProps): JSX.Element {
+  const [saving, setSaving] = useState(false);
   const id = useId();
 
   const mdns = config.use_mdns === true;
@@ -156,12 +157,15 @@ function SKConnectionSettings({
             <button
               type="submit"
               className="btn btn-primary"
-              onClick={(e) => {
+              disabled={saving}
+              onClick={async (e) => {
                 e.preventDefault();
-                void onSave();
+                setSaving(true);
+                await onSave();
+                setSaving(false);
               }}
             >
-              Save
+              {saving ? "Saving..." : "Save"}
             </button>
           </form>
         </div>
@@ -181,10 +185,14 @@ function SKAuthToken({
   setConfig,
   onSave,
 }: SKAuthTokenProps): JSX.Element {
-  function handleClearToken(): void {
+  const [clearing, setClearing] = useState(false);
+
+  async function handleClearToken(): Promise<void> {
     const newConfig = { ...config, token: "" };
     setConfig(newConfig);
-    void onSave(newConfig);
+    setClearing(true);
+    await onSave(newConfig);
+    setClearing(false);
   }
 
   return (
@@ -193,8 +201,12 @@ function SKAuthToken({
         Click the button to clear the Signal K authentication token. This causes
         the device to request re-authorization from the Signal K server.
       </p>
-      <button className="btn btn-primary" onClick={handleClearToken}>
-        Clear Token
+      <button
+        className="btn btn-primary"
+        disabled={clearing}
+        onClick={handleClearToken}
+      >
+        {clearing ? "Clearing..." : "Clear Token"}
       </button>
     </Card>
   );
@@ -213,6 +225,7 @@ function SKSSLSettings({
   onSave,
   onConfigUpdate,
 }: SKSSLSettingsProps): JSX.Element {
+  const [saving, setSaving] = useState(false);
   const [resetting, setResetting] = useState(false);
   const id = useId();
 
@@ -319,12 +332,15 @@ function SKSSLSettings({
           <button
             type="submit"
             className="btn btn-primary"
-            onClick={(e) => {
+            disabled={saving}
+            onClick={async (e) => {
               e.preventDefault();
-              void onSave();
+              setSaving(true);
+              await onSave();
+              setSaving(false);
             }}
           >
-            Save
+            {saving ? "Saving..." : "Save"}
           </button>
         </form>
       </div>

--- a/frontend/src/pages/SignalK/SignalKSettingsPanel.tsx
+++ b/frontend/src/pages/SignalK/SignalKSettingsPanel.tsx
@@ -12,11 +12,16 @@ export function SignalKSettingsPanel(): JSX.Element {
   const [config, setConfig] = useState({});
   const [errorText, setErrorText] = useState("");
 
-  async function handleSave(): Promise<void> {
+  async function handleSave(configOverride?: JsonObject): Promise<void> {
     try {
-      await saveConfigData(CONFIG_PATH, JSON.stringify(config), (e: Error) => {
-        setErrorText(e.message);
-      });
+      const configToSave = configOverride ?? config;
+      await saveConfigData(
+        CONFIG_PATH,
+        JSON.stringify(configToSave),
+        (e: Error) => {
+          setErrorText(e.message);
+        },
+      );
     } catch (e) {
       setErrorText(e.message);
     }
@@ -51,18 +56,18 @@ export function SignalKSettingsPanel(): JSX.Element {
         <SKConnectionSettings
           config={config}
           setConfig={setConfig}
-          setRequestSave={handleSave}
+          onSave={handleSave}
         />
         <SKSSLSettings
           config={config}
           setConfig={setConfig}
-          setRequestSave={handleSave}
+          onSave={handleSave}
           onConfigUpdate={updateConfig}
         />
         <SKAuthToken
           config={config}
           setConfig={setConfig}
-          setRequestSave={handleSave}
+          onSave={handleSave}
         />
       </div>
     </>
@@ -72,13 +77,13 @@ export function SignalKSettingsPanel(): JSX.Element {
 interface SKConnectionSettingsProps {
   config: JsonObject;
   setConfig: (cfg: JsonObject) => void;
-  setRequestSave: (b: boolean) => void;
+  onSave: (configOverride?: JsonObject) => Promise<void>;
 }
 
 function SKConnectionSettings({
   config,
   setConfig,
-  setRequestSave,
+  onSave,
 }: SKConnectionSettingsProps): JSX.Element {
   const id = useId();
 
@@ -153,7 +158,7 @@ function SKConnectionSettings({
               className="btn btn-primary"
               onClick={(e) => {
                 e.preventDefault();
-                setRequestSave(true);
+                void onSave();
               }}
             >
               Save
@@ -168,17 +173,18 @@ function SKConnectionSettings({
 interface SKAuthTokenProps {
   config: JsonObject;
   setConfig: (cfg: JsonObject) => void;
-  setRequestSave: (b: boolean) => void;
+  onSave: (configOverride?: JsonObject) => Promise<void>;
 }
 
 function SKAuthToken({
   config,
   setConfig,
-  setRequestSave,
+  onSave,
 }: SKAuthTokenProps): JSX.Element {
   function handleClearToken(): void {
-    setConfig({ ...config, token: "" });
-    setRequestSave(true);
+    const newConfig = { ...config, token: "" };
+    setConfig(newConfig);
+    void onSave(newConfig);
   }
 
   return (
@@ -197,14 +203,14 @@ function SKAuthToken({
 interface SKSSLSettingsProps {
   config: JsonObject;
   setConfig: (cfg: JsonObject) => void;
-  setRequestSave: (b: boolean) => void;
+  onSave: (configOverride?: JsonObject) => Promise<void>;
   onConfigUpdate: () => Promise<void>;
 }
 
 function SKSSLSettings({
   config,
   setConfig,
-  setRequestSave,
+  onSave,
   onConfigUpdate,
 }: SKSSLSettingsProps): JSX.Element {
   const [resetting, setResetting] = useState(false);
@@ -315,7 +321,7 @@ function SKSSLSettings({
             className="btn btn-primary"
             onClick={(e) => {
               e.preventDefault();
-              setRequestSave(true);
+              void onSave();
             }}
           >
             Save


### PR DESCRIPTION
## Summary

- Fix the "Clear Token" button in the Signal K Settings panel which did nothing when clicked
- Root cause: Preact's `setConfig()` is asynchronous, so calling the save function immediately after setting state serialized the *old* config (with token still present)
- Pass the modified config directly to the save function, bypassing the async state timing issue
- Also clean up incorrect `setRequestSave: (b: boolean) => void` prop typing to `onSave: (configOverride?: JsonObject) => Promise<void>`

## Test plan

- [ ] Load the Signal K Settings page on a device with a stored auth token
- [ ] Click "Clear Token" and verify the PUT request body contains `token: ""`
- [ ] Verify the Connection Settings and SSL Settings "Save" buttons still work correctly
- [ ] Verify the device requests re-authorization from Signal K server after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)