### PR TITLE
test: assert TaskQueueProducer burst keeps newest values

### DIFF
--- a/test/system/test_task_queue_producer/task_queue_producer_test.cpp
+++ b/test/system/test_task_queue_producer/task_queue_producer_test.cpp
@@ -300,17 +300,21 @@ void test_task_queue_producer_burst() {
   TaskHandle_t task_handle;
   xTaskCreate(tqp_burst_producer_task, "burst", 4096, &ctx, 1, &task_handle);
 
-  unsigned long start = millis();
-  while (received_count < kTQPCount && millis() - start < 5000) {
-    event_loop->tick();
-    vTaskDelay(1);
-  }
-
+  // Let the burst finish before draining: the event loop is not ticked while
+  // we block here, so all kTQPCount values are pushed into the bounded queue
+  // first. SafeQueue evicts the oldest on overflow, so only the most recent
+  // values survive.
   xSemaphoreTake(ctx.done, pdMS_TO_TICKS(2000));
 
-  TEST_ASSERT_EQUAL(kTQPCount, received_count);
-  for (int i = 0; i < kTQPCount; i++) {
-    TEST_ASSERT_EQUAL(i, received_values[i]);
+  event_loop->tick();  // drain the survivors to the consumer
+
+  // The survivors are the newest values: a contiguous, in-order suffix ending
+  // at the last value pushed (kTQPCount - 1).
+  TEST_ASSERT_GREATER_THAN(0, received_count);
+  TEST_ASSERT_LESS_OR_EQUAL(kTQPCount, received_count);
+  TEST_ASSERT_EQUAL(kTQPCount - 1, received_values[received_count - 1]);
+  for (int i = 0; i < received_count; i++) {
+    TEST_ASSERT_EQUAL(kTQPCount - received_count + i, received_values[i]);
   }
 
   vSemaphoreDelete(ctx.done);


### PR DESCRIPTION
## Problem

`test_task_queue_producer_burst` asserted that a no-yield burst of 50 values is delivered losslessly and in order. But `SafeQueue` is **intentionally bounded** (default capacity 10) and **evicts the oldest** on overflow (it logs "Queue full, dropping oldest entry"). So the test's expectation contradicts the queue's documented contract — it's a test bug, not a product bug (confirmed with the maintainer).

## Fix

Rewrite the assertion to match the lossy-bounded contract: let the burst complete **without draining** (the event loop isn't ticked while blocked on the producer's done semaphore), then drain once and assert the survivors are the newest contiguous, in-order suffix ending at the last value pushed. This avoids the producer/consumer race and doesn't hardcode the capacity.

## How it was found

On-device execution (`test_task_queue_producer_burst` — "Expected 50 Was 10"); compile-only CI never ran it. Passes on-device after this change.