### PR TITLE
fix(web): bail out when httpd_start fails instead of serving a dead UI

### DIFF
--- a/src/sensesp/net/http_server.h
+++ b/src/sensesp/net/http_server.h
@@ -106,9 +106,11 @@ class HTTPServer : public FileSystemSaveable {
       if (error != ESP_OK) {
         ESP_LOGE(__FILENAME__, "Error starting HTTP server: %s",
                  esp_err_to_name(error));
-      } else {
-        ESP_LOGI(__FILENAME__, "HTTP server started");
+        // Registering handlers or announcing mDNS against a failed handle would
+        // leave the device advertising a dead web UI with no further signal.
+        return;
       }
+      ESP_LOGI(__FILENAME__, "HTTP server started");
 
       // register the request dispatcher for all methods and all URIs
       httpd_uri_t uri = {


### PR DESCRIPTION
## Why

In `HTTPServer`'s constructor, when `httpd_start()` failed it logged the error but fell through and registered URI handlers and announced HTTP over mDNS anyway — operating on the failed/null server handle. The device booted healthy and advertised a web UI that was actually dead, with no signal to the user that the server never started.

The most likely trigger is a `max_open_sockets` value exceeding the lwIP socket budget (`config.max_open_sockets + 3 > CONFIG_LWIP_MAX_SOCKETS`), which `httpd_start()` rejects with `ESP_ERR_INVALID_ARG`. CI only covers arduino + pioarduino frameworks, so it doesn't catch the espidf default of `CONFIG_LWIP_MAX_SOCKETS = 10`.

## What

Return early from the startup lambda when `httpd_start()` fails, skipping handler registration and the mDNS announcement. The error is still logged via `ESP_LOGE`.

Split out from review discussion on #960; that PR no longer triggers this path, so this is an independent pre-existing bug.

Verified by building `examples/minimal_app.cpp` for `pioarduino_esp32`.

Fixes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)