### PR TITLE
fix(transforms): avoid NaN at CurveInterpolator's lowest sample point

### DIFF
--- a/src/sensesp/transforms/curveinterpolator.cpp
+++ b/src/sensesp/transforms/curveinterpolator.cpp
@@ -77,7 +77,13 @@ void CurveInterpolator::set(const float& input) {
   if (it != samples_.end()) {
     float x1 = it->input_;
     float y1 = it->output_;
-    output_ = (y0 * (x1 - input) + y1 * (input - x0)) / (x1 - x0);
+    if (x1 == x0) {
+      // Exact hit on a sample point (e.g. the lowest one, where the search
+      // never advances past begin()) — avoid a zero-width interval divide.
+      output_ = y1;
+    } else {
+      output_ = (y0 * (x1 - input) + y1 * (input - x0)) / (x1 - x0);
+    }
   } else {
     // Hit the end of the table with no match, calculate output using the
     // gradient from the last two points


### PR DESCRIPTION
## Bug

`CurveInterpolator::set(x)` returns **NaN** when `x` equals the smallest sample's input. The interval search starts at `begin()` and only advances while `input > it->input_`, so at the lowest point it never advances: `x0` and `x1` both reference that same sample, and the interpolation `(…)/(x1 - x0)` divides by zero.

## Fix

Guard the zero-width interval: when `x1 == x0`, output the sample's `y` directly.

## How it was found

Surfaced by **executing** the test suite on a HALMET device (`test_curve_interpolator_exact_sample_points` — "Expected 0 Was nan"). CI only compiles the Unity suites (`pio test --without-testing`), so it never caught this. The existing test in `test_transforms` covers the fix; it passes on-device after this change.