### PR TITLE
fix(transforms): accept threshold config without out_range

### DIFF
--- a/src/sensesp/transforms/threshold.h
+++ b/src/sensesp/transforms/threshold.h
@@ -42,7 +42,7 @@ class ThresholdTransform : public Transform<C, bool> {
   }
 
   bool from_json(const JsonObject& root) override {
-    String expected[] = {"min", "max", "in_range", "out_range"};
+    String expected[] = {"min", "max", "in_range"};
     for (auto str : expected) {
 
       if (!root[str].is<JsonVariant>()) {

--- a/src/sensesp/transforms/threshold.h
+++ b/src/sensesp/transforms/threshold.h
@@ -14,9 +14,8 @@ namespace sensesp {
  *   @param max_value Maximum value of input for output to be the value of
  * in_range.
  *
- *   @param in_range Output value if input value is in range.
- *
- *   @param out_range Output value if input value is out of the range.
+ *   @param in_range Output value if input value is in range. The output is
+ * the negation of this value when the input is out of range.
  */
 template <typename C>
 class ThresholdTransform : public Transform<C, bool> {

--- a/test/system/test_threshold_roundtrip/threshold_roundtrip_test.cpp
+++ b/test/system/test_threshold_roundtrip/threshold_roundtrip_test.cpp
@@ -1,0 +1,66 @@
+/**
+ * @file threshold_roundtrip_test.cpp
+ * @brief Round-trip and validation tests for ThresholdTransform JSON config.
+ *
+ * Regression coverage for the from_json/to_json asymmetry: to_json writes
+ * {min, max, in_range}, so from_json must require exactly those keys. It
+ * previously also required "out_range", which to_json never emits, so a
+ * saved threshold config could never be reloaded.
+ */
+
+#include <Arduino.h>
+
+#include "sensesp/system/lambda_consumer.h"
+#include "sensesp/transforms/threshold.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+void test_float_threshold_round_trip_preserves_behavior() {
+  FloatThreshold original(10.0f, 20.0f, true);
+
+  JsonDocument doc;
+  JsonObject obj = doc.to<JsonObject>();
+  TEST_ASSERT_TRUE(original.to_json(obj));
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 10.0f, obj["min"].as<float>());
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 20.0f, obj["max"].as<float>());
+  TEST_ASSERT_TRUE(obj["in_range"].as<bool>());
+
+  FloatThreshold restored(0.0f, 0.0f, false);
+  JsonObject in = doc.as<JsonObject>();
+  TEST_ASSERT_TRUE(restored.from_json(in));
+
+  bool received = false;
+  LambdaConsumer<bool> consumer([&received](bool v) { received = v; });
+  restored.connect_to(&consumer);
+
+  restored.set(15.0f);  // in range -> in_range value (true)
+  TEST_ASSERT_TRUE(received);
+
+  restored.set(25.0f);  // out of range -> !in_range (false)
+  TEST_ASSERT_FALSE(received);
+}
+
+void test_threshold_from_json_rejects_missing_required_key() {
+  FloatThreshold threshold(0.0f, 0.0f, true);
+
+  JsonDocument doc;
+  doc["min"] = 1.0f;
+  doc["max"] = 2.0f;
+  // "in_range" intentionally missing
+  JsonObject in = doc.as<JsonObject>();
+  TEST_ASSERT_FALSE(threshold.from_json(in));
+}
+
+void setup() {
+  delay(2000);
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_float_threshold_round_trip_preserves_behavior);
+  RUN_TEST(test_threshold_from_json_rejects_missing_required_key);
+
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Bug

`ThresholdTransform::from_json` required an `out_range` key, but `to_json` only writes `{min, max, in_range}` — and the class doesn't even store `out_range` (out-of-range output is derived as `!in_range_`). As a result, **a saved threshold configuration could never be reloaded**: `from_json` always returned `false`, leaving the transform on its constructor defaults after a restart.

## Fix

Require only the keys `to_json` actually emits: `{min, max, in_range}`. Save→load now round-trips.

## Tests

New suite `test/system/test_threshold_roundtrip/`:
- round-trip of a `FloatThreshold` config preserves behavior (in-range → `in_range`, out-of-range → `!in_range`);
- `from_json` still rejects input missing a required key.

Note: as with the rest of the suite, CI only *compiles* tests (`pio test --without-testing`); these assertions must be executed on a device to confirm they pass at runtime.

Discovered while implementing the #920 test coverage.