### PR TITLE
fix(builder): move kDefaultSystemInfoSensorPrefix into namespace

### DIFF
--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -10,9 +10,9 @@
 #include "sensesp_app.h"
 #include "sensesp_base_app_builder.h"
 
-constexpr const char* kDefaultSystemInfoSensorPrefix = "sensorDevice.";
-
 namespace sensesp {
+
+constexpr const char* kDefaultSystemInfoSensorPrefix = "sensorDevice.";
 
 /**
  * @brief A class for quickly configuring a SensESP application object before


### PR DESCRIPTION
## Motivation

`kDefaultSystemInfoSensorPrefix` was declared at global scope in `src/sensesp_app_builder.h`, just above `namespace sensesp {`. The `constexpr` already gives it internal linkage, so the original ODR concern was resolved, but the declaration still polluted the global namespace.

## Approach

Move the declaration inside the `sensesp` namespace, immediately after the opening brace. The in-file references (default arguments in the builder methods) remain unqualified and resolve correctly since they live in the same namespace.

**BREAKING CHANGE**: Any downstream code referencing `::kDefaultSystemInfoSensorPrefix` at global scope must now use `sensesp::kDefaultSystemInfoSensorPrefix`. In practice the symbol had internal linkage and was only used inside this header, so external impact is effectively nil.

Closes #911