### PR TITLE
ci: disable fail-fast on build/test matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         device:
           - esp32
@@ -39,6 +40,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         example:
           - examples/minimal_app.cpp


### PR DESCRIPTION
## Why

A transient `esp_websocket_client` 403 from `components.espressif.com` (#973) lands on the SSL-enabled `pioarduino` jobs. Under the default `fail-fast`, one such 403 cancels every other matrix job, so the whole ~10-job matrix has to be re-run. This blocked the v3.4.0 release three times.

## What

Set `strategy.fail-fast: false` on both the `test` and `build` matrices. A 403 now fails only the one affected job; a single rerun clears it instead of re-running everything.

## Scope decision

This is the cheap, no-maintenance mitigation. The fuller fixes from #973 — a job-level retry in `run-ci.sh` and mirroring the component tarball — are deliberately **not** included: PlatformIO already retries the download 5× internally, and an org-hosted mirror carries ongoing sync burden that isn't justified for an intermittent annoyance that a rerun now resolves. #973 will be trimmed to reflect this.

Refs #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)