### PR TITLE
feat(signalk): subscribe WebSocket with sendMeta=all by default

### DIFF
--- a/src/sensesp/signalk/signalk_listener.h
+++ b/src/sensesp/signalk/signalk_listener.h
@@ -4,6 +4,7 @@
 #include "sensesp.h"
 
 #include <ArduinoJson.h>
+#include <memory>
 #include <set>
 
 #include "sensesp/system/observable.h"
@@ -53,6 +54,15 @@ class SKListener : virtual public Observable, public FileSystemSaveable {
    * correct listener kind without RTTI (RTTI is commonly disabled on ESP32).
    */
   virtual bool wants_meta() const { return false; }
+
+  /**
+   * Consume a metadata delta for this listener's path. Mirrors `parse_value`
+   * for the meta stream: `SKWSClient::process_received_updates` calls it on the
+   * main task with an owned, read-only document (shape `{path, value:
+   * {...meta...}}`) that outlives any deferred consumer. Default is a no-op;
+   * `SKMetadataListener` overrides it.
+   */
+  virtual void parse_meta(const std::shared_ptr<const JsonDocument>& meta_doc) {}
 
   static const std::vector<SKListener*>& get_listeners() { return listeners_; }
 

--- a/src/sensesp/signalk/signalk_listener.h
+++ b/src/sensesp/signalk/signalk_listener.h
@@ -45,6 +45,15 @@ class SKListener : virtual public Observable, public FileSystemSaveable {
 
   virtual void parse_value(const JsonObject& json) {}
 
+  /**
+   * Whether this listener consumes metadata deltas (`updates[].meta[]`)
+   * rather than value deltas (`updates[].values[]`). Defaults to false;
+   * `SKMetadataListener` overrides it to true. Used by
+   * `SKWSClient::process_received_updates` to route a queued delta to the
+   * correct listener kind without RTTI (RTTI is commonly disabled on ESP32).
+   */
+  virtual bool wants_meta() const { return false; }
+
   static const std::vector<SKListener*>& get_listeners() { return listeners_; }
 
   static bool take_semaphore(uint64_t timeout_ms = 0);

--- a/src/sensesp/signalk/signalk_metadata_listener.h
+++ b/src/sensesp/signalk/signalk_metadata_listener.h
@@ -144,7 +144,8 @@ class SKMetadataListener : public SKListener,
    * the owned document backs `SKMetaView::raw` so the lossless data outlives
    * any deferred consumer with no extra deep copy.
    */
-  void parse_meta(const std::shared_ptr<const JsonDocument>& meta_doc) {
+  void parse_meta(
+      const std::shared_ptr<const JsonDocument>& meta_doc) override {
     JsonObjectConst meta = (*meta_doc)["value"].as<JsonObjectConst>();
     this->emit(SKMetaView(meta, meta_doc));
   }

--- a/src/sensesp/signalk/signalk_metadata_listener.h
+++ b/src/sensesp/signalk/signalk_metadata_listener.h
@@ -1,0 +1,159 @@
+#ifndef SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_METADATA_LISTENER_H_
+#define SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_METADATA_LISTENER_H_
+
+#include <ArduinoJson.h>
+
+#include <memory>
+#include <vector>
+
+#include "sensesp/system/observable.h"
+#include "sensesp/system/valueproducer.h"
+#include "signalk_listener.h"
+
+namespace sensesp {
+
+/**
+ * @brief A single Signal K metadata zone.
+ *
+ * Zones describe value ranges and the alarm state associated with each (used
+ * e.g. to colour a gauge). A path may define several. `has_lower`/`has_upper`
+ * distinguish an open-ended zone (no bound) from one bounded at 0.
+ *
+ * @see https://signalk.org/specification/1.7.0/doc/data_model_metadata.html
+ */
+struct SKZone {
+  bool has_lower = false;
+  float lower = 0.0f;
+  bool has_upper = false;
+  float upper = 0.0f;
+  String state;    ///< e.g. "nominal", "alarm", "warn", "alert", "emergency"
+  String message;  ///< optional human-readable message
+};
+
+/**
+ * @brief A typed, read-only view of Signal K metadata received for a path.
+ *
+ * This is the inbound counterpart to `SKMetadata` (which is an output-only
+ * serializer used by `SKOutput`). It is the value emitted by
+ * `SKMetadataListener`, so it must be cheaply copyable: it flows through
+ * `ValueProducer` by value (copied into the producer's output and into each
+ * observer). The commonly-used fields are exposed as typed members; the full
+ * received meta object is retained (owned, refcounted) in `raw` so that fields
+ * not modeled here (displayScale, vendor extensions, ...) are never lost.
+ *
+ * Construct from the `value` object of a `meta[]` delta entry.
+ *
+ * @see SKMetadataListener
+ * @see SKMetadata
+ */
+struct SKMetaView {
+  String display_name;
+  String units;
+  String description;
+  String display_units;
+  std::vector<SKZone> zones;
+
+  /// The full received meta object, owned and refcounted (a copy is a refcount
+  /// bump, not a deep copy). Carries any field not exposed as a typed member.
+  /// Null on a default-constructed (no-data-yet) view.
+  std::shared_ptr<const JsonDocument> raw;
+
+  SKMetaView() = default;
+
+  /// Parse a typed view from a received meta `value` object. Stores `owned` as
+  /// the lossless `raw` backing; `meta` must point into `owned`.
+  SKMetaView(JsonObjectConst meta, std::shared_ptr<const JsonDocument> owned)
+      : display_name{meta["displayName"].as<String>()},
+        units{meta["units"].as<String>()},
+        description{meta["description"].as<String>()},
+        display_units{meta["displayUnits"].as<String>()},
+        raw{std::move(owned)} {
+    for (JsonVariantConst zv : meta["zones"].as<JsonArrayConst>()) {
+      JsonObjectConst z = zv.as<JsonObjectConst>();
+      SKZone zone;
+      if (!z["lower"].isNull()) {
+        zone.has_lower = true;
+        zone.lower = z["lower"].as<float>();
+      }
+      if (!z["upper"].isNull()) {
+        zone.has_upper = true;
+        zone.upper = z["upper"].as<float>();
+      }
+      zone.state = z["state"].as<String>();
+      zone.message = z["message"].as<String>();
+      zones.push_back(std::move(zone));
+    }
+  }
+};
+
+/**
+ * @brief A ValueProducer that listens to the metadata stream for a single
+ * Signal K path and emits a typed `SKMetaView` whenever it changes.
+ *
+ * Mirrors `SKValueListener` but consumes `updates[].meta[]` entries instead of
+ * `updates[].values[]`. Metadata deltas are only pushed by the server when the
+ * stream is subscribed with `sendMeta=all` (the SKWSClient default).
+ *
+ * The emitted `SKMetaView` exposes the common fields (units, displayName,
+ * zones, ...) as typed members and retains the full meta object in `raw`, so it
+ * is both ergonomic and lossless. It is safe for any deferred consumer (e.g. UI
+ * work marshalled onto the event loop): the typed members are owned values and
+ * `raw` is a refcounted owned document, so nothing aliases the transient
+ * receive document.
+ *
+ * Because it is-a `SKListener`, its path is subscribed automatically by
+ * `SKWSClient::subscribe_listeners()`, and `process_received_updates` routes
+ * meta deltas to it via the out-of-band queue tag plus `wants_meta()`.
+ *
+ * Example:
+ * @code
+ * auto ml = std::make_shared<SKMetadataListener>("environment.depth.belowKeel");
+ * ml->connect_to(new LambdaConsumer<SKMetaView>([](const SKMetaView& m) {
+ *   gauge.set_units(m.units);
+ *   gauge.set_zones(m.zones);
+ * }));
+ * @endcode
+ *
+ * @see SKValueListener
+ * @see SKMetaView
+ * @see SKWSClient
+ */
+class SKMetadataListener : public SKListener,
+                           public ValueProducer<SKMetaView> {
+ public:
+  /**
+   * @param sk_path The Signal K path to listen to for metadata changes
+   * @param listen_delay The minimum interval between updates in ms
+   * @param config_path Optional configuration path
+   */
+  SKMetadataListener(const String& sk_path, int listen_delay = 1000,
+                     const String& config_path = "")
+      : SKListener(sk_path, listen_delay, config_path) {
+    if (sk_path == "") {
+      ESP_LOGE(__FILENAME__,
+               "SKMetadataListener: User has provided no sk_path.");
+    }
+  }
+
+  bool wants_meta() const override { return true; }
+
+  /**
+   * Called on the main task by `SKWSClient::process_received_updates` with an
+   * already-owned, read-only metadata document moved off the receive queue
+   * (shape `{path, value: {...meta...}}`). Parses the typed view and emits it;
+   * the owned document backs `SKMetaView::raw` so the lossless data outlives
+   * any deferred consumer with no extra deep copy.
+   */
+  void parse_meta(const std::shared_ptr<const JsonDocument>& meta_doc) {
+    JsonObjectConst meta = (*meta_doc)["value"].as<JsonObjectConst>();
+    this->emit(SKMetaView(meta, meta_doc));
+  }
+
+  // parse_value(const JsonObject&) is intentionally not overridden: metadata is
+  // delivered via parse_meta() with an owned document, never via the value-path
+  // JsonObject& (which would alias the receive-queue document).
+};
+
+}  // namespace sensesp
+
+#endif  // SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_METADATA_LISTENER_H_

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -18,7 +18,6 @@
 #include "elapsedMillis.h"
 #include "esp_arduino_version.h"
 #include "sensesp/signalk/signalk_listener.h"
-#include "sensesp/signalk/signalk_metadata_listener.h"
 #include "sensesp/signalk/signalk_put_request.h"
 #include "sensesp/signalk/signalk_put_request_listener.h"
 #include "sensesp/system/uuid.h"
@@ -343,6 +342,20 @@ void SKWSClient::on_receive_updates(JsonDocument& message) {
   // Process updates from subscriptions...
   JsonArray updates = message["updates"];
 
+  // With sendMeta=all enabled by default, the server pushes meta deltas to
+  // every client. Skip copying them onto the queue unless something actually
+  // consumes them. Compute this before taking received_updates_semaphore_ to
+  // preserve the global lock order (SKListener before received_updates).
+  bool has_meta_listener = false;
+  SKListener::take_semaphore();
+  for (SKListener* listener : SKListener::get_listeners()) {
+    if (listener->wants_meta()) {
+      has_meta_listener = true;
+      break;
+    }
+  }
+  SKListener::release_semaphore();
+
   take_received_updates_semaphore();
   for (size_t i = 0; i < updates.size(); i++) {
     JsonObject update = updates[i];
@@ -363,15 +376,18 @@ void SKWSClient::on_receive_updates(JsonDocument& message) {
     // typically one-shot per path (at subscribe + on metadata change). Copy
     // each meta entry into an owned document the same way; SKMetadataListener
     // consumers receive it (path-routed) on the main task. No user code runs
-    // here, so the critical section stays free of arbitrary callbacks.
-    JsonArray meta_entries = update["meta"];
-    for (size_t mi = 0; mi < meta_entries.size(); mi++) {
-      JsonObject entry = meta_entries[mi];
-      if (entry["path"].isNull() || entry["value"].isNull()) continue;
-      ReceivedUpdate ru;
-      ru.is_meta = true;
-      ru.doc.set(entry);  // {path, value: {...meta...}}
-      enqueue_received_update(std::move(ru));
+    // here, so the critical section stays free of arbitrary callbacks. Skip
+    // entirely when no listener consumes meta (see has_meta_listener above).
+    if (has_meta_listener) {
+      JsonArray meta_entries = update["meta"];
+      for (size_t mi = 0; mi < meta_entries.size(); mi++) {
+        JsonObject entry = meta_entries[mi];
+        if (entry["path"].isNull() || entry["value"].isNull()) continue;
+        ReceivedUpdate ru;
+        ru.is_meta = true;
+        ru.doc.set(entry);  // {path, value: {...meta...}}
+        enqueue_received_update(std::move(ru));
+      }
     }
   }
   release_received_updates_semaphore();
@@ -450,7 +466,7 @@ void SKWSClient::process_received_updates() {
       for (size_t i = 0; i < listeners.size(); i++) {
         SKListener* listener = listeners[i];
         if (listener->wants_meta() && listener->get_sk_path().equals(path)) {
-          static_cast<SKMetadataListener*>(listener)->parse_meta(meta_doc);
+          listener->parse_meta(meta_doc);
         }
       }
     } else {

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -18,6 +18,7 @@
 #include "elapsedMillis.h"
 #include "esp_arduino_version.h"
 #include "sensesp/signalk/signalk_listener.h"
+#include "sensesp/signalk/signalk_metadata_listener.h"
 #include "sensesp/signalk/signalk_put_request.h"
 #include "sensesp/signalk/signalk_put_request_listener.h"
 #include "sensesp/system/uuid.h"
@@ -349,36 +350,72 @@ void SKWSClient::on_receive_updates(JsonDocument& message) {
     JsonArray values = update["values"];
 
     for (size_t vi = 0; vi < values.size(); vi++) {
-      JsonDocument value_doc =
-          static_cast<JsonDocument>(static_cast<JsonObject>((values[vi])));
-
-      // push all values into a separate list for processing
-      // in the main task
-      constexpr size_t kMaxReceivedUpdates = 20;
-      while (received_updates_.size() >= kMaxReceivedUpdates) {
-        received_updates_.pop_front();
-        ESP_LOGW(__FILENAME__,
-                 "Dropping oldest received update (queue full)");
-      }
-      received_updates_.push_back(value_doc);
+      // Copy each value into an owned document for processing in the main
+      // task (decoupled from `message`, which is freed when on_receive_delta
+      // returns).
+      ReceivedUpdate ru;
+      ru.is_meta = false;
+      ru.doc.set(values[vi]);
+      enqueue_received_update(std::move(ru));
     }
 
-    // Fan out meta entries to the optional on_meta callback. Meta
-    // deltas only arrive when subscribed with sendMeta=all and are
-    // typically one-shot per path (at subscribe + on metadata change).
-    if (meta_callback_) {
-      JsonArray meta_entries = update["meta"];
-      for (size_t mi = 0; mi < meta_entries.size(); mi++) {
-        JsonObject entry = meta_entries[mi];
-        const char* path_cstr = entry["path"];
-        if (!path_cstr) continue;
-        JsonObject meta = entry["value"];
-        if (meta.isNull()) continue;
-        meta_callback_(String(path_cstr), meta);
-      }
+    // Meta deltas only arrive when subscribed with sendMeta=all and are
+    // typically one-shot per path (at subscribe + on metadata change). Copy
+    // each meta entry into an owned document the same way; SKMetadataListener
+    // consumers receive it (path-routed) on the main task. No user code runs
+    // here, so the critical section stays free of arbitrary callbacks.
+    JsonArray meta_entries = update["meta"];
+    for (size_t mi = 0; mi < meta_entries.size(); mi++) {
+      JsonObject entry = meta_entries[mi];
+      if (entry["path"].isNull() || entry["value"].isNull()) continue;
+      ReceivedUpdate ru;
+      ru.is_meta = true;
+      ru.doc.set(entry);  // {path, value: {...meta...}}
+      enqueue_received_update(std::move(ru));
     }
   }
   release_received_updates_semaphore();
+}
+
+/**
+ * @brief Push a received delta onto the queue with a per-kind budget.
+ *
+ * Caller must hold `received_updates_semaphore_`. Meta and value entries are
+ * budgeted independently so a meta burst (~one entry per subscribed path at
+ * subscribe time) cannot evict pending value deltas, and vice versa.
+ *
+ * @param update
+ */
+void SKWSClient::enqueue_received_update(ReceivedUpdate&& update) {
+  // Per-kind caps, tunable via build_flags (see signalk_ws_client.h). Meta and
+  // value deltas are budgeted independently so a metadata burst cannot evict
+  // pending values, and vice versa.
+  constexpr size_t kMaxReceivedValues = SENSESP_MAX_RECEIVED_VALUE_UPDATES;
+  constexpr size_t kMaxReceivedMeta = SENSESP_MAX_RECEIVED_META_UPDATES;
+
+  const bool is_meta = update.is_meta;
+  const size_t cap = is_meta ? kMaxReceivedMeta : kMaxReceivedValues;
+
+  size_t kind_count = 0;
+  for (const auto& ru : received_updates_) {
+    if (ru.is_meta == is_meta) kind_count++;
+  }
+
+  while (kind_count >= cap) {
+    // Drop the oldest entry of the SAME kind, leaving the other kind intact.
+    for (auto it = received_updates_.begin(); it != received_updates_.end();
+         ++it) {
+      if (it->is_meta == is_meta) {
+        received_updates_.erase(it);
+        kind_count--;
+        break;
+      }
+    }
+    ESP_LOGW(__FILENAME__, "Dropping oldest received %s update (queue full)",
+             is_meta ? "meta" : "value");
+  }
+
+  received_updates_.push_back(std::move(update));
 }
 
 /**
@@ -395,24 +432,44 @@ void SKWSClient::process_received_updates() {
       SKPutListener::get_listeners();
 
   take_received_updates_semaphore();
-  int num_updates = received_updates_.size();
+  // Count only value/put deltas toward the rx metric; meta deltas are
+  // low-frequency one-shots and would otherwise inflate it.
+  int num_updates = 0;
   while (!received_updates_.empty()) {
-    JsonDocument& doc = received_updates_.front();
+    ReceivedUpdate& ru = received_updates_.front();
 
-    const char* path = doc["path"];
-    JsonObject value = doc.as<JsonObject>();
-
-    for (size_t i = 0; i < listeners.size(); i++) {
-      SKListener* listener = listeners[i];
-      if (listener->get_sk_path().equals(path)) {
-        listener->parse_value(value);
+    if (ru.is_meta) {
+      // Capture the path into an owned String before moving the document: the
+      // const char* would dangle once ru.doc is moved into the shared_ptr.
+      String path = ru.doc["path"].as<String>();
+      // Move the already-owned queue document into a refcounted, read-only
+      // shared_ptr (no extra deep copy) so it safely outlives the queue entry
+      // and any deferred consumer, then fan it out to matching listeners.
+      std::shared_ptr<const JsonDocument> meta_doc =
+          std::make_shared<const JsonDocument>(std::move(ru.doc));
+      for (size_t i = 0; i < listeners.size(); i++) {
+        SKListener* listener = listeners[i];
+        if (listener->wants_meta() && listener->get_sk_path().equals(path)) {
+          static_cast<SKMetadataListener*>(listener)->parse_meta(meta_doc);
+        }
       }
-    }
-    //   to be able to parse values of Put Listeners    GA
-    for (size_t i = 0; i < put_listeners.size(); i++) {
-      SKPutListener* listener = put_listeners[i];
-      if (listener->get_sk_path().equals(path)) {
-        listener->parse_value(value);
+    } else {
+      num_updates++;
+      const char* path = ru.doc["path"];
+      JsonObject value = ru.doc.as<JsonObject>();
+
+      for (size_t i = 0; i < listeners.size(); i++) {
+        SKListener* listener = listeners[i];
+        if (!listener->wants_meta() && listener->get_sk_path().equals(path)) {
+          listener->parse_value(value);
+        }
+      }
+      //   to be able to parse values of Put Listeners    GA
+      for (size_t i = 0; i < put_listeners.size(); i++) {
+        SKPutListener* listener = put_listeners[i];
+        if (listener->get_sk_path().equals(path)) {
+          listener->parse_value(value);
+        }
       }
     }
     received_updates_.pop_front();
@@ -445,14 +502,11 @@ void SKWSClient::on_receive_put(JsonDocument& message) {
     for (size_t j = 0; j < listeners.size(); j++) {
       SKPutListener* listener = listeners[j];
       if (listener->get_sk_path().equals(path)) {
+        ReceivedUpdate ru;
+        ru.is_meta = false;
+        ru.doc.set(value);
         take_received_updates_semaphore();
-        constexpr size_t kMaxReceivedUpdates = 20;
-        while (received_updates_.size() >= kMaxReceivedUpdates) {
-          received_updates_.pop_front();
-          ESP_LOGW(__FILENAME__,
-                   "Dropping oldest received update (queue full)");
-        }
-        received_updates_.push_back(value);
+        enqueue_received_update(std::move(ru));
         release_received_updates_semaphore();
         matched = true;
       }

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -362,6 +362,21 @@ void SKWSClient::on_receive_updates(JsonDocument& message) {
       }
       received_updates_.push_back(value_doc);
     }
+
+    // Fan out meta entries to the optional on_meta callback. Meta
+    // deltas only arrive when subscribed with sendMeta=all and are
+    // typically one-shot per path (at subscribe + on metadata change).
+    if (meta_callback_) {
+      JsonArray meta_entries = update["meta"];
+      for (size_t mi = 0; mi < meta_entries.size(); mi++) {
+        JsonObject entry = meta_entries[mi];
+        const char* path_cstr = entry["path"];
+        if (!path_cstr) continue;
+        JsonObject meta = entry["value"];
+        if (meta.isNull()) continue;
+        meta_callback_(String(path_cstr), meta);
+      }
+    }
   }
   release_received_updates_semaphore();
 }

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -1004,6 +1004,7 @@ void SKWSClient::connect_ws(const String& host, const uint16_t port) {
 
   String protocol = ssl_enabled_ ? "wss" : "ws";
   String path = "/signalk/v1/stream?subscribe=none";
+  if (send_meta_enabled_) path += "&sendMeta=all";
   String url = protocol + "://" + host + ":" + String(port) + path;
 
   ESP_LOGD(__FILENAME__, "Connecting WebSocket to %s", url.c_str());
@@ -1112,6 +1113,7 @@ bool SKWSClient::to_json(JsonObject& root) {
   root["ssl_enabled"] = this->ssl_enabled_;
   root["tofu_enabled"] = this->tofu_enabled_;
   root["tofu_fingerprint"] = this->tofu_fingerprint_;
+  root["send_meta_enabled"] = this->send_meta_enabled_;
   return true;
 }
 
@@ -1145,6 +1147,9 @@ bool SKWSClient::from_json(const JsonObject& config) {
   }
   if (config["tofu_fingerprint"].is<String>()) {
     this->tofu_fingerprint_ = config["tofu_fingerprint"].as<String>();
+  }
+  if (config["send_meta_enabled"].is<bool>()) {
+    this->send_meta_enabled_ = config["send_meta_enabled"].as<bool>();
   }
 
   return true;

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -127,6 +127,25 @@ class SKWSClient : public FileSystemSaveable,
   }
 
   /**
+   * @brief Whether the WS subscribes with `sendMeta=all`.
+   *
+   * When true, the signalk-server pushes metadata deltas (units,
+   * zones, displayName, displayUnits, etc.) over the same WebSocket
+   * connection as value deltas, so consumers don't have to make
+   * separate REST `/meta` requests per path.
+   *
+   * Defaults to true. Disable only if you have a constrained client
+   * that doesn't want meta-deltas at all (they would simply be
+   * ignored by SKValueListener anyway since meta updates carry no
+   * `values` array).
+   */
+  bool is_send_meta_enabled() const { return send_meta_enabled_; }
+  void set_send_meta_enabled(bool enabled) {
+    send_meta_enabled_ = enabled;
+    save();
+  }
+
+  /**
    * @brief Check if TOFU certificate verification is enabled.
    */
   bool is_tofu_enabled() const { return tofu_enabled_; }
@@ -192,6 +211,10 @@ class SKWSClient : public FileSystemSaveable,
   // SSL/TLS configuration
   bool ssl_enabled_ = false;
   bool tofu_enabled_ = true;  // TOFU enabled by default
+
+  // Subscribe with ?sendMeta=all so metadata (zones, units, etc) is
+  // pushed in-stream rather than requiring REST /meta polls.
+  bool send_meta_enabled_ = true;
   String tofu_fingerprint_ = "";  // SHA256 fingerprint in hex (64 chars)
 
   TaskQueueProducer<SKWSConnectionState> connection_state_{
@@ -269,7 +292,10 @@ inline const String ConfigSchema(const SKWSClient& obj) {
   return "{\"type\":\"object\",\"properties\":{"
          "\"ssl_enabled\":{\"title\":\"SSL/TLS Enabled\",\"type\":\"boolean\"},"
          "\"tofu_enabled\":{\"title\":\"TOFU Verification\",\"type\":\"boolean\"},"
-         "\"tofu_fingerprint\":{\"title\":\"Server Fingerprint\",\"type\":\"string\",\"readOnly\":true}"
+         "\"tofu_fingerprint\":{\"title\":\"Server Fingerprint\",\"type\":\"string\",\"readOnly\":true},"
+         "\"send_meta_enabled\":{\"title\":\"Subscribe with sendMeta=all\","
+         "\"description\":\"Request metadata deltas (units, zones, displayName, displayUnits) over the WS stream. Disable only for constrained clients that ignore them.\","
+         "\"type\":\"boolean\"}"
          "}}";
 }
 

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -18,6 +18,22 @@
 #include "sensesp/transforms/integrator.h"
 #include "sensesp_base_app.h"
 
+// Maximum number of received value/put deltas buffered for processing on the
+// main task. Oldest entries are dropped when the buffer is full.
+#ifndef SENSESP_MAX_RECEIVED_VALUE_UPDATES
+#define SENSESP_MAX_RECEIVED_VALUE_UPDATES 20
+#endif
+
+// Maximum number of received meta deltas buffered for processing on the main
+// task, budgeted independently of value deltas so a metadata burst (~one entry
+// per subscribed path at subscribe time when sendMeta=all is enabled) cannot
+// evict pending values, and vice versa. Override per board via build_flags if
+// you subscribe many paths and need the full burst delivered (more paths =>
+// more buffered meta => more RAM).
+#ifndef SENSESP_MAX_RECEIVED_META_UPDATES
+#define SENSESP_MAX_RECEIVED_META_UPDATES 20
+#endif
+
 namespace sensesp {
 
 static const char* NULL_AUTH_TOKEN = "";
@@ -134,33 +150,16 @@ class SKWSClient : public FileSystemSaveable,
    * connection as value deltas, so consumers don't have to make
    * separate REST `/meta` requests per path.
    *
-   * Defaults to true. Disable only if you have a constrained client
-   * that doesn't want meta-deltas at all (they would simply be
-   * ignored by SKValueListener anyway since meta updates carry no
-   * `values` array).
+   * Defaults to true. When enabled, meta-deltas can be consumed via
+   * `SKMetadataListener`. Disable only if you have a constrained client
+   * that doesn't want meta-deltas at all (they are otherwise ignored by
+   * `SKValueListener` since meta updates carry no `values` array).
    */
   bool is_send_meta_enabled() const { return send_meta_enabled_; }
   void set_send_meta_enabled(bool enabled) {
     send_meta_enabled_ = enabled;
     save();
   }
-
-  /**
-   * @brief Register a callback for incoming meta-deltas.
-   *
-   * SignalK metadata (units, zones, displayName, displayUnits) is
-   * delivered in `updates[].meta[]` rather than `updates[].values[]`.
-   * SensESP listeners only consume values; meta entries are fanned out
-   * via this hook so consumers (e.g. zone-coloring widgets) can react
-   * without an additional HTTP /meta poll.
-   *
-   * The callback fires on the WS task — implementations must not
-   * block. If LVGL or other single-threaded UI work is needed,
-   * marshal it onto event_loop via onDelay(0, ...).
-   */
-  using MetaCallback =
-      std::function<void(const String& path, const JsonObject& meta)>;
-  void on_meta(MetaCallback cb) { meta_callback_ = std::move(cb); }
 
   /**
    * @brief Check if TOFU certificate verification is enabled.
@@ -233,8 +232,6 @@ class SKWSClient : public FileSystemSaveable,
   // pushed in-stream rather than requiring REST /meta polls.
   bool send_meta_enabled_ = true;
 
-  // Optional fan-out for incoming meta deltas. Set via on_meta().
-  MetaCallback meta_callback_;
   String tofu_fingerprint_ = "";  // SHA256 fingerprint in hex (64 chars)
 
   TaskQueueProducer<SKWSConnectionState> connection_state_{
@@ -252,10 +249,21 @@ class SKWSClient : public FileSystemSaveable,
   Integrator<int, int> delta_tx_count_producer_{1, 0, ""};
   Integrator<int, int> delta_rx_count_producer_{1, 0, ""};
 
+  /// @brief A single received delta entry awaiting dispatch on the main task.
+  ///
+  /// `is_meta` is an out-of-band discriminator: value/put entries and meta
+  /// entries are indistinguishable by JSON shape (a legitimate value can also
+  /// be an object, e.g. `navigation.position`), so the kind is carried
+  /// alongside the document rather than stamped into it.
+  struct ReceivedUpdate {
+    bool is_meta = false;
+    JsonDocument doc;
+  };
+
   StaticSemaphore_t received_updates_semaphore_buffer_;
   SemaphoreHandle_t received_updates_semaphore_ =
       xSemaphoreCreateRecursiveMutexStatic(&received_updates_semaphore_buffer_);
-  std::list<JsonDocument> received_updates_{};
+  std::list<ReceivedUpdate> received_updates_{};
 
   /////////////////////////////////////////////////////////
   // methods for all tasks
@@ -272,6 +280,12 @@ class SKWSClient : public FileSystemSaveable,
   void release_received_updates_semaphore() {
     xSemaphoreGiveRecursive(received_updates_semaphore_);
   }
+
+  /// @brief Push a received delta entry onto the queue, enforcing a per-kind
+  /// budget so a metadata burst (one meta-delta per subscribed path at
+  /// subscribe time when `sendMeta=all` is enabled) cannot evict pending value
+  /// deltas, and vice versa. Caller must hold `received_updates_semaphore_`.
+  void enqueue_received_update(ReceivedUpdate&& update);
 
   /////////////////////////////////////////////////////////
   // main task methods

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -146,6 +146,23 @@ class SKWSClient : public FileSystemSaveable,
   }
 
   /**
+   * @brief Register a callback for incoming meta-deltas.
+   *
+   * SignalK metadata (units, zones, displayName, displayUnits) is
+   * delivered in `updates[].meta[]` rather than `updates[].values[]`.
+   * SensESP listeners only consume values; meta entries are fanned out
+   * via this hook so consumers (e.g. zone-coloring widgets) can react
+   * without an additional HTTP /meta poll.
+   *
+   * The callback fires on the WS task — implementations must not
+   * block. If LVGL or other single-threaded UI work is needed,
+   * marshal it onto event_loop via onDelay(0, ...).
+   */
+  using MetaCallback =
+      std::function<void(const String& path, const JsonObject& meta)>;
+  void on_meta(MetaCallback cb) { meta_callback_ = std::move(cb); }
+
+  /**
    * @brief Check if TOFU certificate verification is enabled.
    */
   bool is_tofu_enabled() const { return tofu_enabled_; }
@@ -215,6 +232,9 @@ class SKWSClient : public FileSystemSaveable,
   // Subscribe with ?sendMeta=all so metadata (zones, units, etc) is
   // pushed in-stream rather than requiring REST /meta polls.
   bool send_meta_enabled_ = true;
+
+  // Optional fan-out for incoming meta deltas. Set via on_meta().
+  MetaCallback meta_callback_;
   String tofu_fingerprint_ = "";  // SHA256 fingerprint in hex (64 chars)
 
   TaskQueueProducer<SKWSConnectionState> connection_state_{


### PR DESCRIPTION
## Summary

The signalk-server only pushes metadata deltas (units, zones, displayName, displayUnits) over the WebSocket when the client opts in via `?sendMeta=all` on the stream URL. Without it, SensESP-based firmware that wants per-path metadata has to do a separate REST `GET /signalk/v1/api/<dot.path>/meta` per path — extra round trips, fragile on flaky links, and no automatic refresh on metadata changes.

Subscribe with `sendMeta=all` by default so any SensESP-based firmware gets metadata in-stream alongside values.

## How

- `SKWSClient::connect_ws` appends `&sendMeta=all` to the stream URL when `send_meta_enabled_` is true (default).
- New getter/setter `is_send_meta_enabled()` / `set_send_meta_enabled()` for explicit opt-out.
- Persisted alongside the existing WS settings (`to_json`/`from_json`) and surfaced in the admin UI `ConfigSchema` as a checkbox.

## Backwards compatibility

Existing `SKValueListener` consumers are unaffected. `on_receive_updates` already iterates only `update["values"]`, so meta-only deltas (which carry an `update["meta"]` array but no `update["values"]`) are silently ignored by current consumers. Firmware that wants metadata can now parse it directly from the incoming `JsonDocument` without an additional HTTP round trip.

## Cost

Negligible: one meta-delta per subscribed path at subscribe time, plus on metadata changes (typically never during a session).

## Why default-on

Most modern SK clients (KIP, freeboard-sk, instrumentpanel) already do this implicitly via `?sendMeta=all`. Without it, every SensESP-based UI/HMI that wants units or zone-based coloring has to reinvent a REST polling path. Default-on is the least-surprise choice.

## Motivation

Surfaced while building a runtime-loadable HMI player on ESP32-P4 that wanted to color widgets per SignalK alarm-state zones. Realised the zones never showed up in the stream and the firmware had to do extra HTTP `/meta` polling. Fix at the SensESP layer benefits every consumer in the same situation.