### PR TITLE
fix(types): make Nullable<bool> a compile error (#883)

### DIFF
--- a/src/sensesp/types/nullable.cpp
+++ b/src/sensesp/types/nullable.cpp
@@ -36,8 +36,5 @@ uint64_t Nullable<uint64_t>::invalid_value_ = 0xffffffffffffffffLL;
 template <>
 int64_t Nullable<int64_t>::invalid_value_ = 0x7fffffffffffffffLL;
 
-template <>
-bool Nullable<bool>::invalid_value_ = false;
-
 
 }  // namespace sensesp

--- a/src/sensesp/types/nullable.h
+++ b/src/sensesp/types/nullable.h
@@ -1,6 +1,8 @@
 #ifndef SENSESP_SRC_SENSESP_TYPES_NULLABLE_H_
 #define SENSESP_SRC_SENSESP_TYPES_NULLABLE_H_
 
+#include <type_traits>
+
 #include "ArduinoJson.h"
 
 namespace sensesp {
@@ -13,9 +15,19 @@ namespace sensesp {
  * value is invalid only when it equals that sentinel. A default-constructed
  * Nullable holds T{} (0), so it is valid for types whose sentinel differs from
  * 0; use Nullable<T>::invalid() to obtain the invalid value explicitly.
+ *
+ * Nullable<bool> is intentionally unsupported: bool has only two values, so
+ * there is no spare bit pattern to reserve as an invalid sentinel without
+ * making one of `true`/`false` indistinguishable from "missing". Use a plain
+ * bool, or a wider type if you need a distinct invalid state.
  */
 template <typename T>
 class Nullable {
+  static_assert(
+      !std::is_same<T, bool>::value,
+      "Nullable<bool> is not supported: bool has no spare sentinel value. Use a "
+      "plain bool, or a wider type if a distinct invalid state is needed.");
+
   public:
     Nullable() : value_{} {}
     Nullable(T value) : value_{value} {}
@@ -55,7 +67,6 @@ class Nullable {
 typedef Nullable<int> NullableInt;
 typedef Nullable<float> NullableFloat;
 typedef Nullable<double> NullableDouble;
-typedef Nullable<bool> NullableBool;
 
 template <typename T>
 void convertFromJson(JsonVariantConst src, Nullable<T> &dst) {

--- a/test/system/test_nullable/nullable_test.cpp
+++ b/test/system/test_nullable/nullable_test.cpp
@@ -9,7 +9,8 @@
  * sentinel (e.g. float -> -1e9, uint8_t -> 0xff). A value is "invalid" only
  * when it equals that sentinel. A default-constructed Nullable holds T{} (0),
  * which is therefore VALID for types whose sentinel differs from 0 (int,
- * float, uint8_t) and INVALID only for bool, whose sentinel is false.
+ * float, uint8_t). Nullable<bool> is unsupported and fails to compile (bool
+ * has no spare sentinel value); see #883.
  */
 
 #include <Arduino.h>
@@ -55,20 +56,6 @@ void test_nullable_default_float_is_valid_zero() {
   NullableFloat n;
   TEST_ASSERT_TRUE(n.is_valid());
   TEST_ASSERT_FLOAT_WITHIN(0.0001f, 0.0f, n.value());
-}
-
-void test_nullable_bool_sentinel_is_false() {
-  // bool's invalid sentinel is `false`, so a default/false Nullable<bool> is
-  // invalid and a value of `false` is indistinguishable from invalid.
-  NullableBool d;
-  TEST_ASSERT_FALSE(d.is_valid());
-
-  NullableBool t = true;
-  TEST_ASSERT_TRUE(t.is_valid());
-  TEST_ASSERT_TRUE(static_cast<bool>(t));
-
-  NullableBool f = false;
-  TEST_ASSERT_FALSE(f.is_valid());
 }
 
 // ---------------------------------------------------------------------------
@@ -140,7 +127,6 @@ void setup() {
   RUN_TEST(test_nullable_invalid_sentinel_is_not_valid);
   RUN_TEST(test_nullable_value_is_valid);
   RUN_TEST(test_nullable_default_float_is_valid_zero);
-  RUN_TEST(test_nullable_bool_sentinel_is_false);
   RUN_TEST(test_nullable_ptr_mutates_value);
   RUN_TEST(test_nullable_copy_assignment);
   RUN_TEST(test_nullable_to_json_invalid_is_null);


### PR DESCRIPTION
## Motivation

`Nullable<bool>::invalid_value_` was `false`, and `is_valid()` is `value_ != invalid_value_`. So `Nullable<bool>(false)` always read as invalid — `false` was indistinguishable from "missing". bool has no spare bit pattern to reserve as a sentinel, so the type could never work as designed. The `NullableBool` typedef advertised it as usable, which was misleading.

## Approach

- Remove the `NullableBool` typedef and the `Nullable<bool>` specialization.
- Add a `static_assert` so any `Nullable<bool>` instantiation fails to compile with a clear message.
- Update the test that documented the broken behavior.

## Breaking change

Any code referencing `NullableBool` or `Nullable<bool>` stops compiling. This is intentional — it only blocks building something that never worked. Not patch-level; should ride a minor/major bump.

## Verification

Builds clean; `test_nullable` (9 cases) passes on HALMET hardware (pioarduino_esp32).

Closes #883