### PR TITLE
fix(transforms): apply MovingAverage multiplier to the output

### DIFF
--- a/src/sensesp/transforms/moving_average.cpp
+++ b/src/sensesp/transforms/moving_average.cpp
@@ -17,21 +17,19 @@ MovingAverage::MovingAverage(int sample_size, float multiplier,
 }
 
 void MovingAverage::set(const float& input) {
-  // So the first value to be included in the average doesn't default to 0.0
   if (!initialized_) {
+    // Seed the whole buffer with the first value so the average doesn't start
+    // out diluted by zeros.
     buf_.assign(sample_size_, input);
-    output_ = input;
+    sum_ = static_cast<float>(sample_size_) * input;
     initialized_ = true;
   } else {
-    // Subtract 1/nth of the oldest value and add 1/nth of the newest value
-    output_ += -multiplier_ * buf_[ptr_] / sample_size_;
-    output_ += multiplier_ * input / sample_size_;
-
-    // Save the most recent input, then advance to the next storage location.
-    // When storage location n is reached, start over again at 0.
+    // Swap the oldest buffered value out of the running sum for the newest.
+    sum_ += input - buf_[ptr_];
     buf_[ptr_] = input;
     ptr_ = (ptr_ + 1) % sample_size_;
   }
+  output_ = multiplier_ * sum_ / sample_size_;
   notify();
 }
 

--- a/src/sensesp/transforms/moving_average.h
+++ b/src/sensesp/transforms/moving_average.h
@@ -44,6 +44,7 @@ class MovingAverage : public FloatTransform {
   int ptr_ = 0;
   int sample_size_;
   float multiplier_;
+  float sum_ = 0;
   bool initialized_;
 };
 

--- a/test/system/test_moving_average_multiplier/moving_average_multiplier_test.cpp
+++ b/test/system/test_moving_average_multiplier/moving_average_multiplier_test.cpp
@@ -1,0 +1,89 @@
+/**
+ * @file moving_average_multiplier_test.cpp
+ * @brief Regression tests for MovingAverage's multiplier (#1003).
+ *
+ * The documented contract is y = multiplier * (1/n) * sum(last n inputs):
+ * the multiplier scales the averaged output, including the seeded first
+ * sample and a steady input stream.
+ */
+
+#include <Arduino.h>
+
+#include "sensesp/system/lambda_consumer.h"
+#include "sensesp/transforms/moving_average.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+void test_multiplier_scales_seeded_first_sample() {
+  MovingAverage ma(2, 2.0);  // output = 2.0 * mean
+
+  float received = -1.0f;
+  LambdaConsumer<float> consumer([&received](float v) { received = v; });
+  ma.connect_to(&consumer);
+
+  // First sample seeds the whole buffer (mean == input), scaled by 2.0.
+  ma.set(10.0f);
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 20.0f, received);
+}
+
+void test_multiplier_applies_to_steady_input() {
+  MovingAverage ma(4, 3.0);  // output = 3.0 * mean
+
+  float received = -1.0f;
+  LambdaConsumer<float> consumer([&received](float v) { received = v; });
+  ma.connect_to(&consumer);
+
+  // A constant input of 5.0 has mean 5.0; the multiplier must still apply.
+  for (int i = 0; i < 6; i++) {
+    ma.set(5.0f);
+  }
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 15.0f, received);
+}
+
+void test_multiplier_tracks_windowed_mean() {
+  MovingAverage ma(2, 2.0);
+
+  float received = -1.0f;
+  LambdaConsumer<float> consumer([&received](float v) { received = v; });
+  ma.connect_to(&consumer);
+
+  ma.set(10.0f);  // buffer [10,10], mean 10 -> 20
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 20.0f, received);
+
+  ma.set(20.0f);  // buffer [20,10], mean 15 -> 30
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 30.0f, received);
+
+  ma.set(30.0f);  // buffer [20,30], mean 25 -> 50
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 50.0f, received);
+}
+
+void test_default_multiplier_is_plain_average() {
+  MovingAverage ma(4, 1.0);
+
+  float received = -1.0f;
+  LambdaConsumer<float> consumer([&received](float v) { received = v; });
+  ma.connect_to(&consumer);
+
+  // Buffer initializes to all 4.0; push three 8.0s: (8+8+8+4)/4 = 7.0.
+  ma.set(4.0f);
+  ma.set(8.0f);
+  ma.set(8.0f);
+  ma.set(8.0f);
+  TEST_ASSERT_FLOAT_WITHIN(0.0001f, 7.0f, received);
+}
+
+void setup() {
+  delay(2000);
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_multiplier_scales_seeded_first_sample);
+  RUN_TEST(test_multiplier_applies_to_steady_input);
+  RUN_TEST(test_multiplier_tracks_windowed_mean);
+  RUN_TEST(test_default_multiplier_is_plain_average);
+
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Bug

`MovingAverage`'s documented contract is `y = multiplier * (1/n) * Σx` ("Moving average will be multiplied by multiplier before it is output"). The implementation didn't honor it:

- the seeded first sample was emitted unscaled (`output_ = input`);
- subsequent updates applied the multiplier to the *incremental delta* (`±multiplier * value / n`), so for a steady input the multiplier cancelled entirely and only affected the transient.

`multiplier = 1` (the default) behaved correctly as a plain moving average, but any `multiplier ≠ 1` — e.g. the `scale` used in the fuel-level and milone-level examples — produced wrong output.

## Fix

Maintain a running `sum_` of the buffered samples and compute `output_ = multiplier_ * sum_ / sample_size_` on every sample, including the seeded first one. This matches the documented formula exactly.

## Tests

New `test/system/test_moving_average_multiplier/`:
- multiplier scales the seeded first sample;
- multiplier applies to a steady input stream (the case that previously cancelled);
- output tracks `multiplier × windowed mean` across several samples;
- `multiplier = 1` is still a plain moving average.

Compile-verified locally with `pio test --without-uploading --without-testing -e arduino_esp32` (passes). As with the rest of the suite, CI compiles tests but does not execute them; assertions were traced against the new logic and should be run on a device to confirm.

Closes #1003.