### PR TITLE
fix(log): make the web log viewer work with ANSI log colors enabled

### DIFF
--- a/src/sensesp/system/log_buffer.cpp
+++ b/src/sensesp/system/log_buffer.cpp
@@ -69,6 +69,39 @@ int LogBuffer::vprintf_trampoline(const char* format, va_list args) {
   return ret;
 }
 
+namespace {
+// Copy text with ANSI/VT100 escape sequences removed. ESP_LOG wraps each line
+// in color codes when CONFIG_LOG_COLORS is enabled; the raw ESC byte (0x1b) is
+// a control character that ArduinoJson does not escape, so it would otherwise
+// reach the /api/log response unescaped and make the JSON unparseable in the
+// browser. A CSI sequence is ESC '[' then parameter/intermediate bytes up to a
+// final byte in 0x40-0x7e; a lone ESC is simply dropped.
+std::string strip_ansi(const char* text, size_t length) {
+  std::string out;
+  out.reserve(length);
+  size_t i = 0;
+  while (i < length) {
+    if (text[i] == '\x1b') {
+      i++;  // drop ESC
+      if (i < length && text[i] == '[') {
+        i++;  // drop '['
+        while (i < length) {
+          unsigned char c = static_cast<unsigned char>(text[i]);
+          i++;
+          if (c >= 0x40 && c <= 0x7e) {
+            break;  // final byte, end of sequence
+          }
+        }
+      }
+      continue;
+    }
+    out.push_back(text[i]);
+    i++;
+  }
+  return out;
+}
+}  // namespace
+
 void LogBuffer::push_line(const char* text, size_t length, uint32_t now_ms) {
   // Strip trailing CR/LF so each record is one display line.
   while (length > 0 && (text[length - 1] == '\n' || text[length - 1] == '\r')) {
@@ -77,13 +110,20 @@ void LogBuffer::push_line(const char* text, size_t length, uint32_t now_ms) {
   if (length == 0) {
     return;
   }
-  if (length > max_line_length_) {
-    length = max_line_length_;
+
+  // Remove ANSI color escapes so the buffered copy served over /api/log is
+  // plain, JSON-safe text. The console output above keeps its colors.
+  std::string line = strip_ansi(text, length);
+  if (line.empty()) {
+    return;
+  }
+  if (line.size() > max_line_length_) {
+    line.resize(max_line_length_);
   }
 
   xSemaphoreTake(mutex_, portMAX_DELAY);
   prune_locked(now_ms);
-  records_.push_back({next_seq_, now_ms, std::string(text, length)});
+  records_.push_back({next_seq_, now_ms, std::move(line)});
   next_seq_++;
   // Enforce the count cap after inserting the new record.
   while (records_.size() > max_lines_) {

--- a/src/sensesp/system/log_buffer.cpp
+++ b/src/sensesp/system/log_buffer.cpp
@@ -54,6 +54,9 @@ int LogBuffer::vprintf_trampoline(const char* format, va_list args) {
   // mutex, which is illegal in interrupt context. UART output already happened
   // above, so an ISR-context line is forwarded but not captured.
   if (inst != nullptr && !xPortInIsrContext()) {
+    // This buffer bounds the captured line length; LogBuffer's default
+    // max_line_length is sized to match it. Raising one without the other has
+    // no effect past the smaller of the two.
     char buf[256];
     va_list copy;
     va_copy(copy, args);

--- a/src/sensesp/system/log_buffer.h
+++ b/src/sensesp/system/log_buffer.h
@@ -58,6 +58,9 @@ struct LogSnapshot {
  */
 class LogBuffer {
  public:
+  // max_line_length defaults to 256 to match the capture buffer in
+  // vprintf_trampoline(); a larger value cannot recover more than that buffer
+  // already captured.
   explicit LogBuffer(size_t max_lines = 200, uint32_t max_age_ms = 2000,
                      size_t max_line_length = 256);
 

--- a/src/sensesp/system/log_buffer.h
+++ b/src/sensesp/system/log_buffer.h
@@ -59,7 +59,7 @@ struct LogSnapshot {
 class LogBuffer {
  public:
   explicit LogBuffer(size_t max_lines = 200, uint32_t max_age_ms = 2000,
-                     size_t max_line_length = 128);
+                     size_t max_line_length = 256);
 
   /**
    * @brief Install the chained vprintf hook. Call once, early in startup.

--- a/test/system/test_log_buffer/log_buffer_test.cpp
+++ b/test/system/test_log_buffer/log_buffer_test.cpp
@@ -204,6 +204,75 @@ void test_session_id_stable_across_calls() {
 }
 
 // ---------------------------------------------------------------------------
+// ANSI escape stripping
+// ---------------------------------------------------------------------------
+
+void test_ansi_color_sequence_stripped() {
+  LogBuffer buf(200, 2000, 128);
+  push(buf, "\033[0;32mINFO: ready\033[0m", 10);
+  LogSnapshot snap = buf.snapshot_since(0, false, 10);
+  TEST_ASSERT_EQUAL(1, snap.lines.size());
+  TEST_ASSERT_EQUAL_STRING("INFO: ready", snap.lines[0].c_str());
+}
+
+void test_ansi_escape_only_line_dropped() {
+  LogBuffer buf(200, 2000, 128);
+  push(buf, "\033[0;32m\033[0m", 10);  // color codes with no payload
+  LogSnapshot snap = buf.snapshot_since(0, false, 10);
+  TEST_ASSERT_EQUAL(0, snap.lines.size());
+  TEST_ASSERT_EQUAL(0, snap.next);  // empty after stripping does not advance
+}
+
+void test_ansi_lone_trailing_esc_removed() {
+  LogBuffer buf(200, 2000, 128);
+  push(buf, "abc\033", 10);
+  LogSnapshot snap = buf.snapshot_since(0, false, 10);
+  TEST_ASSERT_EQUAL(1, snap.lines.size());
+  TEST_ASSERT_EQUAL_STRING("abc", snap.lines[0].c_str());
+}
+
+void test_ansi_truncated_csi_consumed() {
+  // A CSI cut off before its final byte -- e.g. the upstream 256-byte capture
+  // split a color sequence -- is consumed to end of input, leaving no ESC.
+  LogBuffer buf(200, 2000, 128);
+  push(buf, "abc\033[", 10);   // seq 0: bare CSI introducer
+  push(buf, "def\033[0", 10);  // seq 1: CSI with a parameter, no final byte
+  LogSnapshot snap = buf.snapshot_since(0, false, 10);
+  TEST_ASSERT_EQUAL(2, snap.lines.size());
+  TEST_ASSERT_EQUAL_STRING("abc", snap.lines[0].c_str());
+  TEST_ASSERT_EQUAL_STRING("def", snap.lines[1].c_str());
+}
+
+void test_ansi_lone_esc_keeps_following_byte() {
+  // A bare ESC not followed by '[' drops only the ESC, not the next byte.
+  LogBuffer buf(200, 2000, 128);
+  push(buf, "a\033Zb", 10);
+  LogSnapshot snap = buf.snapshot_since(0, false, 10);
+  TEST_ASSERT_EQUAL(1, snap.lines.size());
+  TEST_ASSERT_EQUAL_STRING("aZb", snap.lines[0].c_str());
+}
+
+void test_ansi_literal_bracket_preserved() {
+  // A '[' not preceded by ESC is ordinary content (Signal K delta JSON is full
+  // of them) and must survive untouched.
+  LogBuffer buf(200, 2000, 128);
+  push(buf, "[boot] values:[1,2]", 10);
+  LogSnapshot snap = buf.snapshot_since(0, false, 10);
+  TEST_ASSERT_EQUAL(1, snap.lines.size());
+  TEST_ASSERT_EQUAL_STRING("[boot] values:[1,2]", snap.lines[0].c_str());
+}
+
+void test_ansi_no_esc_byte_survives() {
+  // The invariant that keeps /api/log valid JSON: no raw ESC (0x1b) is stored.
+  LogBuffer buf(200, 2000, 128);
+  push(buf, "\033[31mA\033[0mB\033[32mC\033[0m", 10);
+  LogSnapshot snap = buf.snapshot_since(0, false, 10);
+  TEST_ASSERT_EQUAL(1, snap.lines.size());
+  TEST_ASSERT_EQUAL_STRING("ABC", snap.lines[0].c_str());
+  TEST_ASSERT_TRUE(snap.lines[0].find('\x1b') == std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
 // Test runner
 // ---------------------------------------------------------------------------
 
@@ -227,6 +296,14 @@ void setup() {
   RUN_TEST(test_post_reboot_stale_cursor_no_gap);
   RUN_TEST(test_prune_keeps_lines_when_now_before_timestamp);
   RUN_TEST(test_bare_newline_dropped);
+
+  RUN_TEST(test_ansi_color_sequence_stripped);
+  RUN_TEST(test_ansi_escape_only_line_dropped);
+  RUN_TEST(test_ansi_lone_trailing_esc_removed);
+  RUN_TEST(test_ansi_truncated_csi_consumed);
+  RUN_TEST(test_ansi_lone_esc_keeps_following_byte);
+  RUN_TEST(test_ansi_literal_bracket_preserved);
+  RUN_TEST(test_ansi_no_esc_byte_survives);
 
   RUN_TEST(test_session_id_stable_across_calls);
 


### PR DESCRIPTION
## Problem

The web log viewer (`/api/log` and the `/log` page) breaks on any build with `CONFIG_LOG_COLORS` enabled — the ESP-IDF default. (The precompiled Arduino framework ships with colors off, so this only surfaces on espidf-framework builds.) Two issues:

1. **Invalid JSON.** `ESP_LOG` wraps each line in ANSI color sequences. `LogBuffer` captured the raw ESC byte (`0x1b`), which ArduinoJson does not escape, so `/api/log` returned a body with a raw control character. The browser receives HTTP 200 but `response.json()` throws on every poll, so the viewer shows a permanent "Reconnecting…".
2. **Truncation.** Lines were capped at 128 chars even though the capture buffer is already 256, clipping most log lines.

## Approach

1. Strip ANSI escape sequences in `LogBuffer::push_line()`, which stores the buffered/served copy. The console output is forwarded to the previous `vprintf` handler *before* `push_line()` runs, so serial log colors are unaffected.
2. Raise the default `max_line_length` from 128 to 256 to match the existing 256-byte capture buffer. The 2-second age window (`max_age_ms`) bounds retained volume, so the added worst-case RAM is small.

## Verification

On an ESP32-C3 espidf build with `CONFIG_LOG_COLORS=y`:
- `/api/log` returns valid JSON — 0 raw `0x1b` bytes (was 7).
- The serial console keeps its colors (ESC bytes still present in the UART/USB stream).
- Lines now show up to 255 chars; 17 of 23 captured lines exceeded the old 128 limit.

Lines longer than the 256-byte capture buffer (e.g. verbose Signal K delta dumps) still clip at 255 — raising that would need a larger capture buffer and is left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)