### PR TITLE
fix: StreamLineProducer emits String, not unique_ptr<char[]>

### DIFF
--- a/src/sensesp/system/stream_producer.h
+++ b/src/sensesp/system/stream_producer.h
@@ -60,7 +60,7 @@ class StreamLineProducer : public ValueProducer<String> {
         // Include the newline character in the output
         buf_[buf_pos++] = c;
         buf_[buf_pos] = '\0';
-        this->emit(buf_);
+        this->emit(String(buf_.get()));
         buf_pos = 0;
       } else {
         buf_[buf_pos++] = c;


### PR DESCRIPTION
## Problem

`StreamLineProducer::receive_line()` calls `this->emit(buf_)`, but `buf_` is a `std::unique_ptr<char[]>` while the base `ValueProducer<String>::emit()` takes a `const String&`. There is no such conversion, so the class fails to compile **wherever it is instantiated**:

```
error: cannot convert 'std::unique_ptr<char []>' to 'const String&'
   63 |         this->emit(buf_);
```

`StreamLineProducer` is new in 3.3.0 and isn't exercised by any in-tree example, so the regression shipped unnoticed. It surfaces immediately in downstream libraries that read lines from a serial stream — e.g. `SensESP/NMEA0183` builds a `StreamLineProducer` in `NMEA0183IOTask`, so **any 3.3.0 project doing NMEA 0183 serial input fails to build**.

## Fix

Construct a `String` from the null-terminated buffer before emitting:

```cpp
this->emit(String(buf_.get()));
```

## Verification

Built a real downstream firmware (SH-ESP32 + NMEA0183 serial input) against the patched library — compiles clean, and on hardware the parsed NMEA sentences flow through as expected.

## Note

The class had no compile coverage, which is why this shipped. A minimal test that instantiates `StreamLineProducer` (with a fake `Stream`) would prevent recurrence — happy to follow up with one if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
