### PR TITLE
docs(ui): document ConfigItem(T*) ownership contract (#893)

### DIFF
--- a/src/sensesp/ui/config_item.h
+++ b/src/sensesp/ui/config_item.h
@@ -295,7 +295,22 @@ std::shared_ptr<ConfigItemT<T>> ConfigItem(std::shared_ptr<T> config_object) {
   return config_item;
 }
 
-// Unsafe: We don't know whether other shared_ptrs to the same object exist!
+/**
+ * @brief Register a ConfigItemT, transferring ownership of a raw pointer.
+ *
+ * Convenience overload for the `new T(...)` idiom used throughout the
+ * examples. It wraps @p config_object in a `std::shared_ptr` and registers
+ * it, so the configuration registry becomes the sole owner.
+ *
+ * @warning This overload TAKES OWNERSHIP. The caller must pass a pointer that
+ * is not owned by anyone else: allocate it with `new` and never `delete` it,
+ * never wrap it in another `std::shared_ptr`, and never pass a pointer to a
+ * stack or member object. Violating this causes a double free. When in doubt,
+ * use the `std::shared_ptr<T>` overload and keep ownership explicit.
+ *
+ * The raw-pointer ownership model is a v3 carry-over; the planned v4 ownership
+ * refactor (#900) removes it. See #893.
+ */
 template <typename T>
 std::shared_ptr<ConfigItemT<T>> ConfigItem(T* config_object) {
   auto config_object_sptr = std::shared_ptr<T>(config_object);


### PR DESCRIPTION
## Motivation

The raw-pointer `ConfigItem(T*)` overload wraps the pointer in a `shared_ptr`, taking ownership. The old comment just said "Unsafe: We don't know whether other shared_ptrs to the same object exist!" — which understates that this is actually the documented `new X()` → `ConfigItem(ptr)` idiom used throughout the examples. The double-free only occurs when a caller violates the (previously unstated) ownership contract.

## Approach

Replace the vague comment with an explicit contract: the overload takes sole ownership; pass only an unowned `new`'d pointer, never `delete` it, never double-wrap it, never pass a stack/member object.

This is the minimal safe fix for v3. The structural fix (eliminating raw-pointer ownership) is the v4 ownership refactor, tracked in #900 — there's no way to detect double-ownership at runtime, so documentation is the only non-breaking option now.

## Scope

Comment-only; no API or behavior change.

## Merge order

Land before #894: #894 clears the config-item registry in `destroy()`, which makes the ownership contract documented here load-bearing.

Refs #893, #900