### PR TITLE
fix(core): clean up static registries on destruction (#894)

### DIFF
--- a/src/sensesp/signalk/signalk_emitter.cpp
+++ b/src/sensesp/signalk/signalk_emitter.cpp
@@ -1,5 +1,7 @@
 #include "signalk_emitter.h"
 
+#include <algorithm>
+
 namespace sensesp {
 
 std::vector<SKEmitter*> SKEmitter::sources_;
@@ -7,6 +9,13 @@ std::vector<SKEmitter*> SKEmitter::sources_;
 SKEmitter::SKEmitter(const String& sk_path) : sk_path_{sk_path} {
   sources_.push_back(this);
 }
+
+SKEmitter::~SKEmitter() {
+  sources_.erase(std::remove(sources_.begin(), sources_.end(), this),
+                 sources_.end());
+}
+
+void SKEmitter::clear_registry() { sources_.clear(); }
 
 void SKEmitter::add_metadata(JsonArray& meta) {
   SKMetadata* my_meta = this->get_metadata();

--- a/src/sensesp/signalk/signalk_emitter.h
+++ b/src/sensesp/signalk/signalk_emitter.h
@@ -27,6 +27,12 @@ class SKEmitter : virtual public Observable {
   SKEmitter(const String& sk_path);
 
   /**
+   * Unregisters this emitter from the static source registry so the
+   * registry never holds a dangling pointer.
+   */
+  virtual ~SKEmitter();
+
+  /**
    * Returns the data to be reported to the server as
    * a Signal K json object.
    */
@@ -64,6 +70,12 @@ class SKEmitter : virtual public Observable {
   void set_sk_path(const String& path) { sk_path_ = path; }
 
   static const std::vector<SKEmitter*>& get_sources() { return sources_; }
+
+  /**
+   * Empties the source registry. Intended for clean app restart and test
+   * isolation; not for normal runtime use.
+   */
+  static void clear_registry();
 
  protected:
   String sk_path_{};

--- a/src/sensesp/signalk/signalk_listener.cpp
+++ b/src/sensesp/signalk/signalk_listener.cpp
@@ -1,5 +1,7 @@
 #include "signalk_listener.h"
 
+#include <algorithm>
+
 #include "sensesp/system/saveable.h"
 
 namespace sensesp {
@@ -17,6 +19,19 @@ SKListener::SKListener(const String &sk_path, int listen_delay,
       listen_delay{listen_delay} {
   listeners_.push_back(this);
   this->load();
+}
+
+SKListener::~SKListener() {
+  take_semaphore();
+  listeners_.erase(std::remove(listeners_.begin(), listeners_.end(), this),
+                   listeners_.end());
+  release_semaphore();
+}
+
+void SKListener::clear_registry() {
+  take_semaphore();
+  listeners_.clear();
+  release_semaphore();
 }
 
 bool SKListener::take_semaphore(uint64_t timeout_ms) {

--- a/src/sensesp/signalk/signalk_listener.h
+++ b/src/sensesp/signalk/signalk_listener.h
@@ -36,6 +36,13 @@ class SKListener : virtual public Observable, public FileSystemSaveable {
              const String& config_path = "");
 
   /**
+   * Unregisters this listener from the static registry so the registry never
+   * holds a dangling pointer. Takes the listener semaphore because the WS
+   * client task iterates the registry under the same lock.
+   */
+  virtual ~SKListener();
+
+  /**
    * Returns the current Signal K path. An empty string
    * is returned if this particular source is not configured
    * or intended to return actual data.
@@ -65,6 +72,12 @@ class SKListener : virtual public Observable, public FileSystemSaveable {
   virtual void parse_meta(const std::shared_ptr<const JsonDocument>& meta_doc) {}
 
   static const std::vector<SKListener*>& get_listeners() { return listeners_; }
+
+  /**
+   * Empties the listener registry. Intended for clean app restart and test
+   * isolation; not for normal runtime use. Takes the listener semaphore.
+   */
+  static void clear_registry();
 
   static bool take_semaphore(uint64_t timeout_ms = 0);
   static void release_semaphore();

--- a/src/sensesp/signalk/signalk_put_request_listener.cpp
+++ b/src/sensesp/signalk/signalk_put_request_listener.cpp
@@ -1,11 +1,30 @@
 #include "signalk_put_request_listener.h"
 
+#include <algorithm>
+
+#include "signalk_listener.h"
+
 namespace sensesp {
 
 std::vector<SKPutListener*> SKPutListener::listeners_;
 
 SKPutListener::SKPutListener(const String& sk_path) : sk_path{sk_path} {
   listeners_.push_back(this);
+}
+
+SKPutListener::~SKPutListener() {
+  // The WS client iterates this registry while holding the SKListener
+  // semaphore, so mutate it under the same lock.
+  SKListener::take_semaphore();
+  listeners_.erase(std::remove(listeners_.begin(), listeners_.end(), this),
+                   listeners_.end());
+  SKListener::release_semaphore();
+}
+
+void SKPutListener::clear_registry() {
+  SKListener::take_semaphore();
+  listeners_.clear();
+  SKListener::release_semaphore();
 }
 
 }  // namespace sensesp

--- a/src/sensesp/signalk/signalk_put_request_listener.h
+++ b/src/sensesp/signalk/signalk_put_request_listener.h
@@ -26,6 +26,13 @@ class SKPutListener : virtual public Observable {
    */
   SKPutListener(const String& sk_path);
 
+  /**
+   * Unregisters this listener from the static registry so the registry never
+   * holds a dangling pointer. Takes the SKListener semaphore because the WS
+   * client task iterates this registry under that same lock.
+   */
+  virtual ~SKPutListener();
+
   String& get_sk_path() { return sk_path; }
 
   virtual void parse_value(const JsonObject& put) = 0;
@@ -33,6 +40,12 @@ class SKPutListener : virtual public Observable {
   static const std::vector<SKPutListener*>& get_listeners() {
     return listeners_;
   }
+
+  /**
+   * Empties the listener registry. Intended for clean app restart and test
+   * isolation; not for normal runtime use. Takes the SKListener semaphore.
+   */
+  static void clear_registry();
 
  protected:
   String sk_path{};

--- a/src/sensesp/transforms/transform.cpp
+++ b/src/sensesp/transforms/transform.cpp
@@ -17,4 +17,8 @@ TransformBase::TransformBase(const String& config_path)
   transforms_.insert(this);
 }
 
+TransformBase::~TransformBase() { transforms_.erase(this); }
+
+void TransformBase::clear_registry() { transforms_.clear(); }
+
 }  // namespace sensesp

--- a/src/sensesp/transforms/transform.h
+++ b/src/sensesp/transforms/transform.h
@@ -39,8 +39,10 @@ class TransformBase : public FileSystemSaveable {
 
   // The transform registry's original purpose (supplying Signal K sources) is
   // now handled by SKEmitter::get_sources(); nothing in the framework consumes
-  // get_transforms() anymore.
-  [[deprecated("Unused; use SKEmitter::get_sources() instead")]]
+  // get_transforms() anymore. get_sources() is not a drop-in replacement -- it
+  // returns only the Signal K emitters, not the full transform set, for which
+  // there is no equivalent accessor.
+  [[deprecated("Deprecated and unused internally; no direct replacement")]]
   static const std::set<TransformBase*>& get_transforms() {
     return transforms_;
   }

--- a/src/sensesp/transforms/transform.h
+++ b/src/sensesp/transforms/transform.h
@@ -31,12 +31,25 @@ class TransformBase : public FileSystemSaveable {
  public:
   TransformBase(const String& config_path);
 
-  // Primary purpose of this was to supply Signal K sources
-  // (now handled by SKEmitter::get_sources). Should
-  // this be deprecated?
+  /**
+   * Unregisters this transform from the static registry so the registry
+   * never holds a dangling pointer.
+   */
+  virtual ~TransformBase();
+
+  // The transform registry's original purpose (supplying Signal K sources) is
+  // now handled by SKEmitter::get_sources(); nothing in the framework consumes
+  // get_transforms() anymore.
+  [[deprecated("Unused; use SKEmitter::get_sources() instead")]]
   static const std::set<TransformBase*>& get_transforms() {
     return transforms_;
   }
+
+  /**
+   * Empties the transform registry. Intended for clean app restart and test
+   * isolation; not for normal runtime use.
+   */
+  static void clear_registry();
 
  private:
   static std::set<TransformBase*> transforms_;

--- a/src/sensesp/ui/config_item.cpp
+++ b/src/sensesp/ui/config_item.cpp
@@ -4,6 +4,8 @@ namespace sensesp {
 
 std::map<String, std::shared_ptr<ConfigItemBase>> ConfigItemBase::config_items_;
 
+void ConfigItemBase::clear_registry() { config_items_.clear(); }
+
 template <>
 const char* get_schema_type_string(const int /*dummy*/) {
   return "number";

--- a/src/sensesp/ui/config_item.h
+++ b/src/sensesp/ui/config_item.h
@@ -70,6 +70,8 @@ std::shared_ptr<ConfigItemT<T>> ConfigItem(std::shared_ptr<T>);
 class ConfigItemBase
     : virtual public std::enable_shared_from_this<ConfigItemBase> {
  public:
+  virtual ~ConfigItemBase() = default;
+
   const String& get_title() const { return title_; }
   ConfigItemBase* set_title(const String& title) {
     title_ = title;
@@ -160,6 +162,14 @@ class ConfigItemBase
 
     return sorted_config_items;
   }
+
+  /**
+   * @brief Empty the config item registry.
+   *
+   * Releases the registry's shared_ptr references. Intended for clean app
+   * restart and test isolation; not for normal runtime use.
+   */
+  static void clear_registry();
 
   virtual bool load() = 0;
   virtual bool refresh() = 0;

--- a/src/sensesp/ui/config_item.h
+++ b/src/sensesp/ui/config_item.h
@@ -168,6 +168,12 @@ class ConfigItemBase
    *
    * Releases the registry's shared_ptr references. Intended for clean app
    * restart and test isolation; not for normal runtime use.
+   *
+   * Unlike the raw-pointer registries (SKEmitter, Transform, StatusPageItem),
+   * this registry owns its entries via shared_ptr, so there is no
+   * unregister-on-destruction: clearing the map releases the objects. A
+   * self-erasing destructor here would be re-entrant and is deliberately
+   * absent.
    */
   static void clear_registry();
 

--- a/src/sensesp/ui/status_page_item.cpp
+++ b/src/sensesp/ui/status_page_item.cpp
@@ -4,4 +4,16 @@ namespace sensesp {
 
 std::map<String, StatusPageItemBase*> StatusPageItemBase::status_page_items_;
 
+StatusPageItemBase::~StatusPageItemBase() {
+  // Only erase if this item is the one registered under its name. Duplicate
+  // names keep the first registration, so a later duplicate must not remove
+  // the original's entry.
+  auto it = status_page_items_.find(name_);
+  if (it != status_page_items_.end() && it->second == this) {
+    status_page_items_.erase(it);
+  }
+}
+
+void StatusPageItemBase::clear_registry() { status_page_items_.clear(); }
+
 }  // namespace sensesp

--- a/src/sensesp/ui/status_page_item.h
+++ b/src/sensesp/ui/status_page_item.h
@@ -21,6 +21,12 @@ class StatusPageItemBase {
   StatusPageItemBase(String name, String group, int order)
       : name_(name), group_(group), order_(order) {}
 
+  /**
+   * Unregisters this item from the static registry so the registry never
+   * holds a dangling pointer.
+   */
+  virtual ~StatusPageItemBase();
+
   String& get_name() { return name_; }
 
   virtual JsonDocument as_json() = 0;
@@ -28,6 +34,12 @@ class StatusPageItemBase {
   static const std::map<String, StatusPageItemBase*>* get_status_page_items() {
     return &status_page_items_;
   }
+
+  /**
+   * Empties the status page item registry. Intended for clean app restart and
+   * test isolation; not for normal runtime use.
+   */
+  static void clear_registry();
 
  protected:
   String name_;

--- a/src/sensesp/ui/ui_button.cpp
+++ b/src/sensesp/ui/ui_button.cpp
@@ -4,4 +4,6 @@ namespace sensesp {
 
 std::map<String, std::shared_ptr<UIButton>> UIButton::ui_buttons_;
 
+void UIButton::clear_registry() { ui_buttons_.clear(); }
+
 }  // namespace sensesp

--- a/src/sensesp/ui/ui_button.h
+++ b/src/sensesp/ui/ui_button.h
@@ -40,6 +40,10 @@ class UIButton : public Observable {
    *
    * Releases the registry's shared_ptr references. Intended for clean app
    * restart and test isolation; not for normal runtime use.
+   *
+   * Like ConfigItemBase and unlike the raw-pointer registries, this registry
+   * owns its entries via shared_ptr, so there is no unregister-on-destruction:
+   * clearing the map releases the objects.
    */
   static void clear_registry();
 

--- a/src/sensesp/ui/ui_button.h
+++ b/src/sensesp/ui/ui_button.h
@@ -35,6 +35,14 @@ class UIButton : public Observable {
     return new_cmd.get();
   }
 
+  /**
+   * @brief Empty the button registry.
+   *
+   * Releases the registry's shared_ptr references. Intended for clean app
+   * restart and test isolation; not for normal runtime use.
+   */
+  static void clear_registry();
+
  protected:
   String title_;
   String name_;

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -60,18 +60,11 @@ class SensESPApp : public SensESPBaseApp {
   }
 
   virtual bool destroy() override {
-    bool outside_users = instance_.use_count() > 2;
-    if (outside_users) {
-      ESP_LOGW(
-          __FILENAME__,
-          "SensESPApp instance has active references and won't be properly "
-          "destroyed.");
-    }
-    clear_registries();
-    instance_ = nullptr;
-    // Also destroy the global pointer
+    // Drop the global pointer's reference first so the base sees the true
+    // outside-user count, then delegate the shared teardown (registry
+    // clearing, instance reset) to SensESPBaseApp::destroy().
     sensesp_app = nullptr;
-    return !outside_users;
+    return SensESPBaseApp::destroy();
   }
 
   // getters for internal members

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -67,6 +67,7 @@ class SensESPApp : public SensESPBaseApp {
           "SensESPApp instance has active references and won't be properly "
           "destroyed.");
     }
+    clear_registries();
     instance_ = nullptr;
     // Also destroy the global pointer
     sensesp_app = nullptr;

--- a/src/sensesp_base_app.cpp
+++ b/src/sensesp_base_app.cpp
@@ -1,7 +1,24 @@
 #include "sensesp_base_app.h"
 
+#include "sensesp/signalk/signalk_emitter.h"
+#include "sensesp/transforms/transform.h"
+#include "sensesp/ui/config_item.h"
+#include "sensesp/ui/status_page_item.h"
+#include "sensesp/ui/ui_button.h"
+
 namespace sensesp {
 
 std::shared_ptr<SensESPBaseApp> SensESPBaseApp::instance_ = nullptr;
+
+void SensESPBaseApp::clear_registries() {
+  // Release shared_ptr-owning registries first so the objects they own are
+  // destroyed; each object's destructor then unregisters itself from the
+  // raw-pointer registries, which the clears below tidy up.
+  ConfigItemBase::clear_registry();
+  UIButton::clear_registry();
+  SKEmitter::clear_registry();
+  TransformBase::clear_registry();
+  StatusPageItemBase::clear_registry();
+}
 
 }  // namespace sensesp

--- a/src/sensesp_base_app.cpp
+++ b/src/sensesp_base_app.cpp
@@ -1,6 +1,8 @@
 #include "sensesp_base_app.h"
 
 #include "sensesp/signalk/signalk_emitter.h"
+#include "sensesp/signalk/signalk_listener.h"
+#include "sensesp/signalk/signalk_put_request_listener.h"
 #include "sensesp/transforms/transform.h"
 #include "sensesp/ui/config_item.h"
 #include "sensesp/ui/status_page_item.h"
@@ -19,6 +21,8 @@ void SensESPBaseApp::clear_registries() {
   SKEmitter::clear_registry();
   TransformBase::clear_registry();
   StatusPageItemBase::clear_registry();
+  SKListener::clear_registry();
+  SKPutListener::clear_registry();
 }
 
 }  // namespace sensesp

--- a/src/sensesp_base_app.h
+++ b/src/sensesp_base_app.h
@@ -55,6 +55,15 @@ class SensESPBaseApp {
   static const std::shared_ptr<SensESPBaseApp>& get() { return instance_; }
 
   /**
+   * @brief Clear all static object registries.
+   *
+   * Empties the ConfigItem, SKEmitter, Transform, StatusPageItem and UIButton
+   * registries so a subsequent app start (or a test) begins from a clean
+   * slate. Called from destroy().
+   */
+  static void clear_registries();
+
+  /**
    * @brief Destroy the SensESPBaseApp instance
    */
   virtual bool destroy() {
@@ -65,6 +74,7 @@ class SensESPBaseApp {
                "SensESPBaseApp instance has active references and won't be "
                "properly destroyed.");
     }
+    clear_registries();
     instance_ = nullptr;
     return !outside_users;
   }

--- a/src/sensesp_base_app.h
+++ b/src/sensesp_base_app.h
@@ -57,9 +57,10 @@ class SensESPBaseApp {
   /**
    * @brief Clear all static object registries.
    *
-   * Empties the ConfigItem, SKEmitter, Transform, StatusPageItem and UIButton
-   * registries so a subsequent app start (or a test) begins from a clean
-   * slate. Called from destroy().
+   * Empties every static registry (ConfigItem, UIButton, SKEmitter, Transform,
+   * StatusPageItem, SKListener, SKPutListener) so a subsequent app start (or a
+   * test) begins from a clean slate. Called from destroy() only when the app is
+   * actually being torn down.
    */
   static void clear_registries();
 
@@ -73,8 +74,13 @@ class SensESPBaseApp {
       ESP_LOGW(__FILENAME__,
                "SensESPBaseApp instance has active references and won't be "
                "properly destroyed.");
+    } else {
+      // Only clear the registries when the app is actually being torn down.
+      // If outside references survive, the registered objects survive too, and
+      // clearing would strand live objects (they register only in their
+      // constructors, so they would never re-appear).
+      clear_registries();
     }
-    clear_registries();
     instance_ = nullptr;
     return !outside_users;
   }

--- a/test/system/test_registries/registries_test.cpp
+++ b/test/system/test_registries/registries_test.cpp
@@ -17,7 +17,9 @@
 #include <memory>
 
 #include "sensesp/signalk/signalk_emitter.h"
+#include "sensesp/signalk/signalk_listener.h"
 #include "sensesp/signalk/signalk_output.h"
+#include "sensesp/signalk/signalk_put_request_listener.h"
 #include "sensesp/transforms/transform.h"
 #include "sensesp/ui/config_item.h"
 #include "sensesp/ui/status_page_item.h"
@@ -76,23 +78,88 @@ void test_statuspageitem_unregisters_on_destruction() {
   TEST_ASSERT_EQUAL(0, StatusPageItemBase::get_status_page_items()->count(name));
 }
 
+// The registry keeps the FIRST registration for a duplicate name. The destructor
+// must only erase the entry it actually owns, so destroying an ignored duplicate
+// must not strand the first registration.
+void test_statuspageitem_duplicate_name_guard() {
+  const char* name = "RegistryTestDuplicateName";
+  auto* items = StatusPageItemBase::get_status_page_items();
+  TEST_ASSERT_EQUAL(0, items->count(name));
+
+  StatusPageItem<int> first(name, 1, "Test", 1000);
+  TEST_ASSERT_EQUAL(1, items->count(name));
+  StatusPageItemBase* first_ptr = items->at(name);
+  {
+    // The duplicate is ignored at registration (keep-first).
+    StatusPageItem<int> second(name, 2, "Test", 1000);
+    TEST_ASSERT_EQUAL(1, items->count(name));
+    TEST_ASSERT_EQUAL_PTR(first_ptr, items->at(name));
+  }
+  // Destroying the ignored duplicate must leave the first registration intact.
+  TEST_ASSERT_EQUAL(1, items->count(name));
+  TEST_ASSERT_EQUAL_PTR(first_ptr, items->at(name));
+}
+
+void test_listener_unregisters_on_destruction() {
+  size_t before_sk = SKListener::get_listeners().size();
+  size_t before_put = SKPutListener::get_listeners().size();
+  {
+    SKListener listener("test.sklistener.unreg", 1000,
+                        "/test/sklistener/unreg");
+    FloatSKPutRequestListener put("test.skput.unreg");
+    TEST_ASSERT_EQUAL(before_sk + 1, SKListener::get_listeners().size());
+    TEST_ASSERT_EQUAL(before_put + 1, SKPutListener::get_listeners().size());
+  }
+  // Both listeners unregistered themselves in their destructors.
+  TEST_ASSERT_EQUAL(before_sk, SKListener::get_listeners().size());
+  TEST_ASSERT_EQUAL(before_put, SKPutListener::get_listeners().size());
+}
+
 // ---------------------------------------------------------------------------
 // clear_registries() empties every registry
 // ---------------------------------------------------------------------------
 
+// Clearing the owning ConfigItem registry must actually destroy a sole-owned
+// object, whose destructor then unregisters it from the raw-pointer registries
+// while clear_registries() is still running -- the load-bearing ordering case.
+void test_clear_registries_destroys_config_owned_object() {
+  std::weak_ptr<SKOutput<float>> weak;
+  {
+    auto sk = std::make_shared<SKOutput<float>>("test.clear.owned",
+                                                "/test/clear/owned");
+    weak = sk;
+    ConfigItem(sk);  // config_items_ co-owns; also in sources_ and transforms_
+    sk.reset();      // drop the local owner: the registry is now the sole owner
+    TEST_ASSERT_FALSE(weak.expired());
+    TEST_ASSERT_TRUE(sources_contains(weak.lock().get()));
+  }
+
+  SensESPBaseApp::clear_registries();
+
+  // The object was destroyed by releasing the ConfigItem registry, and its
+  // destructor removed it from the raw-pointer registries during the clear.
+  TEST_ASSERT_TRUE(weak.expired());
+  TEST_ASSERT_EQUAL(0, SKEmitter::get_sources().size());
+}
+
 void test_clear_registries_empties_all() {
-  // Keep the objects alive through local owners so the registries stay
-  // populated until clear_registries() runs.
   auto sk = std::make_shared<SKOutput<float>>("test.clear.sk", "/test/clear/sk");
   ConfigItem(sk);
   auto status_item =
       std::make_shared<StatusPageItem<int>>("ClearTestItem", 0, "Test", 1100);
   UIButton::add("clear_test_button", "Clear Test Button");
+  SKListener listener("test.clear.listener", 1000, "/test/clear/listener");
+  FloatSKPutRequestListener put_listener("test.clear.put");
 
-  TEST_ASSERT_GREATER_OR_EQUAL(1, SKEmitter::get_sources().size());
-  TEST_ASSERT_GREATER_OR_EQUAL(1, StatusPageItemBase::get_status_page_items()->size());
-  TEST_ASSERT_GREATER_OR_EQUAL(1, UIButton::get_ui_buttons().size());
-  TEST_ASSERT_GREATER_OR_EQUAL(1, ConfigItemBase::get_config_items()->size());
+  // Assert membership of the specific objects, not just non-empty sizes, so
+  // cross-test residue cannot mask a failed registration.
+  TEST_ASSERT_TRUE(sources_contains(sk.get()));
+  TEST_ASSERT_NOT_NULL(ConfigItemBase::get_config_item("/test/clear/sk").get());
+  TEST_ASSERT_EQUAL(
+      1, StatusPageItemBase::get_status_page_items()->count("ClearTestItem"));
+  TEST_ASSERT_EQUAL(1, UIButton::get_ui_buttons().count("clear_test_button"));
+  TEST_ASSERT_GREATER_OR_EQUAL(1, SKListener::get_listeners().size());
+  TEST_ASSERT_GREATER_OR_EQUAL(1, SKPutListener::get_listeners().size());
 
   SensESPBaseApp::clear_registries();
 
@@ -100,13 +167,25 @@ void test_clear_registries_empties_all() {
   TEST_ASSERT_EQUAL(0, StatusPageItemBase::get_status_page_items()->size());
   TEST_ASSERT_EQUAL(0, UIButton::get_ui_buttons().size());
   TEST_ASSERT_EQUAL(0, ConfigItemBase::get_config_items()->size());
+  TEST_ASSERT_EQUAL(0, SKListener::get_listeners().size());
+  TEST_ASSERT_EQUAL(0, SKPutListener::get_listeners().size());
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   TEST_ASSERT_EQUAL(0, TransformBase::get_transforms().size());
 #pragma GCC diagnostic pop
 
-  // The locally-owned objects are destroyed at scope exit; their destructors
-  // must safely no-op against the already-cleared registries.
+  // The locally-owned objects (sk, status_item, listeners) are destroyed at
+  // scope exit; their destructors must safely no-op against the already-cleared
+  // registries.
+}
+
+void test_clear_registries_idempotent() {
+  SensESPBaseApp::clear_registries();
+  // A second clear on already-empty registries must be a safe no-op.
+  SensESPBaseApp::clear_registries();
+  TEST_ASSERT_EQUAL(0, SKEmitter::get_sources().size());
+  TEST_ASSERT_EQUAL(0, SKListener::get_listeners().size());
+  TEST_ASSERT_EQUAL(0, ConfigItemBase::get_config_items()->size());
 }
 
 // ---------------------------------------------------------------------------
@@ -121,7 +200,11 @@ void setup() {
   RUN_TEST(test_skemitter_unregisters_on_destruction);
   RUN_TEST(test_transformbase_unregisters_on_destruction);
   RUN_TEST(test_statuspageitem_unregisters_on_destruction);
+  RUN_TEST(test_statuspageitem_duplicate_name_guard);
+  RUN_TEST(test_listener_unregisters_on_destruction);
+  RUN_TEST(test_clear_registries_destroys_config_owned_object);
   RUN_TEST(test_clear_registries_empties_all);
+  RUN_TEST(test_clear_registries_idempotent);
 
   UNITY_END();
 }

--- a/test/system/test_registries/registries_test.cpp
+++ b/test/system/test_registries/registries_test.cpp
@@ -1,0 +1,129 @@
+/**
+ * @file registries_test.cpp
+ * @brief Tests for static object registry cleanup (#894).
+ *
+ * Verifies that objects unregister from the raw-pointer registries when they
+ * are destroyed (so the registries can never hold a dangling pointer), and
+ * that SensESPBaseApp::clear_registries() empties every registry for clean
+ * restart / test isolation.
+ *
+ * SKOutput<T> derives from both SKEmitter and SymmetricTransform<T>, so a
+ * single instance exercises both the SKEmitter source registry and the
+ * Transform registry.
+ */
+
+#include <Arduino.h>
+
+#include <memory>
+
+#include "sensesp/signalk/signalk_emitter.h"
+#include "sensesp/signalk/signalk_output.h"
+#include "sensesp/transforms/transform.h"
+#include "sensesp/ui/config_item.h"
+#include "sensesp/ui/status_page_item.h"
+#include "sensesp/ui/ui_button.h"
+#include "sensesp_base_app.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+static bool sources_contains(SKEmitter* emitter) {
+  for (auto* source : SKEmitter::get_sources()) {
+    if (source == emitter) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Unregister on destruction: raw-pointer registries
+// ---------------------------------------------------------------------------
+
+void test_skemitter_unregisters_on_destruction() {
+  size_t before = SKEmitter::get_sources().size();
+  {
+    SKOutput<float> out("test.skemitter.unregister", "/test/skemitter/unreg");
+    TEST_ASSERT_TRUE(sources_contains(&out));
+    TEST_ASSERT_EQUAL(before + 1, SKEmitter::get_sources().size());
+  }
+  // The emitter unregistered itself in its destructor.
+  TEST_ASSERT_EQUAL(before, SKEmitter::get_sources().size());
+}
+
+void test_transformbase_unregisters_on_destruction() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  size_t before = TransformBase::get_transforms().size();
+  {
+    SKOutput<float> out("test.transform.unregister", "/test/transform/unreg");
+    TEST_ASSERT_EQUAL(before + 1, TransformBase::get_transforms().size());
+  }
+  // The transform unregistered itself in its destructor.
+  TEST_ASSERT_EQUAL(before, TransformBase::get_transforms().size());
+#pragma GCC diagnostic pop
+}
+
+void test_statuspageitem_unregisters_on_destruction() {
+  const char* name = "RegistryTestStatusItem";
+  TEST_ASSERT_EQUAL(0, StatusPageItemBase::get_status_page_items()->count(name));
+  {
+    StatusPageItem<int> item(name, 0, "Test", 1000);
+    TEST_ASSERT_EQUAL(
+        1, StatusPageItemBase::get_status_page_items()->count(name));
+  }
+  // The item unregistered itself in its destructor.
+  TEST_ASSERT_EQUAL(0, StatusPageItemBase::get_status_page_items()->count(name));
+}
+
+// ---------------------------------------------------------------------------
+// clear_registries() empties every registry
+// ---------------------------------------------------------------------------
+
+void test_clear_registries_empties_all() {
+  // Keep the objects alive through local owners so the registries stay
+  // populated until clear_registries() runs.
+  auto sk = std::make_shared<SKOutput<float>>("test.clear.sk", "/test/clear/sk");
+  ConfigItem(sk);
+  auto status_item =
+      std::make_shared<StatusPageItem<int>>("ClearTestItem", 0, "Test", 1100);
+  UIButton::add("clear_test_button", "Clear Test Button");
+
+  TEST_ASSERT_GREATER_OR_EQUAL(1, SKEmitter::get_sources().size());
+  TEST_ASSERT_GREATER_OR_EQUAL(1, StatusPageItemBase::get_status_page_items()->size());
+  TEST_ASSERT_GREATER_OR_EQUAL(1, UIButton::get_ui_buttons().size());
+  TEST_ASSERT_GREATER_OR_EQUAL(1, ConfigItemBase::get_config_items()->size());
+
+  SensESPBaseApp::clear_registries();
+
+  TEST_ASSERT_EQUAL(0, SKEmitter::get_sources().size());
+  TEST_ASSERT_EQUAL(0, StatusPageItemBase::get_status_page_items()->size());
+  TEST_ASSERT_EQUAL(0, UIButton::get_ui_buttons().size());
+  TEST_ASSERT_EQUAL(0, ConfigItemBase::get_config_items()->size());
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  TEST_ASSERT_EQUAL(0, TransformBase::get_transforms().size());
+#pragma GCC diagnostic pop
+
+  // The locally-owned objects are destroyed at scope exit; their destructors
+  // must safely no-op against the already-cleared registries.
+}
+
+// ---------------------------------------------------------------------------
+// Test runner
+// ---------------------------------------------------------------------------
+
+void setup() {
+  delay(2000);
+
+  UNITY_BEGIN();
+
+  RUN_TEST(test_skemitter_unregisters_on_destruction);
+  RUN_TEST(test_transformbase_unregisters_on_destruction);
+  RUN_TEST(test_statuspageitem_unregisters_on_destruction);
+  RUN_TEST(test_clear_registries_empties_all);
+
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Motivation

Several static registries accumulated object registrations during construction but never removed them. For the raw-pointer registries (`SKEmitter::sources_`, `TransformBase::transforms_`, `StatusPageItemBase::status_page_items_`) a destroyed object left a dangling pointer, and consumers iterate these globally (`signalk_delta_queue`, `base_command_handler`) — a use-after-free. The shared_ptr registries (`ConfigItemBase::config_items_`, `UIButton::ui_buttons_`) instead kept objects alive indefinitely. None were reset on app restart.

## Approach

- **Raw-pointer registries:** unregistering virtual destructors so they can never hold a dangling pointer. `StatusPageItemBase` only erases the entry it actually owns, preserving keep-first-duplicate behavior.
- **shared_ptr registries:** no self-erasing destructor — the registry *owns* the object, so a self-erase in the destructor would be re-entrant and pointless. A `clear_registry()` covers them.
- `ConfigItemBase` gets a virtual destructor (polymorphic-base hygiene).
- `SensESPBaseApp::clear_registries()` clears all five; called from both `destroy()` overrides for clean restart / test isolation.
- Deprecate the unused `TransformBase::get_transforms()` (superseded by `SKEmitter::get_sources()`).

## Behavioral / compatibility notes

- `destroy()` now empties all registries (intended; previously left populated).
- Objects unregister on destruction (only "breaks" code relying on the dangling-pointer bug).
- `get_transforms()` is `[[deprecated]]` — warning only; a hard error solely under `-Werror` (not used by this project).
- Declaring the destructors suppresses implicit move ops on those classes — harmless (registered by `this`, never moved).

## Merge order

Land after #893 (the ConfigItem ownership contract that registry clearing relies on).

## Verification

Full test suite passes on HALMET hardware (pioarduino_esp32): **15 suites / 121 cases**, including the new `test_registries` (unregister-on-destruction for all three raw registries + `clear_registries()` emptying every registry and surviving objects safely no-op'ing afterward). No regressions in the existing suites.

Closes #894