### PR TITLE
fix(ci): pin ReactESP to ~3.2.0 to unbreak arduino_esp32 build

### DIFF
--- a/library.json
+++ b/library.json
@@ -28,7 +28,7 @@
     {
       "owner": "mairas",
       "name": "ReactESP",
-      "version": "^3.1.0"
+      "version": "~3.2.0"
     },
     {
       "owner": "bblanchon",

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ upload_speed = 2000000
 monitor_speed = 115200
 
 lib_deps =
-    mairas/ReactESP @ ^3.2.0
+    mairas/ReactESP @ ~3.2.0
     bblanchon/ArduinoJson @ ^7.0.0
     pfeerick/elapsedMillis @ ^1.0.6
     bxparks/AceButton @ ^1.10.1


### PR DESCRIPTION
## Summary

ReactESP **3.3.0** (Apr 2026) broke the `arduino_esp32` CI matrix env. With the existing `mairas/ReactESP @ ^3.2.0` constraint, every fresh CI install now pulls 3.3.0 and fails to compile under the Arduino-Espressif toolchain. Pinning to `~3.2.0` restores the matrix.

## What 3.3.0 changed

Two upstream changes in `event_loop.h`:

1. Uses `std::set::node_type` (a C++17 feature) — but `espressif32 @ ^6.9.0` (the platform used by `arduino_esp32`) defaults to C++14.
2. References `std::vector` without `#include <vector>` — an outright bug in 3.3.0.

The `pioarduino` envs happen to compile fine because their newer toolchain defaults to gnu++2a and transitively pulls `<vector>`, but the `arduino_esp32` matrix entries fail like so:

```
error: 'node_type' in 'using TimedEventSet = ...' does not name a type
error: 'vector' in namespace 'std' does not name a template type
```

(see [run 26077887618](https://github.com/SignalK/SensESP/actions/runs/26077887618), the failing CI on #960 — that PR's code change is unrelated; it just happens to be the first push since 3.3.0 dropped on Apr 15.)

## The change

- `platformio.ini`: `mairas/ReactESP @ ^3.2.0` → `~3.2.0`
- `library.json`: `^3.1.0` → `~3.2.0`

`~3.2.0` allows future `3.2.x` patches but blocks `3.3.x` until upstream ships a fix.

## Verification

Locally built both envs against the pinned 3.2.0 on a Pi 5 (running the same `ci/run-tests.sh` script CI uses):

- `arduino_esp32` — `[PASSED]`, no `event_loop.h` errors.
- `pioarduino_esp32` — compile passes (no `node_type` / `vector` errors); the only local failure is an unrelated `min_spiffs.csv` link-step issue from my multi-framework install, not present in CI.