### PR TITLE
ci: speed up workflow (trigger, cache, example matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: SensESP CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -24,7 +31,9 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
-          key: ${{ runner.os }}-pio
+          key: ${{ runner.os }}-pio-${{ matrix.platform }}-${{ matrix.device }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-${{ matrix.platform }}-${{ matrix.device }}-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -46,18 +55,10 @@ jobs:
           - examples/minimal_app.cpp
           - examples/rpm_counter.cpp
           - examples/ssl_connection.cpp
+        platform:
+          - pioarduino
         device:
           - esp32
-          - esp32c3
-        platform:
-          - arduino
-          - pioarduino
-        exclude:
-          - platform: arduino
-            device: esp32c3
-          # SSL example requires pioarduino (SENSESP_SSL_SUPPORT)
-          - platform: arduino
-            example: examples/ssl_connection.cpp
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4
@@ -65,7 +66,9 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
-          key: ${{ runner.os }}-pio
+          key: ${{ runner.os }}-pio-build-${{ matrix.platform }}-${{ matrix.device }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-build-${{ matrix.platform }}-${{ matrix.device }}-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"


### PR DESCRIPTION
## Why

CI feedback was slow and wasted runner minutes. Three independent problems compounded:

1. **Double-trigger** — `on: [push, pull_request]` ran the full matrix twice for any branch with an open PR.
2. **Broken cache key** — `key: ${{ runner.os }}-pio` was static. `actions/cache` only writes a new entry on a key miss, so the entry was written once and never updated; any toolchain or `lib_deps` change then forced every job to re-download the large ESP32 toolchains. The single key was also shared across all matrix cells (arduino/pioarduino, esp32/esp32c3 — different toolchains), so cells thrashed one entry.
3. **Redundant example fan-out** — the `build` job built 3 examples × device × platform (8 cells). Both jobs are compile-only, and the `test` job already exercises cross-platform portability, so the fan-out mostly re-proved it.

## How

- **Trigger:** `push` restricted to `main`, `pull_request` unfiltered. PRs build once; post-merge `main` pushes still run. Added a workflow-level `concurrency` group with `cancel-in-progress` so a newer push cancels the older run.
- **Cache:** per-cell key including `${{ matrix.platform }}`, `${{ matrix.device }}`, and `hashFiles('platformio.ini')`, with a `restore-keys` fallback. Each cell gets its own entry that refreshes when dependencies change.
- **Example matrix:** collapsed to one env per curated example (`minimal_app`, `rpm_counter`, `ssl_connection`) on `pioarduino_esp32` — the project default env, which also satisfies the ssl example's `SENSESP_SSL_SUPPORT` requirement. Drops 8 build cells to 3.

The `test` job keeps its 3-platform/device matrix unchanged — that's the real portability signal now that unit tests exist (compiled, not run, in CI).

## Tradeoffs

- Dropping arduino-platform example builds loses arduino-specific *example* compile coverage. The `test` job still compiles the framework on `arduino_esp32`, so framework portability is unaffected; example-specific arduino breakage is unlikely and low-impact.
- Branch pushes without an open PR no longer trigger CI on origin — standard GitHub flow; coverage resumes when the PR opens.

Closes #1008, closes #1009, closes #1010, closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)
