### PR TITLE
fix(ui): warn on StatusPageItem name collision

### DIFF
--- a/src/sensesp/ui/status_page_item.h
+++ b/src/sensesp/ui/status_page_item.h
@@ -51,9 +51,13 @@ class StatusPageItem : public StatusPageItemBase, public ObservableValue<T> {
   StatusPageItem(String name, const T& value, String group, int order)
       : StatusPageItemBase(name, group, order), ObservableValue<T>(value) {
           if (status_page_items_.count(name) > 0) {
-            ESP_LOGW("StatusPageItem", "Duplicate status page item name: %s", name.c_str());
+            ESP_LOGW("StatusPageItem",
+                     "Duplicate status page item name: %s; keeping the first "
+                     "registration and ignoring this one",
+                     name.c_str());
+          } else {
+            status_page_items_[name] = this;
           }
-          status_page_items_[name] = this;
   }
 
   protected:


### PR DESCRIPTION
## Motivation

In `src/sensesp/ui/status_page_item.h`, registering a `StatusPageItem` did `status_page_items_[name] = this;` unconditionally. When two items shared a name, the later one silently overwrote the earlier registration, so the first item's value never appeared on the status page and no diagnostic was emitted.

## Approach

Before inserting, check whether `name` is already a key in `status_page_items_`. On collision, log an `ESP_LOGW` warning naming the colliding `name` and keep the existing (first) registration, ignoring the later item. Only insert when the name is not already present.

Closes #918