### PR TITLE
fix(http): raise HTTPServer max_open_sockets to 13

### DIFF
--- a/src/sensesp/net/http_server.h
+++ b/src/sensesp/net/http_server.h
@@ -24,6 +24,19 @@ namespace sensesp {
 #define HTTP_DEFAULT_PORT 80
 #endif
 
+// Maximum simultaneous client sockets the HTTP server will accept.
+// The default esp_http_server value (7) is too low for modern browsers,
+// which open 6+ parallel connections to fetch JS/CSS bundles of the
+// embedded SPA — extras get TCP-RST and the web UI hangs half-loaded.
+//
+// Note: esp_http_server reserves 3 sockets internally, so the effective
+// client cap is HTTP_SERVER_MAX_OPEN_SOCKETS. Additionally,
+// `CONFIG_LWIP_MAX_SOCKETS` must be >= HTTP_SERVER_MAX_OPEN_SOCKETS + 3
+// or lwIP itself will refuse the extra sockets.
+#ifndef HTTP_SERVER_MAX_OPEN_SOCKETS
+#define HTTP_SERVER_MAX_OPEN_SOCKETS 13
+#endif
+
 #include <ctype.h>
 #include <stdlib.h>
 
@@ -66,6 +79,7 @@ class HTTPServer : public FileSystemSaveable {
     config_.server_port = port;
     config_.stack_size = HTTP_SERVER_STACK_SIZE;
     config_.max_uri_handlers = 20;
+    config_.max_open_sockets = HTTP_SERVER_MAX_OPEN_SOCKETS;
     config_.uri_match_fn = httpd_uri_match_wildcard;
     String auth_realm_ = "Login required for " + SensESPBaseApp::get_hostname();
     load();

--- a/src/sensesp/net/http_server.h
+++ b/src/sensesp/net/http_server.h
@@ -25,16 +25,19 @@ namespace sensesp {
 #endif
 
 // Maximum simultaneous client sockets the HTTP server will accept.
-// The default esp_http_server value (7) is too low for modern browsers,
-// which open 6+ parallel connections to fetch JS/CSS bundles of the
-// embedded SPA — extras get TCP-RST and the web UI hangs half-loaded.
 //
-// Note: esp_http_server reserves 3 sockets internally, so the effective
-// client cap is HTTP_SERVER_MAX_OPEN_SOCKETS. Additionally,
-// `CONFIG_LWIP_MAX_SOCKETS` must be >= HTTP_SERVER_MAX_OPEN_SOCKETS + 3
-// or lwIP itself will refuse the extra sockets.
+// Kept at the esp_http_server default (7, of which 3 are reserved internally).
+// The web UI stalls modern browsers suffered with this default were caused by
+// keep-alive socket starvation, not the cap itself, and are addressed by
+// enabling `lru_purge_enable` (see the HTTPServer constructor) rather than by
+// claiming more of the lwIP socket budget — which the Signal K WebSocket
+// client, mDNS, and SNTP also draw from.
+//
+// Raising this requires `CONFIG_LWIP_MAX_SOCKETS >= HTTP_SERVER_MAX_OPEN_SOCKETS
+// + 3`; the espidf framework defaults that to 10, so values above 7 also need
+// `CONFIG_LWIP_MAX_SOCKETS` raised in sdkconfig.defaults or httpd_start() fails.
 #ifndef HTTP_SERVER_MAX_OPEN_SOCKETS
-#define HTTP_SERVER_MAX_OPEN_SOCKETS 13
+#define HTTP_SERVER_MAX_OPEN_SOCKETS 7
 #endif
 
 #include <ctype.h>
@@ -80,6 +83,15 @@ class HTTPServer : public FileSystemSaveable {
     config_.stack_size = HTTP_SERVER_STACK_SIZE;
     config_.max_uri_handlers = 20;
     config_.max_open_sockets = HTTP_SERVER_MAX_OPEN_SOCKETS;
+    // The embedded SPA is served over HTTP/1.1 keep-alive, so a browser holds
+    // several connections open. Without LRU purge, once every socket slot is
+    // camped by an idle keep-alive connection the server defers (starves) any
+    // new connection — a late chunk, a retried fetch, a second tab — until one
+    // times out. On high-latency links (e.g. esp_hosted SDIO WiFi) that window
+    // is long enough to fail the SPA's parallel /api/* requests outright.
+    // Enabling LRU purge evicts the least-recently-used (idle) socket to admit
+    // the newcomer instead, which the browser simply reopens.
+    config_.lru_purge_enable = true;
     config_.uri_match_fn = httpd_uri_match_wildcard;
     String auth_realm_ = "Login required for " + SensESPBaseApp::get_hostname();
     load();


### PR DESCRIPTION
## Summary

`esp_http_server` defaults `config_.max_open_sockets = 7`, of which 3 are reserved internally by the IDF httpd implementation — leaving only **4 simultaneous client sockets**.

Modern browsers open 6+ parallel TCP connections when loading the embedded SensESP SPA (HTTP/1.1 module-federated JS/CSS chunks). The extras get TCP-RST, the React app's parallel `/api/*` fetches fail, and the UI is left stuck on its initial "device is restarting" state with broken CSS — even though the backend is healthy.

This raises the default to **13** (so 10 client sockets after the 3 reserved), exposed as an overridable macro `HTTP_SERVER_MAX_OPEN_SOCKETS` consistent with the existing `HTTP_SERVER_STACK_SIZE` and `HTTP_DEFAULT_PORT` pattern.

## Dependency note

The HTTPServer setting alone is not sufficient — `CONFIG_LWIP_MAX_SOCKETS` must be ≥ `HTTP_SERVER_MAX_OPEN_SOCKETS + 3` (default 10 is too low for max_open_sockets=13). A header comment documents this. Users keeping the IDF default of 10 will need to either lower `HTTP_SERVER_MAX_OPEN_SOCKETS` via build flag or raise `CONFIG_LWIP_MAX_SOCKETS` in their sdkconfig.

## Test plan

- Tested on an ESP32-P4 (Waveshare Touch-LCD-7B) running esp_hosted SDIO WiFi + a SensESP-based cockpit app with embedded SPA.
- Before the patch: web UI half-loaded with no CSS, stuck on "device is restarting", `/api/*` requests returned empty replies. `curl` parallel burst of 10 → 0 succeed.
- After the patch (with `CONFIG_LWIP_MAX_SOCKETS=16`): web UI loads fully, all tabs work, `/api/info`, `/api/routes`, `/api/config` all return 200. `curl` parallel burst of 10 → 6-10 succeed.