### PR TITLE
fix(transforms): wire weather multi-input transforms

### DIFF
--- a/src/sensesp/transforms/air_density.cpp
+++ b/src/sensesp/transforms/air_density.cpp
@@ -4,18 +4,19 @@
 
 namespace sensesp {
 
-// dew point
+// air density
 
-AirDensity::AirDensity() : FloatTransform() {}
+AirDensity::AirDensity()
+    : Transform<std::tuple<float, float, float>, float>() {}
 
-void AirDensity::set(const float& /*input*/) {
+void AirDensity::set(const std::tuple<float, float, float>& input) {
   // For more info on the calculation see
   // https://en.wikipedia.org/wiki/Density_of_air
 
-  const float temp_kelvin = inputs[0];
+  const float temp_kelvin = std::get<0>(input);
   const float temp_celsius = temp_kelvin - 273.15;
-  const float relative_humidity = inputs[1];
-  const float pressure = inputs[2];
+  const float relative_humidity = std::get<1>(input);
+  const float pressure = std::get<2>(input);
 
   // Saturation vapor pressure of water
   float saturation_pressure =

--- a/src/sensesp/transforms/air_density.h
+++ b/src/sensesp/transforms/air_density.h
@@ -1,6 +1,8 @@
 #ifndef SENSESP_TRANSFORMS_AIR_DENSITY_H_
 #define SENSESP_TRANSFORMS_AIR_DENSITY_H_
 
+#include <tuple>
+
 #include "transform.h"
 
 namespace sensesp {
@@ -11,13 +13,10 @@ namespace sensesp {
  * More info about the equation can be found at
  * https://en.wikipedia.org/wiki/Density_of_air
  */
-class AirDensity : public FloatTransform {
+class AirDensity : public Transform<std::tuple<float, float, float>, float> {
  public:
   AirDensity();
-  virtual void set(const float& input) override;
-
- private:
-  float inputs[3]{};
+  virtual void set(const std::tuple<float, float, float>& input) override;
 };
 
 }  // namespace sensesp

--- a/src/sensesp/transforms/dew_point.cpp
+++ b/src/sensesp/transforms/dew_point.cpp
@@ -1,16 +1,20 @@
 #include "dew_point.h"
 
+#include <cmath>
+
 namespace sensesp {
 
 // dew point
 
-void DewPoint::set(const float& /*input*/) {
+DewPoint::DewPoint() : Transform<std::tuple<float, float>, float>() {}
+
+void DewPoint::set(const std::tuple<float, float>& input) {
   // Dew point is calculated with Arden Buck Equation and Arden Buck valuation
   // sets For more info on the calculation see
   // https://en.wikipedia.org/wiki/Dew_point#Calculating_the_dew_point
 
-  float const temp_celsius = inputs[0] - 273.15;
-  float const relative_humidity = inputs[1];
+  float const temp_celsius = std::get<0>(input) - 273.15;
+  float const relative_humidity = std::get<1>(input);
 
   // valuation set for temperatures above 0°C
   float b = 17.368;

--- a/src/sensesp/transforms/dew_point.h
+++ b/src/sensesp/transforms/dew_point.h
@@ -1,6 +1,8 @@
 #ifndef SENSESP_TRANSFORMS_DEW_POINT_H_
 #define SENSESP_TRANSFORMS_DEW_POINT_H_
 
+#include <tuple>
+
 #include "transform.h"
 
 namespace sensesp {
@@ -12,13 +14,10 @@ namespace sensesp {
  * temperatures from -40°C to +50°C. More info about the equation can be found
  * at https://en.wikipedia.org/wiki/Dew_point
  */
-class DewPoint : public FloatTransform {
+class DewPoint : public Transform<std::tuple<float, float>, float> {
  public:
   DewPoint();
-  virtual void set(const float& input) override;
-
- private:
-  float inputs[2]{};
+  virtual void set(const std::tuple<float, float>& input) override;
 };
 
 }  // namespace sensesp

--- a/src/sensesp/transforms/heat_index.cpp
+++ b/src/sensesp/transforms/heat_index.cpp
@@ -93,7 +93,7 @@ void HeatIndexEffect::set(const float& input) {
   } else if (heat_index_temperature > 32) {
     heat_index_effect = "Extreme Caution";
   } else if (heat_index_temperature > 27) {
-    heat_index_effect + "Caution";
+    heat_index_effect = "Caution";
   }
 
   this->emit(heat_index_effect);

--- a/src/sensesp/transforms/heat_index.cpp
+++ b/src/sensesp/transforms/heat_index.cpp
@@ -46,7 +46,7 @@ void HeatIndexTemperature::set(const std::tuple<float, float>& input) {
       const float c9 = -0.00000199;
 
       // equation for heat index
-      float heat_index_temperature =
+      heat_index_temperature =
           c1 + c2 * temp_fahrenheit + c3 * relative_humidity +
           c4 * temp_fahrenheit * relative_humidity +
           c5 * pow(temp_fahrenheit, 2) + c6 * pow(relative_humidity, 2) +

--- a/src/sensesp/transforms/heat_index.cpp
+++ b/src/sensesp/transforms/heat_index.cpp
@@ -1,22 +1,25 @@
 #include "heat_index.h"
 
+#include <cmath>
+
 namespace sensesp {
 
 // heat index temperature
 
-HeatIndexTemperature::HeatIndexTemperature() : FloatTransform() {}
+HeatIndexTemperature::HeatIndexTemperature()
+    : Transform<std::tuple<float, float>, float>() {}
 
-void HeatIndexTemperature::set(const float& /*input*/) {
+void HeatIndexTemperature::set(const std::tuple<float, float>& input) {
   // The following equation approximate the heat index
   // using both Steadman's and Rothfusz equations
   // See https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3801457/
   // Algorithm 1 (table 1) (algorithm in figure 3)
 
   float const temp_fahrenheit =
-      1.8 * (inputs[0] - 273.15) +
+      1.8 * (std::get<0>(input) - 273.15) +
       32;  // dry-bulb temperature in degrees fahrenheit
   float const relative_humidity =
-      inputs[1] * 100;  // relative humidity in percent
+      std::get<1>(input) * 100;  // relative humidity in percent
 
   // step 1: if temperature is less than 40°F then heat index temperature is
   // dry bulb temperature.
@@ -69,10 +72,10 @@ void HeatIndexTemperature::set(const float& /*input*/) {
             0.02 * (relative_humidity - 85) * (87 - temp_fahrenheit);
       }
     }
-
-    this->emit((heat_index_temperature - 32) / 1.8 +
-               273.15);  // Fahrenheit to Kelvin
   }
+
+  this->emit((heat_index_temperature - 32) / 1.8 +
+             273.15);  // Fahrenheit to Kelvin
 }
 
 // heat index effect (warning levels)

--- a/src/sensesp/transforms/heat_index.h
+++ b/src/sensesp/transforms/heat_index.h
@@ -1,6 +1,8 @@
 #ifndef SENSESP_TRANSFORMS_HEAT_INDEX_H_
 #define SENSESP_TRANSFORMS_HEAT_INDEX_H_
 
+#include <tuple>
+
 #include "transform.h"
 
 namespace sensesp {
@@ -13,13 +15,10 @@ namespace sensesp {
  * the NOAA NWS. More info about the equation can be found at
  * https://en.wikipedia.org/wiki/Heat_index
  */
-class HeatIndexTemperature : public FloatTransform {
+class HeatIndexTemperature : public Transform<std::tuple<float, float>, float> {
  public:
   HeatIndexTemperature();
-  virtual void set(const float& input) override;
-
- private:
-  float inputs[2]{};
+  virtual void set(const std::tuple<float, float>& input) override;
 };
 
 /**

--- a/test/system/test_transform_correctness/transform_correctness_test.cpp
+++ b/test/system/test_transform_correctness/transform_correctness_test.cpp
@@ -4,7 +4,7 @@
  *
  * Covers: MovingAverage from_json resize (#874), Hysteresis uninitialized
  * last_value_ (#906), VoltageDivider division by zero (#907), weather
- * transform tuple inputs (#872).
+ * transform tuple inputs (#872), HeatIndex Rothfusz result (#870).
  */
 
 #include <Arduino.h>
@@ -186,6 +186,17 @@ void test_heat_index_temperature_tuple_input() {
   TEST_ASSERT_FLOAT_WITHIN(0.0001f, 299.1111f, received);
 }
 
+void test_heat_index_temperature_rothfusz_branch() {
+  HeatIndexTemperature heat_index_temperature;
+
+  float received = -1.0f;
+  LambdaConsumer<float> consumer([&received](float v) { received = v; });
+  heat_index_temperature.connect_to(&consumer);
+
+  heat_index_temperature.set(std::make_tuple(303.15f, 0.70f));
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 308.1880f, received);
+}
+
 void test_heat_index_temperature_cold_branch_emits() {
   HeatIndexTemperature heat_index_temperature;
 
@@ -240,6 +251,7 @@ void setup() {
   RUN_TEST(test_air_density_tuple_input);
   RUN_TEST(test_dew_point_tuple_input);
   RUN_TEST(test_heat_index_temperature_tuple_input);
+  RUN_TEST(test_heat_index_temperature_rothfusz_branch);
   RUN_TEST(test_heat_index_temperature_cold_branch_emits);
   RUN_TEST(test_weather_zip_wiring_waits_for_all_inputs);
 

--- a/test/system/test_transform_correctness/transform_correctness_test.cpp
+++ b/test/system/test_transform_correctness/transform_correctness_test.cpp
@@ -3,15 +3,21 @@
  * @brief Tests for transform correctness bug fixes.
  *
  * Covers: MovingAverage from_json resize (#874), Hysteresis uninitialized
- * last_value_ (#906), VoltageDivider division by zero (#907).
+ * last_value_ (#906), VoltageDivider division by zero (#907), weather
+ * transform tuple inputs (#872).
  */
 
 #include <Arduino.h>
 
 #include "sensesp/system/lambda_consumer.h"
+#include "sensesp/system/observablevalue.h"
+#include "sensesp/transforms/air_density.h"
+#include "sensesp/transforms/dew_point.h"
+#include "sensesp/transforms/heat_index.h"
 #include "sensesp/transforms/hysteresis.h"
 #include "sensesp/transforms/moving_average.h"
 #include "sensesp/transforms/voltagedivider.h"
+#include "sensesp/transforms/zip.h"
 #include "unity.h"
 
 using namespace sensesp;
@@ -144,6 +150,79 @@ void test_voltage_divider_r1_normal() {
 }
 
 // ---------------------------------------------------------------------------
+// Weather transforms: tuple inputs replace removed input channels (#872)
+// ---------------------------------------------------------------------------
+
+void test_air_density_tuple_input() {
+  AirDensity air_density;
+
+  float received = -1.0f;
+  LambdaConsumer<float> consumer([&received](float v) { received = v; });
+  air_density.connect_to(&consumer);
+
+  air_density.set(std::make_tuple(303.15f, 0.70f, 101325.0f));
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 1.164269f, received);
+}
+
+void test_dew_point_tuple_input() {
+  DewPoint dew_point;
+
+  float received = -1.0f;
+  LambdaConsumer<float> consumer([&received](float v) { received = v; });
+  dew_point.connect_to(&consumer);
+
+  dew_point.set(std::make_tuple(303.15f, 0.70f));
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 296.83775f, received);
+}
+
+void test_heat_index_temperature_tuple_input() {
+  HeatIndexTemperature heat_index_temperature;
+
+  float received = -1.0f;
+  LambdaConsumer<float> consumer([&received](float v) { received = v; });
+  heat_index_temperature.connect_to(&consumer);
+
+  heat_index_temperature.set(std::make_tuple(299.15f, 0.50f));
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 299.1111f, received);
+}
+
+void test_heat_index_temperature_cold_branch_emits() {
+  HeatIndexTemperature heat_index_temperature;
+
+  float received = -1.0f;
+  LambdaConsumer<float> consumer([&received](float v) { received = v; });
+  heat_index_temperature.connect_to(&consumer);
+
+  heat_index_temperature.set(std::make_tuple(273.15f, 0.50f));
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 273.15f, received);
+}
+
+void test_weather_zip_wiring_waits_for_all_inputs() {
+  ObservableValue<float> temperature(0.0f);
+  ObservableValue<float> humidity(0.0f);
+  Zip<float, float> zip;
+  HeatIndexTemperature heat_index_temperature;
+
+  float received = -1.0f;
+  bool was_called = false;
+  LambdaConsumer<float> consumer([&](float v) {
+    received = v;
+    was_called = true;
+  });
+
+  temperature.connect_to(&(std::get<0>(zip.consumers)));
+  humidity.connect_to(&(std::get<1>(zip.consumers)));
+  zip.connect_to(&heat_index_temperature)->connect_to(&consumer);
+
+  temperature.set(299.15f);
+  TEST_ASSERT_FALSE(was_called);
+
+  humidity.set(0.50f);
+  TEST_ASSERT_TRUE(was_called);
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 299.1111f, received);
+}
+
+// ---------------------------------------------------------------------------
 // Test runner
 // ---------------------------------------------------------------------------
 
@@ -158,6 +237,11 @@ void setup() {
   RUN_TEST(test_voltage_divider_r1_zero_vout);
   RUN_TEST(test_voltage_divider_r2_vout_equals_vin);
   RUN_TEST(test_voltage_divider_r1_normal);
+  RUN_TEST(test_air_density_tuple_input);
+  RUN_TEST(test_dew_point_tuple_input);
+  RUN_TEST(test_heat_index_temperature_tuple_input);
+  RUN_TEST(test_heat_index_temperature_cold_branch_emits);
+  RUN_TEST(test_weather_zip_wiring_waits_for_all_inputs);
 
   UNITY_END();
 }

--- a/test/system/test_transform_correctness/transform_correctness_test.cpp
+++ b/test/system/test_transform_correctness/transform_correctness_test.cpp
@@ -4,7 +4,8 @@
  *
  * Covers: MovingAverage from_json resize (#874), Hysteresis uninitialized
  * last_value_ (#906), VoltageDivider division by zero (#907), weather
- * transform tuple inputs (#872), HeatIndex Rothfusz result (#870).
+ * transform tuple inputs (#872), HeatIndex Rothfusz result (#870),
+ * HeatIndex Caution effect (#871).
  */
 
 #include <Arduino.h>
@@ -208,6 +209,17 @@ void test_heat_index_temperature_cold_branch_emits() {
   TEST_ASSERT_FLOAT_WITHIN(0.0001f, 273.15f, received);
 }
 
+void test_heat_index_effect_caution_range() {
+  HeatIndexEffect heat_index_effect;
+
+  String received = "";
+  LambdaConsumer<String> consumer([&received](String v) { received = v; });
+  heat_index_effect.connect_to(&consumer);
+
+  heat_index_effect.set(301.15f);
+  TEST_ASSERT_EQUAL_STRING("Caution", received.c_str());
+}
+
 void test_weather_zip_wiring_waits_for_all_inputs() {
   ObservableValue<float> temperature(0.0f);
   ObservableValue<float> humidity(0.0f);
@@ -253,6 +265,7 @@ void setup() {
   RUN_TEST(test_heat_index_temperature_tuple_input);
   RUN_TEST(test_heat_index_temperature_rothfusz_branch);
   RUN_TEST(test_heat_index_temperature_cold_branch_emits);
+  RUN_TEST(test_heat_index_effect_caution_range);
   RUN_TEST(test_weather_zip_wiring_waits_for_all_inputs);
 
   UNITY_END();


### PR DESCRIPTION
## Summary

This fixes the weather transform input path and the two HeatIndex correctness bugs that become active once that path is live.

- Converts `AirDensity`, `DewPoint`, and `HeatIndexTemperature` to tuple-input transforms instead of reading dead `inputs[]` arrays.
- Uses the existing tuple/Zip pattern rather than adding a new multi-input abstraction.
- Preserves the Rothfusz heat index result instead of discarding it through local variable shadowing.
- Emits `"Caution"` correctly from `HeatIndexEffect`.

Fixes #872
Fixes #870
Fixes #871

I left #899 alone as it's out of scope for this PR.

## Test plan

- Format check passed on touched files.
- `git diff --check`
- `system/test_transform_correctness` PlatformIO test build passed.
- Verified on ESP32 hardware.