### PR TITLE
fix(sensors): register DigitalInputDebounceCounter events and restore its config

### DIFF
--- a/src/sensesp/sensors/digital_input.h
+++ b/src/sensesp/sensors/digital_input.h
@@ -180,7 +180,17 @@ class DigitalInputDebounceCounter : public DigitalInputCounter {
                               String config_path = "")
       : DigitalInputCounter(pin, pin_mode, interrupt_type, read_delay,
                             config_path, [this]() { this->handleInterrupt(); }),
-        ignore_interval_ms_{ignore_interval_ms} {}
+        ignore_interval_ms_{ignore_interval_ms} {
+    repeat_event_ = event_loop()->onRepeat(read_delay_, [this]() {
+      noInterrupts();
+      output_ = counter_;
+      counter_ = 0;
+      interrupts();
+      notify();
+    });
+    isr_event_ = event_loop()->onInterrupt(
+        pin_, interrupt_type, [this]() { this->handleInterrupt(); });
+  }
 
  private:
   void handleInterrupt();

--- a/src/sensesp/sensors/digital_input.h
+++ b/src/sensesp/sensors/digital_input.h
@@ -118,6 +118,11 @@ class DigitalInputCounter : public DigitalInput, public Sensor<int> {
   virtual bool from_json(const JsonObject& config) override;
 
  protected:
+  // load() calls the virtual from_json(). Inside a base-class constructor the
+  // dynamic type is still the base, so loading there dispatches to the base
+  // from_json() and silently drops fields a derived class adds. A derived class
+  // with extra config therefore constructs with kNo and calls load() from its
+  // own constructor body, where the full dynamic type is established.
   enum class LoadConfig { kNo, kYes };
 
   DigitalInputCounter(uint8_t pin, int pin_mode, int interrupt_type,
@@ -140,6 +145,8 @@ class DigitalInputCounter : public DigitalInput, public Sensor<int> {
     }
   }
 
+  // Call after member init and after load(): registration captures read_delay_,
+  // which load() may overwrite from persisted config.
   void register_events() {
     isr_event_ = event_loop()->onInterrupt(pin_, interrupt_type_, interrupt_handler_);
     repeat_event_ = event_loop()->onRepeat(read_delay_, [this]() {
@@ -196,6 +203,10 @@ class DigitalInputDebounceCounter : public DigitalInputCounter {
                             config_path, [this]() { this->handleInterrupt(); },
                             LoadConfig::kNo),
         ignore_interval_ms_{ignore_interval_ms} {
+    // Load here, not in the base ctor (LoadConfig::kNo above): only now is the
+    // dynamic type complete, so from_json() dispatches to this class's override
+    // and ignore_interval is restored. ignore_interval_ms_ is already set, so a
+    // persisted value overrides the constructor default.
     load();
     register_events();
   }

--- a/src/sensesp/sensors/digital_input.h
+++ b/src/sensesp/sensors/digital_input.h
@@ -126,15 +126,26 @@ class DigitalInputCounter : public DigitalInput, public Sensor<int> {
   virtual bool from_json(const JsonObject& config) override;
 
  protected:
+  enum class LoadConfig { kNo, kYes };
+
   DigitalInputCounter(uint8_t pin, int pin_mode, int interrupt_type,
                       unsigned int read_delay, String config_path,
                       std::function<void()> interrupt_handler)
+      : DigitalInputCounter(pin, pin_mode, interrupt_type, read_delay,
+                            config_path, interrupt_handler, LoadConfig::kYes) {}
+
+  DigitalInputCounter(uint8_t pin, int pin_mode, int interrupt_type,
+                      unsigned int read_delay, String config_path,
+                      std::function<void()> interrupt_handler,
+                      LoadConfig load_config)
       : DigitalInput{pin, pin_mode},
         Sensor<int>(config_path),
         read_delay_{read_delay},
         interrupt_type_{interrupt_type},
         interrupt_handler_{interrupt_handler} {
-    load();
+    if (load_config == LoadConfig::kYes) {
+      load();
+    }
   }
 
   unsigned int read_delay_;
@@ -179,8 +190,10 @@ class DigitalInputDebounceCounter : public DigitalInputCounter {
                               unsigned int ignore_interval_ms,
                               String config_path = "")
       : DigitalInputCounter(pin, pin_mode, interrupt_type, read_delay,
-                            config_path, [this]() { this->handleInterrupt(); }),
+                            config_path, [this]() { this->handleInterrupt(); },
+                            LoadConfig::kNo),
         ignore_interval_ms_{ignore_interval_ms} {
+    load();
     repeat_event_ = event_loop()->onRepeat(read_delay_, [this]() {
       noInterrupts();
       output_ = counter_;

--- a/src/sensesp/sensors/digital_input.h
+++ b/src/sensesp/sensors/digital_input.h
@@ -102,15 +102,7 @@ class DigitalInputCounter : public DigitalInput, public Sensor<int> {
                       unsigned int read_delay, String config_path = "")
       : DigitalInputCounter(pin, pin_mode, interrupt_type, read_delay,
                             config_path, [this]() { this->counter_ = this->counter_ + 1; }) {
-    isr_event_ = event_loop()->onInterrupt(pin_, interrupt_type_, interrupt_handler_);
-
-    repeat_event_ = event_loop()->onRepeat(read_delay_, [this]() {
-      noInterrupts();
-      output_ = counter_;
-      counter_ = 0;
-      interrupts();
-      notify();
-    });
+    register_events();
   }
 
   virtual ~DigitalInputCounter() {
@@ -146,6 +138,17 @@ class DigitalInputCounter : public DigitalInput, public Sensor<int> {
     if (load_config == LoadConfig::kYes) {
       load();
     }
+  }
+
+  void register_events() {
+    isr_event_ = event_loop()->onInterrupt(pin_, interrupt_type_, interrupt_handler_);
+    repeat_event_ = event_loop()->onRepeat(read_delay_, [this]() {
+      noInterrupts();
+      output_ = counter_;
+      counter_ = 0;
+      interrupts();
+      notify();
+    });
   }
 
   unsigned int read_delay_;
@@ -194,15 +197,7 @@ class DigitalInputDebounceCounter : public DigitalInputCounter {
                             LoadConfig::kNo),
         ignore_interval_ms_{ignore_interval_ms} {
     load();
-    repeat_event_ = event_loop()->onRepeat(read_delay_, [this]() {
-      noInterrupts();
-      output_ = counter_;
-      counter_ = 0;
-      interrupts();
-      notify();
-    });
-    isr_event_ = event_loop()->onInterrupt(
-        pin_, interrupt_type, [this]() { this->handleInterrupt(); });
+    register_events();
   }
 
  private:

--- a/test/system/test_debounce_config_load/debounce_config_load_test.cpp
+++ b/test/system/test_debounce_config_load/debounce_config_load_test.cpp
@@ -1,0 +1,96 @@
+/**
+ * @file debounce_config_load_test.cpp
+ * @brief Regression test for DigitalInputDebounceCounter config persistence.
+ *
+ * load() calls the virtual from_json(). The bug (PR #1021) was that load() ran
+ * from the DigitalInputCounter base constructor, where the dynamic type is
+ * DigitalInputCounter, so DigitalInputCounter::from_json() (read_delay only) ran
+ * instead of the derived DigitalInputDebounceCounter::from_json() (read_delay +
+ * ignore_interval). A persisted ignore_interval was silently dropped on reboot.
+ *
+ * This test seeds a persisted config, constructs a FRESH counter through the
+ * load()-during-construction path, and asserts ignore_interval survived. A
+ * plain to_json/from_json round-trip would NOT catch the bug: it calls from_json
+ * on an already-complete object where dispatch is correct either way. The
+ * ignore_interval assertion is the one that distinguishes the derived override
+ * from the base one (both write read_delay; only the derived writes
+ * ignore_interval), so it is what fails before the fix and passes after.
+ *
+ * The counter's config members are private, so the loaded value is read back
+ * through the public Serializable::to_json().
+ */
+
+#include <Arduino.h>
+
+#include <ArduinoJson.h>
+
+#include "sensesp/sensors/digital_input.h"
+#include "sensesp/system/serializable.h"
+#include "sensesp_base_app.h"
+#include "sensesp_minimal_app_builder.h"
+#include "unity.h"
+
+using namespace sensesp;
+
+namespace {
+
+constexpr const char* kConfigPath = "/test/debounce_config_load";
+constexpr unsigned int kSavedReadDelay = 500;
+constexpr unsigned int kSavedIgnoreInterval = 250;
+constexpr unsigned int kCtorReadDelay = 1000;
+constexpr unsigned int kCtorIgnoreInterval = 750;
+
+unsigned int serialized_value(DigitalInputDebounceCounter& counter,
+                              const char* key) {
+  JsonDocument doc;
+  JsonObject obj = doc.to<JsonObject>();
+  static_cast<Serializable&>(counter).to_json(obj);
+  return obj[key].as<unsigned int>();
+}
+
+}  // namespace
+
+void test_debounce_counter_restores_persisted_ignore_interval() {
+  SensESPMinimalAppBuilder builder;
+  auto app = builder.get_app();
+  TEST_ASSERT_NOT_NULL(app);
+
+  // Remove any config left by a previous run on this device's flash.
+  {
+    DigitalInputDebounceCounter cleaner(4, INPUT_PULLUP, RISING, kSavedReadDelay,
+                                        kSavedIgnoreInterval, kConfigPath);
+    cleaner.clear();
+  }
+
+  // Seed a known config. With no file on disk, the seeder's construction-time
+  // load() finds nothing and keeps the constructor values, so save() writes
+  // exactly kSavedReadDelay / kSavedIgnoreInterval.
+  {
+    DigitalInputDebounceCounter seeder(4, INPUT_PULLUP, RISING, kSavedReadDelay,
+                                       kSavedIgnoreInterval, kConfigPath);
+    TEST_ASSERT_TRUE(seeder.save());
+  }
+
+  // Construct with different defaults; the construction-time load() must restore
+  // the persisted values. A different pin avoids re-registering the same ISR.
+  DigitalInputDebounceCounter restored(5, INPUT_PULLUP, RISING, kCtorReadDelay,
+                                       kCtorIgnoreInterval, kConfigPath);
+
+  // read_delay is restored by both the base and derived from_json, so it only
+  // confirms load() ran at all.
+  TEST_ASSERT_EQUAL_UINT(kSavedReadDelay,
+                         serialized_value(restored, "read_delay"));
+  // ignore_interval is restored only by the derived from_json. This is the
+  // assertion that fails before the fix (base from_json runs, value stays at the
+  // constructor default) and passes after.
+  TEST_ASSERT_EQUAL_UINT(kSavedIgnoreInterval,
+                         serialized_value(restored, "ignore_interval"));
+}
+
+void setup() {
+  UNITY_BEGIN();
+  RUN_TEST(test_debounce_counter_restores_persisted_ignore_interval);
+  UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
## Summary

This fixes two bugs in `DigitalInputDebounceCounter`. One left the sensor completely inert, the other quietly dropped its saved `ignore_interval` on reboot.

- Registers the interrupt and repeat events in the constructor body, like the public `DigitalInputCounter` ctor, instead of delegating to the protected base ctor and registering nothing.
- Loads config from the derived constructor instead of the base one, so the debounce counter's own `from_json()` runs and a persisted `ignore_interval` survives a reboot.
- Adds a `LoadConfig` flag for that. The plain `DigitalInputCounter` still loads in the base ctor, just as before.

Fixes #816

The `ignore_interval` bug has no issue of its own.. I found it reviewing this one.

## Verification

- Full PlatformIO test suite on ESP32 (esp32dev): 127/127 across 16 suites, no regressions.
- Confirmed on hardware that the debounce counter registers its events and emits... It fails before the fix and passes after.
