### PR TITLE
refactor(system): deprecate no-op Startable shim

### DIFF
--- a/src/sensesp/system/startable.h
+++ b/src/sensesp/system/startable.h
@@ -4,10 +4,15 @@
 namespace sensesp {
 
 /**
- * @brief Dummy Startable class for backward compatibility.
+ * @brief No-op Startable shim kept only for source compatibility.
  *
+ * All methods are no-ops: there is no startup ordering or callback dispatch.
+ * Startup is now handled by the event loop, so inheritance from this class
+ * should be removed.
  */
-class Startable {
+class [[deprecated(
+    "Startable is a no-op kept only for source compatibility; remove "
+    "inheritance, startup is handled by the event loop")]] Startable {
  public:
   Startable(int priority = 0) {}
   virtual void start() {}


### PR DESCRIPTION
## Motivation

`src/sensesp/system/startable.h` defines a `Startable` class whose methods are all no-ops: there is no startup ordering, no callback dispatch. Startup is now handled by the event loop, so the class serves no functional purpose and only exists for source compatibility with older code that still inherits from it.

## Approach

Mark the class `[[deprecated(...)]]` with a message explaining it is a no-op kept only for source compatibility and that inheritance should be removed. The class is intentionally **not** removed, preserving source compatibility. A short doc comment is updated to the same effect.

This is a non-breaking change: the project's build flags contain only `-Werror=reorder` (not blanket `-Werror`), and there are no `Startable` inheritors in `src/` or `examples/`, so the new attribute emits no hard errors.

Closes #902