### PR TITLE
fix(web): avoid leaking secrets via the network-readable log

### DIFF
--- a/src/sensesp/net/http_server.cpp
+++ b/src/sensesp/net/http_server.cpp
@@ -2,6 +2,7 @@
 
 #include "sensesp/net/http_server.h"
 
+#include <cstring>
 #include <functional>
 #include <list>
 #include <lwip/sockets.h>
@@ -38,7 +39,13 @@ void urldecode2(char* dst, const char* src) {
 }
 
 esp_err_t HTTPServer::dispatch_request(httpd_req_t* req) {
-  ESP_LOGI(__FILENAME__, "Handling request: %s", req->uri);
+  // Log only the path, not the query string: the captured log is served over
+  // HTTP (and the server is unauthenticated by default), so a future endpoint
+  // carrying a secret as a query parameter must not echo it into the log.
+  const char* query = strchr(req->uri, '?');
+  int path_len = query ? static_cast<int>(query - req->uri)
+                       : static_cast<int>(strlen(req->uri));
+  ESP_LOGI(__FILENAME__, "Handling request: %.*s", path_len, req->uri);
 
   if (captive_portal_) {
     bool captured;

--- a/src/sensesp/net/web/base_command_handler.cpp
+++ b/src/sensesp/net/web/base_command_handler.cpp
@@ -111,17 +111,18 @@ void add_http_log_handler(std::shared_ptr<HTTPServer>& server) {
   auto log_handler = std::make_shared<HTTPRequestHandler>(
       1 << HTTP_GET, "/api/log", [](httpd_req_t* req) {
         LogBuffer* log_buffer = LogBuffer::instance();
-        httpd_resp_set_type(req, "application/json");
+        httpd_resp_set_type(req, "application/json; charset=utf-8");
         if (log_buffer == nullptr) {
           httpd_resp_sendstr(
               req, "{\"session\":0,\"next\":0,\"gap\":false,\"lines\":[]}");
           return ESP_OK;
         }
 
-        // Access control: none of its own. /api/log is gated by the global
-        // dispatcher auth, exactly like /api/info. check_origin() is anti-CSRF
-        // for destructive POSTs and gives no read protection, so it is not used
-        // here.
+        // Access control: none of its own, like /api/info. The only gate is the
+        // dispatcher's HTTP auth, which is off by default — so /api/log mirrors
+        // the serial log to anyone who can reach the web server unless web auth
+        // is enabled. check_origin() is anti-CSRF for destructive POSTs and
+        // gives no read protection, so it is not used here.
         uint32_t since = 0;
         bool has_since = false;
         size_t query_len = httpd_req_get_url_query_len(req) + 1;

--- a/src/sensesp/net/web/config_handler.cpp
+++ b/src/sensesp/net/web/config_handler.cpp
@@ -2,11 +2,24 @@
 
 #include "config_handler.h"
 
+#include <cstring>
 #include <memory>
 
 #include "sensesp/ui/config_item.h"
 
 namespace sensesp {
+
+namespace {
+
+// Length of the path portion of a URI, excluding any query string. The query
+// may carry secrets and the captured log is served over HTTP, so only the path
+// is logged (see HTTPServer::dispatch_request).
+int uri_path_len(const char* uri) {
+  const char* query = strchr(uri, '?');
+  return query ? static_cast<int>(query - uri) : static_cast<int>(strlen(uri));
+}
+
+}  // namespace
 
 bool get_item_data(JsonDocument& doc,
                    const std::shared_ptr<ConfigItemBase>& item) {
@@ -37,7 +50,8 @@ bool get_item_data(JsonDocument& doc,
 }
 
 esp_err_t handle_config_item_list(httpd_req_t* req) {
-  ESP_LOGI("ConfigHandler", "GET request to URL %s", req->uri);
+  ESP_LOGI("ConfigHandler", "GET request to URL %.*s", uri_path_len(req->uri),
+           req->uri);
   String url = String(req->uri);
   String query = "";
   if (url.indexOf('?') != -1) {
@@ -88,7 +102,8 @@ void add_config_list_handler(std::shared_ptr<HTTPServer>& server) {
 void add_config_get_handler(std::shared_ptr<HTTPServer>& server) {
   auto handler = std::make_shared<HTTPRequestHandler>(
       1 << HTTP_GET, "/api/config/*", [](httpd_req_t* req) {
-        ESP_LOGD("ConfigHandler", "GET request to URL %s", req->uri);
+        ESP_LOGD("ConfigHandler", "GET request to URL %.*s",
+                 uri_path_len(req->uri), req->uri);
         String url_tail = String(req->uri).substring(11);
         String path;
         String query = "";
@@ -132,7 +147,8 @@ void add_config_put_handler(std::shared_ptr<HTTPServer>& server) {
   auto handler = std::make_shared<HTTPRequestHandler>(
       1 << HTTP_PUT, "/api/config/*",
       [](httpd_req_t* req) {  // check that the content type is JSON
-        ESP_LOGI(__FILENAME__, "PUT request to URL %s", req->uri);
+        ESP_LOGI(__FILENAME__, "PUT request to URL %.*s",
+                 uri_path_len(req->uri), req->uri);
         if (get_content_type(req) != "application/json") {
           httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
                               "application/json content type expected");


### PR DESCRIPTION
## Why

Since #984, captured log lines are served over HTTP at `/api/log`, and the web server is unauthenticated by default. That turns the log into network-readable output, so anything logged is potentially exposed.

## What

- **Strip the query string before logging the request URI.** `dispatch_request` logged `req->uri` (including query string) at INFO. No secret-bearing GET parameter exists today, but any future endpoint that carried a token as a query param would echo it into the web-readable log. Now only the path is logged.
- **`/api/log` returns `application/json; charset=utf-8`** so UTF-8 log lines render correctly.
- **Corrected the access-control comment** on the log handler: it claimed `/api/log` is "gated by the global dispatcher auth," but auth is off by default. The comment now states plainly that `/api/log` mirrors the serial log to anyone who can reach the server unless web auth is enabled.

## Deliberately out of scope

The DEBUG payload logs in `signalk_ws_client.cpp` (#987 also mentioned them) carry SK data, not auth tokens, and are DEBUG-level — off in normal builds. Removing them would cost debuggability for no token-exposure benefit, so they're left as-is.

Verified by building `examples/minimal_app.cpp` for `pioarduino_esp32`.

Fixes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)