### PR TITLE
fix(build): restrict PlatformIO package export to source

### DIFF
--- a/library.json
+++ b/library.json
@@ -48,5 +48,8 @@
   ],
   "version": "3.4.0",
   "frameworks": "arduino",
-  "platforms": ["espressif32"]
+  "platforms": ["espressif32"],
+  "export": {
+    "include": ["src", "examples", "library.json", "library.properties", "README.md", "LICENSE", "CHANGELOG.md"]
+  }
 }


### PR DESCRIPTION
## Problem

The 3.4.0 release failed to publish to the PlatformIO registry:

```
HTTPClientError: File size exceeds your limit: 50 MB
```

`library.json` had no `export` filter, so `pio package publish` bundled the entire worktree — `frontend/` (node_modules, ~25k files), `frontend-plugins/`, `managed_components/`, and the generated `docs/` — for a 54MB+ tarball. `pio package pack` ignores `.gitignore`, so excludes alone don't reliably contain it.

## Fix

Add an `export.include` allowlist so only the library source and manifests are packaged:

- `src`, `examples`, `library.json`, `library.properties`, `README.md`, `LICENSE`, `CHANGELOG.md`

The embedded web UI is already compiled into `src/sensesp/net/web/autogen/frontend_files.h`, so the `frontend/` source isn't needed in the package. Local `pio package pack` drops from 103MB to **5.8MB**.

This is folded into the v3.4.0 release (the tag will be re-cut to include it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)