### PR TITLE
chore(deps): require ReactESP ^3.3.1

### DIFF
--- a/library.json
+++ b/library.json
@@ -28,7 +28,7 @@
     {
       "owner": "mairas",
       "name": "ReactESP",
-      "version": "^3.1.0"
+      "version": "^3.3.1"
     },
     {
       "owner": "bblanchon",

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ upload_speed = 2000000
 monitor_speed = 115200
 
 lib_deps =
-    mairas/ReactESP @ ^3.2.0
+    mairas/ReactESP @ ^3.3.1
     bblanchon/ArduinoJson @ ^7.0.0
     pfeerick/elapsedMillis @ ^1.0.6
     bxparks/AceButton @ ^1.10.1


### PR DESCRIPTION
## Motivation

ReactESP **3.3.0** (Apr 2026) broke compilation under the C++14 Arduino-Espressif toolchain: it used `std::set::node_type` (C++17) and referenced `std::vector` without `#include <vector>`. ReactESP **3.3.1** backported the fix (conditional compilation + missing include).

The current constraints predate that release and have drifted apart:

- `platformio.ini`: `mairas/ReactESP @ ^3.2.0`
- `library.json`: `^3.1.0`

Both carets already resolve to the latest (3.3.1), so CI is not currently broken — this is hygiene, not a fix.

## Approach

Raise both manifests to `^3.3.1`. This puts the floor above the known-broken 3.3.0 so it can never be selected (e.g. from a stale resolver cache), and aligns the two manifests that had drifted.

## Notes

Supersedes the abandoned pin-down approach in #961, which was closed unmerged once 3.3.1 shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)