### PR TITLE
chore: address dead code and minor code-review findings

### DIFF
--- a/src/sensesp/net/http_authenticator.cpp
+++ b/src/sensesp/net/http_authenticator.cpp
@@ -18,10 +18,10 @@ bool HTTPDigestAuthenticator::authenticate_request(httpd_req_t* req) {
     return true;
   } else if (result == 0) {
     request_authentication(req, false);
-    return 0;
+    return false;
   } else {
     request_authentication(req, true);
-    return 0;
+    return false;
   }
 }
 

--- a/src/sensesp/net/http_server.cpp
+++ b/src/sensesp/net/http_server.cpp
@@ -190,14 +190,13 @@ esp_err_t call_request_dispatcher(httpd_req_t* req) {
 }
 
 String get_content_type(httpd_req_t* req) {
-  if (httpd_req_get_hdr_value_len(req, "Content-Type") != 16) {
+  char content_type[32];
+  if (httpd_req_get_hdr_value_str(req, "Content-Type", content_type,
+                                  sizeof(content_type)) != ESP_OK) {
     ESP_LOGE(__FILENAME__, "Invalid content type");
     return "";
-  } else {
-    char content_type[32];
-    httpd_req_get_hdr_value_str(req, "Content-Type", content_type, 32);
-    return String(content_type);
   }
+  return String(content_type);
 }
 
 }  // namespace sensesp

--- a/src/sensesp/net/web/base_command_handler.cpp
+++ b/src/sensesp/net/web/base_command_handler.cpp
@@ -180,8 +180,6 @@ void add_routes_handlers(std::shared_ptr<HTTPServer>& server) {
   JsonDocument json_doc;
   JsonArray routes_json = json_doc.to<JsonArray>();
 
-  int sz = routes.size();
-
   for (auto it = routes.begin(); it != routes.end(); ++it) {
     routes_json.add(it->as_json());
   }

--- a/src/sensesp/sensors/analog_reader.h
+++ b/src/sensesp/sensors/analog_reader.h
@@ -11,9 +11,6 @@ namespace sensesp {
  * @brief Used by AnalogInput as a hardware abstraction layer
  **/
 class BaseAnalogReader {
- private:
-  int output_scale_;
-
  public:
   virtual float read() = 0;
 };

--- a/src/sensesp/sensors/digital_input.h
+++ b/src/sensesp/sensors/digital_input.h
@@ -54,8 +54,7 @@ class DigitalInputState : public DigitalInput, public Sensor<bool> {
                     String config_path = "")
       : DigitalInput{pin, pin_mode},
         Sensor<bool>(config_path),
-        read_delay_{read_delay},
-        triggered_{false} {
+        read_delay_{read_delay} {
     load();
 
     repeat_event_ = event_loop()->onRepeat(read_delay_,
@@ -70,7 +69,6 @@ class DigitalInputState : public DigitalInput, public Sensor<bool> {
 
  private:
   int read_delay_;
-  bool triggered_;
   reactesp::RepeatEvent* repeat_event_ = nullptr;
   virtual bool to_json(JsonObject& root) override;
   virtual bool from_json(const JsonObject& config) override;

--- a/src/sensesp/system/async_response_handler.h
+++ b/src/sensesp/system/async_response_handler.h
@@ -4,7 +4,6 @@
 #include "sensesp.h"
 
 #include <Arduino.h>
-#include <elapsedMillis.h>
 
 #include "sensesp_base_app.h"
 #include "valueproducer.h"
@@ -45,7 +44,6 @@ class AsyncResponseHandler : public ValueConsumer<bool>,
    */
   void activate() {
     ESP_LOGV("AsyncResponseHandler", "Activating response handler");
-    elapsed_millis_ = 0;
     status_ = AsyncResponseStatus::kPending;
     this->emit(status_);
 
@@ -93,9 +91,7 @@ class AsyncResponseHandler : public ValueConsumer<bool>,
  protected:
   reactesp::DelayEvent* timeout_event_ = nullptr;
   AsyncResponseStatus status_ = AsyncResponseStatus::kReady;
-  String result_message_;
   int timeout_ = 3000;  // Default timeout in ms
-  elapsedMillis elapsed_millis_;
 };
 
 }  // namespace sensesp

--- a/src/sensesp/system/led_blinker.h
+++ b/src/sensesp/system/led_blinker.h
@@ -38,14 +38,11 @@ class BaseBlinker {
    * Flip the LED off and on for `duration` milliseconds.
    */
   void blip(int duration = 20) {
-    // indicator for a blip being in progress
-    static bool blipping = false;
-
     // only allow one blip at a time
-    if (blipping) {
+    if (blipping_) {
       return;
     }
-    blipping = true;
+    blipping_ = true;
 
     bool const orig_state = this->state_;
     this->set_state(false);
@@ -61,10 +58,10 @@ class BaseBlinker {
               if (this->update_counter_ == new_counter) {
                 this->set_state(orig_state);
               }
-              blipping = false;
+              blipping_ = false;
             });
           } else {
-            blipping = false;
+            blipping_ = false;
           }
         });
   }
@@ -95,6 +92,7 @@ class BaseBlinker {
   bool enabled_ = true;
   bool state_ = false;
   int update_counter_ = 0;
+  bool blipping_ = false;
   reactesp::Event* event_ = NULL;
 };
 
@@ -127,9 +125,7 @@ class LEDPattern {
   LEDPattern(const std::vector<LEDPatternFragment>& fragments)
       : fragments_(fragments) {}
   LEDPattern(const std::initializer_list<LEDPatternFragment>& fragments)
-      : fragments_(fragments),
-        current_fragment_idx_(0),
-        fragment_begin_ms_(0) {}
+      : fragments_(fragments) {}
 
   // Assignment operator
   LEDPattern& operator=(const LEDPattern& other) {

--- a/src/sensesp/system/minimal_button.h
+++ b/src/sensesp/system/minimal_button.h
@@ -79,4 +79,4 @@ class MinimalButtonHandler : public BaseButtonHandler {
 
 }  // namespace sensesp
 
-#endif  // SENSESP_SRC_SENSESP_SYSTEM_BASE_BUTTON_H_
+#endif  // SENSESP_SYSTEM_MINIMAL_BUTTON_H_

--- a/src/sensesp/transforms/analogvoltage.h
+++ b/src/sensesp/transforms/analogvoltage.h
@@ -4,9 +4,9 @@
 #include "sensesp/ui/config_item.h"
 #include "transform.h"
 
-constexpr int kMaxAnalogOutput = 4096;
-
 namespace sensesp {
+
+constexpr int kMaxAnalogOutput = 4096;
 
 /**
  * @brief A transform that takes the output of an

--- a/src/sensesp/transforms/voltage_multiplier.h
+++ b/src/sensesp/transforms/voltage_multiplier.h
@@ -32,7 +32,7 @@ class VoltageMultiplier : public FloatTransform {
  public:
   VoltageMultiplier(uint16_t R1, uint16_t R2, const String& config_path = "");
 
-  virtual void set(const float& input);
+  virtual void set(const float& input) override;
 
  private:
   uint16_t R1_{};

--- a/src/sensesp/types/json.h
+++ b/src/sensesp/types/json.h
@@ -26,6 +26,6 @@ struct Converter<std::vector<T> > {
     return result;
   }
 };
-}  // namespace ARDUINOJSON_NAMESPACE
+}  // namespace ArduinoJson
 
 #endif  // SENSESP_SRC_SENSESP_TYPES_JSON_H_

--- a/src/sensesp/types/position.cpp
+++ b/src/sensesp/types/position.cpp
@@ -33,7 +33,7 @@ bool canConvertFromJson(JsonVariantConst src, const Position & /*position*/) {
 }
 
 bool canConvertFromJson(JsonVariantConst src, const ENUVector & /*enu*/) {
-  return src["east"].is<double>() && src["north"].is<double>();
+  return src["east"].is<float>() && src["north"].is<float>();
 }
 
 bool canConvertFromJson(JsonVariantConst src,

--- a/src/sensesp/types/position.h
+++ b/src/sensesp/types/position.h
@@ -40,7 +40,8 @@ struct ENUVector {
   float north;
   float up = kPositionInvalidAltitude;
 
-  ENUVector() : east(kInvalidDouble), north(kInvalidDouble) {}
+  ENUVector()
+      : east(kPositionInvalidAltitude), north(kPositionInvalidAltitude) {}
   ENUVector(float east, float north, float up = kPositionInvalidAltitude)
       : east(east), north(north), up(up) {}
 };
@@ -58,7 +59,9 @@ struct AttitudeVector {
   float yaw;  // heading
 
   AttitudeVector()
-      : roll(kInvalidDouble), pitch(kInvalidDouble), yaw(kInvalidDouble) {}
+      : roll(kPositionInvalidAltitude),
+        pitch(kPositionInvalidAltitude),
+        yaw(kPositionInvalidAltitude) {}
   AttitudeVector(float roll, float pitch, float yaw)
       : roll(roll), pitch(pitch), yaw(yaw) {}
 };


### PR DESCRIPTION
## Motivation

Issue #919 collects ~20 minor code-review findings: dead members/locals, stale comments, a narrowing conversion, a missing `override`, a shared-state bug, and a few correctness/readability nits.

## Approach

Each item was verified against current `main` before acting. Clearly-correct, low-risk fixes were applied; items that were already fixed, no longer present, or that would change behavior in a non-obvious way were skipped (listed below).

### Fixed

- **`system/async_response_handler.h`** — removed unused `result_message_` and `elapsed_millis_` members (and the now-unused `<elapsedMillis.h>` include and `elapsed_millis_ = 0` assignment).
- **`sensors/digital_input.h`** — removed `triggered_` from `DigitalInputState` (initialized but never read/written; `DigitalInputChange` keeps its own).
- **`sensors/analog_reader.h`** — removed unused `output_scale_` from `BaseAnalogReader`.
- **`net/web/base_command_handler.cpp`** — removed unused `int sz = routes.size();`.
- **`types/json.h`** — fixed closing comment `ARDUINOJSON_NAMESPACE` → `ArduinoJson` to match the actual namespace.
- **`types/position.h`** — `ENUVector` and `AttitudeVector` default constructors initialized `float` members from `kInvalidDouble` (a `double`), a narrowing conversion; now use the `float` constant `kPositionInvalidAltitude`. (Both structs share the identical defect, so both were fixed for consistency.)
- **`types/position.cpp`** — `canConvertFromJson(ENUVector)` checked `is<double>()` but the fields are `float`; changed to `is<float>()` to match the fields (and the existing `AttitudeVector` check).
- **`transforms/analogvoltage.h`** — moved `constexpr int kMaxAnalogOutput` inside `namespace sensesp` (it was at global scope; the only use is inside the namespace).
- **`transforms/voltage_multiplier.h`** — added `override` to `set()`.
- **`net/http_authenticator.cpp`** — `authenticate_request()` returns `bool`; changed two `return 0;` to `return false;`.
- **`net/http_server.cpp`** — `get_content_type()` gated on the Content-Type header *length* being exactly 16; now reads the value and returns it (the sole caller already compares the value strictly, so call-site behavior is unchanged while the magic-length check is removed).
- **`system/minimal_button.h`** — fixed stale include-guard closing comment (`..._BASE_BUTTON_H_` → `..._MINIMAL_BUTTON_H_`).
- **`system/led_blinker.h`** — `LEDPattern` initializer-list constructor redundantly re-initialized members that already have in-class initializers; removed for consistency with the vector constructor. Also changed `BaseBlinker::blip()`'s `static bool blipping` to a per-instance member `blipping_` — as a function-local `static` it was shared across all blinker instances, so one LED's in-progress blip would block another's.

### Skipped

- **`system/saveable.cpp` (hash_path in `load()`, "to Json" log message)** — already fixed in current code: `load()` no longer computes `hash_path`, and the log already reads "from Json".
- **`transforms/change_filter.cpp` (custom `absf`)** — already fixed; current code uses `fabsf`.
- **`system/led_blinker.h` `#define max` macro (#909)** — already removed; not touched per instructions.
- **`digital_pcnt_input.cpp` include-guard comment** — not a mismatch: the trailing `#endif  // ESP_ARDUINO_VERSION_MAJOR < 3` correctly labels its `#if`, and the header guard is consistent.
- **`system/local_debug.h` `*ln` macros (double newline with ESP_LOG)** — the `*ln`/`debug*` macros are unused inside SensESP and exist purely as a RemoteDebug/SerialDebug compatibility shim. Dropping `"\n"` is a behavior change to an external-facing compat API for no internal benefit, so left as-is.
- **`net/networking.cpp` static locals in lambda** — the referenced file no longer exists; the equivalent code now lives in `net/wifi_provisioner.cpp` inside `WiFiProvisioner`, which is effectively a singleton (one WiFi provisioner per device), so the "shared across instances" concern does not apply.
- **`ui/ui_controls.h` string-replacement schema generation** — replacing the `{{title}}` template substitution with proper JSON escaping is a non-trivial, behavior-affecting change out of scope for this cleanup.

## Verification

A full PlatformIO build could not be run locally: every environment targets ESP32 and the Arduino framework package is not provisioned in this environment (the build fails in `arduino.py` with `FRAMEWORK_DIR` = None before any compilation, independent of these changes). Relying on CI for the compile check. All changes are localized header/source edits reviewed by hand.

Closes #919