### PR TITLE
fix(log): drop captured lines under low heap instead of aborting

### DIFF
--- a/src/sensesp/system/log_buffer.cpp
+++ b/src/sensesp/system/log_buffer.cpp
@@ -1,5 +1,6 @@
 #include "sensesp/system/log_buffer.h"
 
+#include <esp_heap_caps.h>
 #include <esp_log.h>
 #include <esp_random.h>
 #include <esp_timer.h>
@@ -19,10 +20,11 @@ namespace sensesp {
 LogBuffer* LogBuffer::instance_ = nullptr;
 
 LogBuffer::LogBuffer(size_t max_lines, uint32_t max_age_ms,
-                     size_t max_line_length)
+                     size_t max_line_length, size_t min_headroom_bytes)
     : max_lines_(max_lines),
       max_age_ms_(max_age_ms),
       max_line_length_(max_line_length),
+      min_headroom_bytes_(min_headroom_bytes),
       session_id_(0) {
   mutex_ = xSemaphoreCreateMutexStatic(&mutex_buffer_);
 }
@@ -204,6 +206,16 @@ void LogBuffer::push_line(const char* text, size_t length, uint32_t now_ms) {
     length--;
   }
   if (length == 0) {
+    return;
+  }
+
+  // Never let log capture be the allocation that exhausts the heap. strip_ansi()
+  // and the records_ deque below both allocate; with C++ exceptions disabled a
+  // failed allocation throws std::bad_alloc, which routes to abort() and reboots
+  // the device -- so under memory pressure the logger would crash the device
+  // while capturing the very errors that report the pressure. Drop the line
+  // instead, mirroring the queue-full drop policy in enqueue_capture().
+  if (heap_caps_get_largest_free_block(MALLOC_CAP_8BIT) < min_headroom_bytes_) {
     return;
   }
 

--- a/src/sensesp/system/log_buffer.h
+++ b/src/sensesp/system/log_buffer.h
@@ -33,6 +33,16 @@ inline constexpr size_t kLogCaptureQueueDepth = 16;
 /// priority 1 matches the other SensESP service tasks.
 inline constexpr uint32_t kLogCaptureTaskStackSize = 4096;
 inline constexpr UBaseType_t kLogCaptureTaskPriority = 1;
+/// Minimum largest-free-block (bytes) required before the capture path will
+/// allocate. Below this, push_line() drops the line instead of building the
+/// std::string/deque record. With C++ exceptions disabled (the default on
+/// ESP32) a failed allocation throws std::bad_alloc, which routes to abort()
+/// and reboots the device -- so the logger must never be the allocation that
+/// exhausts the heap, least of all while capturing the errors that report the
+/// pressure. The margin is far larger than one line (<= kLogCaptureLineMax plus
+/// a deque node) to stay clear of the check-then-allocate race and to leave
+/// contiguous heap for the TLS Signal K connection.
+inline constexpr size_t kLogCaptureMinHeadroomBytes = 8192;
 
 /// One formatted line in transit from the vprintf hook to the capture task.
 /// Copied by value through the queue, so the hook allocates nothing.
@@ -88,7 +98,8 @@ class LogBuffer {
   // in vprintf_trampoline(); a larger value cannot recover more than that
   // buffer already captured.
   explicit LogBuffer(size_t max_lines = 200, uint32_t max_age_ms = 2000,
-                     size_t max_line_length = kLogCaptureLineMax);
+                     size_t max_line_length = kLogCaptureLineMax,
+                     size_t min_headroom_bytes = kLogCaptureMinHeadroomBytes);
 
   /**
    * @brief Install the chained vprintf hook. Call once, early in startup.
@@ -142,6 +153,7 @@ class LogBuffer {
   size_t max_lines_;
   uint32_t max_age_ms_;
   size_t max_line_length_;
+  size_t min_headroom_bytes_;
 
   std::deque<LogRecord> records_;
   uint32_t next_seq_ = 0;

--- a/test/system/test_log_buffer/log_buffer_test.cpp
+++ b/test/system/test_log_buffer/log_buffer_test.cpp
@@ -9,6 +9,7 @@
 
 #include <Arduino.h>
 
+#include <cstdint>
 #include <string>
 
 #include "sensesp/system/log_buffer.h"
@@ -191,6 +192,24 @@ void test_bare_newline_dropped() {
 }
 
 // ---------------------------------------------------------------------------
+// Memory-pressure backoff
+// ---------------------------------------------------------------------------
+
+void test_drops_line_under_heap_pressure() {
+  // With a headroom threshold larger than any achievable largest-free-block, the
+  // capture path must drop the line rather than attempt the std::string/deque
+  // allocation that would throw std::bad_alloc -> abort() under real exhaustion.
+  // Dropped lines leave the buffer and the sequence counter untouched.
+  LogBuffer buf(200, 2000, 128, /*min_headroom_bytes=*/SIZE_MAX);
+  push(buf, "should be dropped", 10);
+
+  TEST_ASSERT_EQUAL(0, buf.size());
+  LogSnapshot snap = buf.snapshot_since(0, /*has_since=*/false, 10);
+  TEST_ASSERT_EQUAL(0, snap.lines.size());
+  TEST_ASSERT_EQUAL(0, snap.next);
+}
+
+// ---------------------------------------------------------------------------
 // Session id
 // ---------------------------------------------------------------------------
 
@@ -296,6 +315,8 @@ void setup() {
   RUN_TEST(test_post_reboot_stale_cursor_no_gap);
   RUN_TEST(test_prune_keeps_lines_when_now_before_timestamp);
   RUN_TEST(test_bare_newline_dropped);
+
+  RUN_TEST(test_drops_line_under_heap_pressure);
 
   RUN_TEST(test_ansi_color_sequence_stripped);
   RUN_TEST(test_ansi_escape_only_line_dropped);


### PR DESCRIPTION
## Problem

`LogBuffer` reboots the device when it can't allocate. Every captured log line runs
`capture_task -> push_line -> strip_ansi -> std::string::reserve -> operator new`.
Under heap exhaustion that throws `std::bad_alloc`; with C++ exceptions disabled the
throw routes through `__cxa_allocate_exception -> abort()`, resetting the chip
(`rst:0xc (RTC_SW_CPU_RST)`).

The failure is self-reinforcing: low memory makes ESP-IDF log the distress (mbedTLS
errors, `httpd_accept_conn: error in accept (23)`, reconnect spam), and each of those
lines is a fresh `LogBuffer` allocation -- so logging "low memory" is the allocation
that aborts the device. Full root cause, decoded backtrace, and reset reason in #1025.

## Fix

Before allocating in `push_line()`, drop the line when the largest free block is below
`kLogCaptureMinHeadroomBytes` (default 8 KB), mirroring the existing queue-full drop in
`enqueue_capture()`. The logger degrades gracefully (stops capturing) under pressure
instead of aborting. The threshold is an injectable constructor parameter so the drop
path is unit-testable.

## Validation

Reproduced on a HALSER (ESP32-C3) with a TLS Signal K client: a concurrent
`/api/config` fetch storm exhausts the lwIP socket pool and collapses the heap
(largest block 32 KB -> 1.5 KB); the unpatched build aborts (uptime 920 s -> 25 s).

With this fix, the identical storm still exhausts sockets and collapses the heap
(1230 `accept (23)` errors, largest block -> 7 KB) but produces **0 aborts** -- the
device stays up, uptime climbing monotonically through the storm.

Unit tests: 22/22 pass on `arduino_esp32c3`, including a new
`test_drops_line_under_heap_pressure`.

## Scope

This makes the logger resilient to OOM. The *causes* of OOM are separate concerns:
the config-card socket storm trigger is addressed by the bounded request queue (#1023),
and TLS reconnect heap fragmentation on the ESP32-C3 is a separate memory-budget issue.

Closes #1025
