### PR TITLE
feat(system): report reset reason and pre-reset heap on /api/info

### DIFF
--- a/src/sensesp/system/reset_info.cpp
+++ b/src/sensesp/system/reset_info.cpp
@@ -1,0 +1,62 @@
+#include "sensesp/system/reset_info.h"
+
+#include <esp_attr.h>
+#include <esp_system.h>
+
+namespace sensesp {
+
+namespace {
+// Bumped if the RTC layout below changes, so a stale image reads as a cold boot.
+constexpr uint32_t kRtcMagic = 0x5E5E0001;
+
+// RTC_NOINIT memory is not zeroed at startup and survives panic, watchdog, and
+// software resets (but not power loss), so it carries the watermark across a
+// crash. Guarded by kRtcMagic to reject uninitialised contents after power-up.
+RTC_NOINIT_ATTR uint32_t rtc_magic_;
+RTC_NOINIT_ATTR uint32_t rtc_min_free_heap_;
+
+esp_reset_reason_t reason_ = ESP_RST_UNKNOWN;
+uint32_t min_free_before_reset_ = 0;
+}  // namespace
+
+void begin_reset_info() {
+  reason_ = esp_reset_reason();
+  min_free_before_reset_ = (rtc_magic_ == kRtcMagic) ? rtc_min_free_heap_ : 0;
+  rtc_magic_ = kRtcMagic;
+  rtc_min_free_heap_ = esp_get_minimum_free_heap_size();
+}
+
+const char* reset_reason_str() {
+  switch (reason_) {
+    case ESP_RST_POWERON:
+      return "Power-on";
+    case ESP_RST_EXT:
+      return "External pin";
+    case ESP_RST_SW:
+      return "Software restart";
+    case ESP_RST_PANIC:
+      return "Panic/abort";
+    case ESP_RST_INT_WDT:
+      return "Interrupt watchdog";
+    case ESP_RST_TASK_WDT:
+      return "Task watchdog";
+    case ESP_RST_WDT:
+      return "Other watchdog";
+    case ESP_RST_DEEPSLEEP:
+      return "Deep-sleep wake";
+    case ESP_RST_BROWNOUT:
+      return "Brownout";
+    case ESP_RST_SDIO:
+      return "SDIO";
+    default:
+      return "Unknown";
+  }
+}
+
+uint32_t min_free_heap_before_reset() { return min_free_before_reset_; }
+
+void update_min_free_heap_watermark() {
+  rtc_min_free_heap_ = esp_get_minimum_free_heap_size();
+}
+
+}  // namespace sensesp

--- a/src/sensesp/system/reset_info.h
+++ b/src/sensesp/system/reset_info.h
@@ -1,0 +1,42 @@
+#ifndef SENSESP_SRC_SENSESP_SYSTEM_RESET_INFO_H_
+#define SENSESP_SRC_SENSESP_SYSTEM_RESET_INFO_H_
+
+#include <cstdint>
+
+namespace sensesp {
+
+/**
+ * @brief Reset-cause and pre-reset heap diagnostics for the status page.
+ *
+ * begin_reset_info() records esp_reset_reason() (why the last boot happened)
+ * and, from a value carried across the reset in RTC memory, the lowest free
+ * heap the previous boot reached before it ended. Together these distinguish a
+ * crash (Panic/abort) from a watchdog, a brownout, or a deliberate software
+ * restart, and show whether the heap was exhausted -- diagnosable remotely over
+ * /api/info, without a serial console.
+ *
+ * The watermark lives in RTC_NOINIT memory, which survives software reset,
+ * panic, and watchdog resets but not a power cycle. A magic number guards it so
+ * a cold boot reports "unknown" rather than uninitialised garbage.
+ */
+
+/// Record the reset reason and the previous boot's heap watermark, then re-arm
+/// the watermark for this boot. Call once, early in setup().
+void begin_reset_info();
+
+/// Human-readable reason for the most recent reset (e.g. "Panic/abort",
+/// "Task watchdog", "Brownout", "Software restart", "Power-on").
+const char* reset_reason_str();
+
+/// Lowest free heap (bytes) seen before the previous reset, or 0 if unknown
+/// (first boot after power-up, RTC contents not valid).
+uint32_t min_free_heap_before_reset();
+
+/// Stamp this boot's current minimum free heap into RTC memory. Call
+/// periodically; it is cheap. After a reset, min_free_heap_before_reset()
+/// returns the last value stamped here.
+void update_min_free_heap_watermark();
+
+}  // namespace sensesp
+
+#endif  // SENSESP_SRC_SENSESP_SYSTEM_RESET_INFO_H_

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -21,6 +21,7 @@
 #include "sensesp/signalk/signalk_ws_client.h"
 #include "sensesp/system/button.h"
 #include "sensesp/system/log_buffer.h"
+#include "sensesp/system/reset_info.h"
 #include "sensesp/system/system_status_led.h"
 #include "sensesp/ui/status_page_item.h"
 #include "sensesp_base_app.h"
@@ -349,6 +350,13 @@ class SensESPApp : public SensESPBaseApp {
 
   // Collect metrics for the status page
   void connect_status_page_items() {
+    // Reset cause and the previous boot's heap watermark are fixed for this
+    // session; capture them once here.
+    begin_reset_info();
+    reset_reason_ui_output_.set(String(reset_reason_str()));
+    min_free_before_reset_ui_output_.set(
+        static_cast<int>(min_free_heap_before_reset()));
+
     this->hostname_->connect_to(&this->hostname_ui_output_);
     this->event_loop_->onRepeat(4999, [this]() {
       // WiFi-specific status: only populated when WiFi is the active
@@ -363,6 +371,10 @@ class SensESPApp : public SensESPBaseApp {
       }
       mac_address_ui_output_.set(network_provisioner_->mac_address());
       free_memory_ui_output_.set(ESP.getFreeHeap());
+      min_free_memory_ui_output_.set(ESP.getMinFreeHeap());
+      // Carry this boot's heap low-water mark into RTC memory so it survives a
+      // crash and reports as "min free before last reset" on the next boot.
+      update_min_free_heap_watermark();
 
       // Uptime
       uptime_ui_output_.set(millis() / 1000);
@@ -466,6 +478,13 @@ class SensESPApp : public SensESPBaseApp {
   StatusPageItem<int> free_memory_ui_output_{"Free memory (bytes)", 0, "System",
                                              1000};
   StatusPageItem<int> uptime_ui_output_{"Uptime (s)", 0, "System", 1100};
+
+  StatusPageItem<int> min_free_memory_ui_output_{"Min free memory (bytes)", 0,
+                                                 "System", 1010};
+  StatusPageItem<int> min_free_before_reset_ui_output_{
+      "Min free memory before last reset (bytes)", 0, "System", 1020};
+  StatusPageItem<String> reset_reason_ui_output_{"Last reset reason", "",
+                                                 "System", 1030};
 
   StatusPageItem<String> hostname_ui_output_{"Hostname", "", "Network", 1200};
   StatusPageItem<String> mac_address_ui_output_{"MAC Address", "", "Network",


### PR DESCRIPTION
## Motivation

Deployed SensESP devices often run headless — no serial console attached. When one reboots unexpectedly, there's currently no way to tell *why* (panic/abort vs watchdog vs brownout vs a deliberate software restart) or whether the heap had been exhausted, purely from the network. That makes remote diagnosis guesswork.

This came directly out of investigating recurring reboots on a deployed HALSER wind interface: being able to read "Last reset reason = Panic/abort" and the pre-crash heap low-water mark over `/api/info` turned a blind investigation into a targeted one.

## Approach

A small `reset_info` module:
- Records `esp_reset_reason()` at boot and maps it to a human-readable string.
- Carries the previous boot's minimum-free-heap watermark across the reset in `RTC_NOINIT` memory, which survives panic, watchdog, and software resets (but not power loss). A magic guard rejects uninitialised contents so a cold boot reports "unknown" rather than garbage.

`SensESPApp` surfaces three new System status items — last reset reason, this boot's minimum free heap, and the minimum free heap before the last reset — and re-arms the RTC watermark inside the existing status-page update loop.

No new dependencies. ESP32-only (`RTC_NOINIT_ATTR` / `esp_reset_reason()` are ESP-IDF); the module is compiled the same as the rest of the system layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)