### PR TITLE
fix(controllers): rename swich_consumer_ typo to switch_consumer_

### DIFF
--- a/examples/smart_switch/remote_switch_example.cpp
+++ b/examples/smart_switch/remote_switch_example.cpp
@@ -103,7 +103,7 @@ void setup() {
   // sent across the Signal K network when the controlling device
   // confirms it has made the change in state.
   auto* sk_listener = new SKValueListener<bool>(sk_path);
-  sk_listener->connect_to(controller->swich_consumer_);
+  sk_listener->connect_to(controller->switch_consumer_);
 }
 
 void loop() { event_loop()->tick(); }

--- a/src/sensesp/controllers/smart_switch_controller.h
+++ b/src/sensesp/controllers/smart_switch_controller.h
@@ -105,7 +105,7 @@ class SmartSwitchController : public ValueProducer<bool>, FileSystemSaveable {
     this->emit(this->is_on_);
   }};
 
-  LambdaConsumer<bool> swich_consumer_{[this](bool value) {
+  LambdaConsumer<bool> switch_consumer_{[this](bool value) {
     this->is_on_ = value;
     this->emit(is_on_);
   }};


### PR DESCRIPTION
## Motivation

The `SmartSwitchController` member `LambdaConsumer<bool> swich_consumer_` contains a typo ("swich"). This makes the public member name misleading and awkward to reference from downstream firmware.

## Approach

Rename the member to `switch_consumer_` and update every reference. A repo-wide grep for `swich` confirms only two occurrences, both now fixed:

- `src/sensesp/controllers/smart_switch_controller.h` (member declaration)
- `examples/smart_switch/remote_switch_example.cpp` (usage via `connect_to`)

No backward-compatibility alias is added, since aliasing a misspelled name is not worthwhile.

**BREAKING CHANGE**: Downstream code that references the public member `SmartSwitchController::swich_consumer_` must update to `switch_consumer_`.

Closes #912