### PR TITLE
Run the Signal K WebSocket client on the event loop (remove its dedicated task)

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -1506,6 +1506,7 @@ void SKWSClient::send_delta() {
     if (sk_delta_queue_->data_available()) {
       std::vector<String> deltas;
       sk_delta_queue_->get_deltas(deltas);
+      bool first = true;
       for (const auto& delta : deltas) {
         int send_result = esp_websocket_client_send_text(
             client_.load(), delta.c_str(), delta.length(), kWsDeltaSendTimeoutTicks);
@@ -1516,12 +1517,21 @@ void SKWSClient::send_delta() {
           // internally -- its disconnect/error event drives reconnect. Never
           // block or tear the connection down from here. Deltas are
           // supersedable, so drop the rest of this batch. See SignalK/SensESP#1033.
+          if (first) {
+            // get_deltas() builds one-shot metadata (units, zones, ...) into the
+            // first delta and marks it sent before it leaves the device. The
+            // first delta is the only one that can carry that metadata, so if its
+            // send is the one that fails, re-arm metadata for the next batch --
+            // otherwise the server runs without it until the next reconnect.
+            sk_delta_queue_->reset_meta_send();
+          }
           ESP_LOGW(__FILENAME__,
                    "Delta send incomplete (result=%d); dropping rest of batch",
                    send_result);
           break;
         }
         this->delta_tx_tick_producer_.set(1);
+        first = false;
       }
     }
   }

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -31,6 +31,10 @@ namespace sensesp {
 constexpr int kWsClientTaskStackSize = 8192;  // Stack for ExecuteWebSocketTask
 constexpr int kWsTransportTaskStackSize = 6144;  // Stack for esp_websocket_client internal task
 constexpr TickType_t kWsSendTimeoutTicks = pdMS_TO_TICKS(5000);
+// Periodic delta telemetry must never block the caller (it will be driven from
+// the event loop). 0 = enqueue if the ws-client lock and transport are free
+// right now, otherwise fail fast. Deltas are supersedable. See SignalK/SensESP#1033.
+constexpr TickType_t kWsDeltaSendTimeoutTicks = 0;
 
 SKWSClient* ws_client;
 
@@ -1403,13 +1407,18 @@ void SKWSClient::send_delta() {
       sk_delta_queue_->get_deltas(deltas);
       for (const auto& delta : deltas) {
         int send_result = esp_websocket_client_send_text(
-            client_, delta.c_str(), delta.length(), kWsSendTimeoutTicks);
+            client_, delta.c_str(), delta.length(), kWsDeltaSendTimeoutTicks);
         if (send_result < 0) {
-          ESP_LOGE(__FILENAME__,
-                   "WebSocket send failed (result=%d), restarting",
+          // Non-blocking send (0 timeout) did not complete: either brief
+          // ws-client lock contention (retry next cycle) or the transport
+          // backpressured and esp_websocket_client aborted the connection
+          // internally -- its disconnect/error event drives reconnect. Never
+          // block or tear the connection down from here. Deltas are
+          // supersedable, so drop the rest of this batch. See SignalK/SensESP#1033.
+          ESP_LOGW(__FILENAME__,
+                   "Delta send incomplete (result=%d); dropping rest of batch",
                    send_result);
-          this->restart();
-          return;
+          break;
         }
         this->delta_tx_tick_producer_.set(1);
       }

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -303,6 +303,14 @@ static esp_err_t tofu_crt_bundle_attach(void* conf) {
 static void websocket_event_handler(void* handler_args,
                                     esp_event_base_t base,
                                     int32_t event_id, void* event_data) {
+  // Drop events from a client that has been handed off for destruction: the
+  // handler was registered with the generation current at build time; if that no
+  // longer matches the live generation, this callback is from a reaped client.
+  if (ws_client == nullptr ||
+      static_cast<uint32_t>(reinterpret_cast<uintptr_t>(handler_args)) !=
+          ws_client->client_generation()) {
+    return;
+  }
   esp_websocket_event_data_t* data = (esp_websocket_event_data_t*)event_data;
   switch (event_id) {
     case WEBSOCKET_EVENT_CONNECTED:
@@ -877,6 +885,16 @@ void SKWSClient::connect() {
     return;
   }
 
+  // Reap any client left from a previous attempt before starting a new one,
+  // off this context. While the reap is in flight, defer bring-up so at most one
+  // client ever exists; state stays Disconnected, so a later cycle retries.
+  if (client_ != nullptr) {
+    detach_teardown();
+  }
+  if (teardown_in_progress_.load()) {
+    return;
+  }
+
   // Discard any anchor candidate stashed by a previous attempt; it is only
   // committed after a fully successful connection (see on_connected). Clearing
   // here also prevents committing stale data if a resumed TLS session skips the
@@ -1315,6 +1333,15 @@ void SKWSClient::poll_access_request(const String server_address,
 }
 
 void SKWSClient::connect_ws(const String& host, const uint16_t port) {
+  // connect() reaps any prior client before dispatching here, so client_ is
+  // null and no teardown is in flight. Guard defensively against a leak.
+  if (client_ != nullptr || teardown_in_progress_.load()) {
+    ESP_LOGW(__FILENAME__, "connect_ws: prior client not reaped; deferring");
+    detach_teardown();
+    set_connection_state(SKWSConnectionState::kSKWSDisconnected);
+    return;
+  }
+
   // Discard any anchor candidate stashed by the earlier esp_http_client legs
   // (token check / access request). Only the WebSocket handshake -- the one
   // whose success reaches on_connected and proves the server holds the leaf's
@@ -1353,13 +1380,6 @@ void SKWSClient::connect_ws(const String& host, const uint16_t port) {
   }
 #endif
 
-  // Destroy any existing client
-  if (client_ != nullptr) {
-    esp_websocket_client_stop(client_);
-    esp_websocket_client_destroy(client_);
-    client_ = nullptr;
-  }
-
   client_ = esp_websocket_client_init(&config);
   if (client_ == nullptr) {
     ESP_LOGE(__FILENAME__, "Failed to initialize WebSocket client");
@@ -1367,9 +1387,13 @@ void SKWSClient::connect_ws(const String& host, const uint16_t port) {
     return;
   }
 
-  // Register event handler
-  esp_websocket_register_events(client_, WEBSOCKET_EVENT_ANY,
-                                websocket_event_handler, nullptr);
+  // Register the event handler tagged with the current generation, so that any
+  // late event from this client after it is later handed off for destruction is
+  // dropped by websocket_event_handler (generation mismatch).
+  esp_websocket_register_events(
+      client_, WEBSOCKET_EVENT_ANY, websocket_event_handler,
+      reinterpret_cast<void*>(
+          static_cast<uintptr_t>(client_generation_.load())));
 
   // Start the client
   esp_err_t err = esp_websocket_client_start(client_);
@@ -1389,15 +1413,53 @@ bool SKWSClient::is_connected() {
   return get_connection_state() == SKWSConnectionState::kSKWSConnected;
 }
 
+namespace {
+struct WsTeardownArg {
+  esp_websocket_client_handle_t handle;
+  SKWSClient* self;
+};
+}  // namespace
+
+void SKWSClient::teardown_task(void* arg) {
+  auto* a = static_cast<WsTeardownArg*>(arg);
+  // Blocking: esp_websocket_client_stop() waits for the client's task to exit
+  // (up to one ~1 s poll cycle), destroy() frees its buffers. Run here, on a
+  // throwaway task, so it never blocks the connect/event-loop context.
+  esp_websocket_client_stop(a->handle);
+  esp_websocket_client_destroy(a->handle);
+  a->self->teardown_in_progress_.store(false);
+  delete a;
+  vTaskDelete(nullptr);
+}
+
+void SKWSClient::detach_teardown() {
+  if (client_ == nullptr) {
+    return;
+  }
+  esp_websocket_client_handle_t old = client_;
+  client_ = nullptr;
+  // Invalidate the old client's generation so any late event it dispatches
+  // while being reaped is dropped by websocket_event_handler.
+  client_generation_.fetch_add(1);
+  teardown_in_progress_.store(true);
+  auto* arg = new WsTeardownArg{old, this};
+  if (xTaskCreate(&SKWSClient::teardown_task, "SKWSTeardown", 4096, arg, 1,
+                  nullptr) != pdPASS) {
+    // Spawn failed (OOM): reap synchronously rather than leak the handle. Rare;
+    // blocking here is an acceptable last resort.
+    ESP_LOGE(__FILENAME__, "teardown task spawn failed; reaping synchronously");
+    esp_websocket_client_stop(old);
+    esp_websocket_client_destroy(old);
+    teardown_in_progress_.store(false);
+    delete arg;
+  }
+}
+
 void SKWSClient::restart() {
   // Set state first so event handler callbacks and send callsites see the
   // disconnected state and skip operations on the client being destroyed.
   set_connection_state(SKWSConnectionState::kSKWSDisconnected);
-  if (client_ != nullptr) {
-    esp_websocket_client_stop(client_);
-    esp_websocket_client_destroy(client_);
-    client_ = nullptr;
-  }
+  detach_teardown();
 }
 
 void SKWSClient::send_delta() {

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -492,7 +492,7 @@ void SKWSClient::subscribe_listeners() {
     ESP_LOGI(__FILENAME__, "Subscription JSON message:\n %s",
              json_message.c_str());
     int result = esp_websocket_client_send_text(
-        client_, json_message.c_str(), json_message.length(),
+        client_.load(), json_message.c_str(), json_message.length(),
         kWsSendTimeoutTicks);
     if (result < 0) {
       ESP_LOGE(__FILENAME__, "Subscription send failed (result=%d)", result);
@@ -762,7 +762,7 @@ void SKWSClient::on_receive_put(JsonDocument& message) {
     String response_text;
     serializeJson(put_response, response_text);
     int result = esp_websocket_client_send_text(
-        client_, response_text.c_str(), response_text.length(),
+        client_.load(), response_text.c_str(), response_text.length(),
         kWsSendTimeoutTicks);
     if (result < 0) {
       ESP_LOGE(__FILENAME__, "PUT response send failed (result=%d)", result);
@@ -780,7 +780,7 @@ void SKWSClient::on_receive_put(JsonDocument& message) {
 void SKWSClient::sendTXT(String& payload) {
   if (get_connection_state() == SKWSConnectionState::kSKWSConnected) {
     int result = esp_websocket_client_send_text(
-        client_, payload.c_str(), payload.length(), kWsSendTimeoutTicks);
+        client_.load(), payload.c_str(), payload.length(), kWsSendTimeoutTicks);
     if (result < 0) {
       ESP_LOGE(__FILENAME__, "sendTXT failed (result=%d)", result);
     }
@@ -885,10 +885,15 @@ void SKWSClient::connect() {
     return;
   }
 
+  // A connect attempt is already running on a worker task; let it finish.
+  if (auth_job_running_.load()) {
+    return;
+  }
+
   // Reap any client left from a previous attempt before starting a new one,
   // off this context. While the reap is in flight, defer bring-up so at most one
   // client ever exists; state stays Disconnected, so a later cycle retries.
-  if (client_ != nullptr) {
+  if (client_.load() != nullptr) {
     detach_teardown();
   }
   if (teardown_in_progress_.load()) {
@@ -916,9 +921,31 @@ void SKWSClient::connect() {
     return;
   }
 
+  set_connection_state(SKWSConnectionState::kSKWSAuthorizing);
+
+  // The rest of the attempt — mDNS resolve, SSL detect, and the access-request /
+  // poll / connect_ws leg — makes blocking HTTP/mDNS calls, so run it on a
+  // one-shot worker task. The SK/event-loop context stays responsive, and
+  // auth_job_running_ keeps at most one attempt in flight.
+  auth_job_running_.store(true);
+  if (xTaskCreate(&SKWSClient::connect_worker, "SKWSConnect",
+                  kWsClientTaskStackSize, this, 1, nullptr) != pdPASS) {
+    ESP_LOGE(__FILENAME__, "connect worker spawn failed");
+    auth_job_running_.store(false);
+    set_connection_state(SKWSConnectionState::kSKWSDisconnected);
+  }
+}
+
+void SKWSClient::connect_worker(void* arg) {
+  auto* self = static_cast<SKWSClient*>(arg);
+  self->run_connect_attempt();
+  self->auth_job_running_.store(false);
+  vTaskDelete(nullptr);
+}
+
+void SKWSClient::run_connect_attempt() {
   ESP_LOGI(__FILENAME__, "Initiating websocket connection with server...");
 
-  set_connection_state(SKWSConnectionState::kSKWSAuthorizing);
   if (use_mdns_) {
     if (!get_mdns_service(this->server_address_, this->server_port_)) {
       ESP_LOGE(__FILENAME__,
@@ -1279,6 +1306,7 @@ void SKWSClient::poll_access_request(const String server_address,
     if (error) {
       ESP_LOGW(__FILENAME__, "WARNING: Could not deserialize http payload.");
       ESP_LOGW(__FILENAME__, "DeserializationError: %s", error.c_str());
+      set_connection_state(SKWSConnectionState::kSKWSDisconnected);
       return;
     }
     String state = doc["state"];
@@ -1330,12 +1358,17 @@ void SKWSClient::poll_access_request(const String server_address,
     set_connection_state(SKWSConnectionState::kSKWSDisconnected);
     return;
   }
+  // Catch-all: a 200/202 COMPLETED whose permission is neither APPROVED nor
+  // DENIED, or any unexpected state, leaves no terminal state. With no live
+  // client, no event will move us off Authorizing, so fall back to Disconnected
+  // to retry rather than wedge.
+  set_connection_state(SKWSConnectionState::kSKWSDisconnected);
 }
 
 void SKWSClient::connect_ws(const String& host, const uint16_t port) {
   // connect() reaps any prior client before dispatching here, so client_ is
   // null and no teardown is in flight. Guard defensively against a leak.
-  if (client_ != nullptr || teardown_in_progress_.load()) {
+  if (client_.load() != nullptr || teardown_in_progress_.load()) {
     ESP_LOGW(__FILENAME__, "connect_ws: prior client not reaped; deferring");
     detach_teardown();
     set_connection_state(SKWSConnectionState::kSKWSDisconnected);
@@ -1380,28 +1413,30 @@ void SKWSClient::connect_ws(const String& host, const uint16_t port) {
   }
 #endif
 
-  client_ = esp_websocket_client_init(&config);
-  if (client_ == nullptr) {
+  esp_websocket_client_handle_t h = esp_websocket_client_init(&config);
+  if (h == nullptr) {
     ESP_LOGE(__FILENAME__, "Failed to initialize WebSocket client");
     set_connection_state(SKWSConnectionState::kSKWSDisconnected);
     return;
   }
+  client_.store(h);
 
   // Register the event handler tagged with the current generation, so that any
   // late event from this client after it is later handed off for destruction is
   // dropped by websocket_event_handler (generation mismatch).
   esp_websocket_register_events(
-      client_, WEBSOCKET_EVENT_ANY, websocket_event_handler,
+      h, WEBSOCKET_EVENT_ANY, websocket_event_handler,
       reinterpret_cast<void*>(
           static_cast<uintptr_t>(client_generation_.load())));
 
   // Start the client
-  esp_err_t err = esp_websocket_client_start(client_);
+  esp_err_t err = esp_websocket_client_start(h);
   if (err != ESP_OK) {
     ESP_LOGE(__FILENAME__, "Failed to start WebSocket client: %s",
              esp_err_to_name(err));
-    esp_websocket_client_destroy(client_);
-    client_ = nullptr;
+    // Null the shared handle before freeing it so a concurrent send sees null.
+    client_.store(nullptr);
+    esp_websocket_client_destroy(h);
     set_connection_state(SKWSConnectionState::kSKWSDisconnected);
     return;
   }
@@ -1433,11 +1468,12 @@ void SKWSClient::teardown_task(void* arg) {
 }
 
 void SKWSClient::detach_teardown() {
-  if (client_ == nullptr) {
+  // Single atomic check-and-null: if two contexts race here, only one gets the
+  // handle, so it is stopped/destroyed exactly once (no double-free).
+  esp_websocket_client_handle_t old = client_.exchange(nullptr);
+  if (old == nullptr) {
     return;
   }
-  esp_websocket_client_handle_t old = client_;
-  client_ = nullptr;
   // Invalidate the old client's generation so any late event it dispatches
   // while being reaped is dropped by websocket_event_handler.
   client_generation_.fetch_add(1);
@@ -1469,7 +1505,7 @@ void SKWSClient::send_delta() {
       sk_delta_queue_->get_deltas(deltas);
       for (const auto& delta : deltas) {
         int send_result = esp_websocket_client_send_text(
-            client_, delta.c_str(), delta.length(), kWsDeltaSendTimeoutTicks);
+            client_.load(), delta.c_str(), delta.length(), kWsDeltaSendTimeoutTicks);
         if (send_result < 0) {
           // Non-blocking send (0 timeout) did not complete: either brief
           // ws-client lock contention (retry next cycle) or the transport

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -28,7 +28,7 @@
 
 namespace sensesp {
 
-constexpr int kWsClientTaskStackSize = 8192;  // Stack for ExecuteWebSocketTask
+constexpr int kWsClientTaskStackSize = 8192;  // Stack for the connect worker
 constexpr int kWsTransportTaskStackSize = 6144;  // Stack for esp_websocket_client internal task
 constexpr TickType_t kWsSendTimeoutTicks = pdMS_TO_TICKS(5000);
 // Periodic delta telemetry must never block the caller (it will be driven from
@@ -342,24 +342,6 @@ static void websocket_event_handler(void* handler_args,
   }
 }
 
-void ExecuteWebSocketTask(void* /*parameter*/) {
-  elapsedMillis delta_loop_elapsed = 0;
-
-  ws_client->connect();
-
-  while (true) {
-    if (ws_client->is_connect_due()) {
-      ws_client->connect();
-    }
-    if (delta_loop_elapsed > 5) {
-      delta_loop_elapsed = 0;
-      ws_client->send_delta();
-    }
-    vTaskDelay(pdMS_TO_TICKS(100));
-  }
-}
-
-
 SKWSClient::SKWSClient(const String& config_path,
                        std::shared_ptr<SKDeltaQueue> sk_delta_queue,
                        const String& server_address, uint16_t server_port,
@@ -389,8 +371,18 @@ SKWSClient::SKWSClient(const String& config_path,
 
   event_loop()->onDelay(0, [this]() {
     ESP_LOGD(__FILENAME__, "Starting SKWSClient");
-    xTaskCreate(ExecuteWebSocketTask, "SKWSClient", kWsClientTaskStackSize,
-                this, 1, NULL);
+    // Run the connection lifecycle on the event loop instead of a dedicated
+    // task: connect() is a non-blocking dispatcher (it spawns a worker for the
+    // blocking auth legs) and send_delta() is non-blocking, so neither stalls
+    // the loop. The ~100 ms cadence matches the former task's vTaskDelay(100ms).
+    event_loop()->onRepeat(100, [this]() {
+      // Retry a teardown whose reaper failed to spawn under OOM (no-op if none).
+      reap_async(pending_teardown_.load());
+      if (is_connect_due()) {
+        connect();
+      }
+      send_delta();
+    });
     MDNS.addService("signalk-sensesp", "tcp", 80);
   });
 }
@@ -1467,6 +1459,27 @@ void SKWSClient::teardown_task(void* arg) {
   vTaskDelete(nullptr);
 }
 
+void SKWSClient::reap_async(esp_websocket_client_handle_t old) {
+  if (old == nullptr) {
+    return;
+  }
+  auto* arg = new WsTeardownArg{old, this};
+  if (xTaskCreate(&SKWSClient::teardown_task, "SKWSTeardown", 4096, arg, 1,
+                  nullptr) == pdPASS) {
+    // The task now owns `old` and clears teardown_in_progress_ when done.
+    pending_teardown_.store(nullptr);
+    return;
+  }
+  // Spawn failed (OOM). Do NOT reap synchronously: a ~1 s stop()+destroy() on
+  // the event loop would stall every consumer under the exact heap pressure
+  // this path exists for. Stash the handle and retry on the next loop tick;
+  // teardown_in_progress_ stays set so bring-up remains deferred (at most one
+  // un-reaped client, no leak beyond it).
+  delete arg;
+  pending_teardown_.store(old);
+  ESP_LOGW(__FILENAME__, "teardown task spawn failed; will retry next cycle");
+}
+
 void SKWSClient::detach_teardown() {
   // Single atomic check-and-null: if two contexts race here, only one gets the
   // handle, so it is stopped/destroyed exactly once (no double-free).
@@ -1478,17 +1491,7 @@ void SKWSClient::detach_teardown() {
   // while being reaped is dropped by websocket_event_handler.
   client_generation_.fetch_add(1);
   teardown_in_progress_.store(true);
-  auto* arg = new WsTeardownArg{old, this};
-  if (xTaskCreate(&SKWSClient::teardown_task, "SKWSTeardown", 4096, arg, 1,
-                  nullptr) != pdPASS) {
-    // Spawn failed (OOM): reap synchronously rather than leak the handle. Rare;
-    // blocking here is an acceptable last resort.
-    ESP_LOGE(__FILENAME__, "teardown task spawn failed; reaping synchronously");
-    esp_websocket_client_stop(old);
-    esp_websocket_client_destroy(old);
-    teardown_in_progress_.store(false);
-    delete arg;
-  }
+  reap_async(old);
 }
 
 void SKWSClient::restart() {

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -119,11 +119,11 @@ class SKWSClient : public FileSystemSaveable,
   /// @brief Drop the current connection (detached, non-blocking teardown) and
   /// let the reconnect path rebuild it.
   ///
-  /// @warning Must run on the SK connection context only (the SKWSClient task
-  /// today; the event loop after the fold). It does not check auth_job_running_,
-  /// so calling it concurrently with a running connect worker could interleave
-  /// its client_.exchange(nullptr) with the worker's client_.store(h) and orphan
-  /// a live client (leak + dropped events). Has no callers today. See #1033.
+  /// @warning Must run on the event-loop (SK connection) context only. It does
+  /// not check auth_job_running_, so calling it concurrently with a running
+  /// connect worker could interleave its client_.exchange(nullptr) with the
+  /// worker's client_.store(h) and orphan a live client (leak + dropped events).
+  /// Has no callers today. See #1033.
   void restart();
   bool is_connect_due() const { return millis() >= next_attempt_ms_; }
   void send_delta();
@@ -373,10 +373,12 @@ class SKWSClient : public FileSystemSaveable,
   // SK/event-loop context loads it to send and reaps it via exchange(nullptr)
   // (single check-and-null, so no double-free). Writers are serialized
   // single-owner-at-a-time by auth_job_running_ / teardown_in_progress_.
-  // NOTE: the atomic does NOT confer lifetime safety — a cross-task sender that
-  // already loaded the handle can still race the detached teardown's destroy()
-  // (narrow window, pre-existing since the teardown was detached; tracked for
-  // the fold commit, where all sends move onto one context). See #1033.
+  // NOTE: the atomic confers pointer-atomicity, not lifetime safety. send_delta
+  // and sendTXT run on the event loop, serialized with detach_teardown (same
+  // context), so they cannot hold a handle across its reap. Transport-task
+  // senders (on_connected -> subscribe_listeners, on_receive_put's response)
+  // are made safe by esp_websocket_client_stop() joining the transport task
+  // before destroy() frees the struct. See #1033.
   std::atomic<esp_websocket_client_handle_t> client_{nullptr};
   // Bumped on every teardown so the (singleton) event handler can drop late
   // callbacks from a client that has been handed off for destruction. The
@@ -390,6 +392,11 @@ class SKWSClient : public FileSystemSaveable,
   // (mDNS / SSL-detect / access-request / poll legs). The dispatcher skips
   // while it is set, so at most one attempt runs at a time.
   std::atomic<bool> auth_job_running_{false};
+  // Holds a handle whose detached reaper task failed to spawn (OOM); the event
+  // loop retries the spawn each tick rather than reaping it synchronously (which
+  // would block the loop). At most one at a time (teardown_in_progress_ defers
+  // bring-up until it is reaped).
+  std::atomic<esp_websocket_client_handle_t> pending_teardown_{nullptr};
   std::shared_ptr<SKDeltaQueue> sk_delta_queue_;
   /// @brief Emits the number of deltas sent since last report
   TaskQueueProducer<int> delta_tx_tick_producer_{0, event_loop(), 990};
@@ -458,6 +465,10 @@ class SKWSClient : public FileSystemSaveable,
   /// bumps client_generation_ / sets teardown_in_progress_ immediately; no-op if
   /// client_ is null. The OOM-spawn fallback reaps synchronously.
   void detach_teardown();
+  /// @brief Spawn the detached reaper for `old`; on spawn failure (OOM) stash it
+  /// in pending_teardown_ for a later retry instead of blocking the loop with a
+  /// synchronous reap. No-op if `old` is null. Call on the event-loop context.
+  void reap_async(esp_websocket_client_handle_t old);
   /// @brief Body of the detached teardown task (stop+destroy+self-delete).
   static void teardown_task(void* arg);
   /// @brief The (blocking) connect attempt — mDNS resolve, SSL detect, and the

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -103,7 +103,7 @@ class SKWSClient : public FileSystemSaveable,
   String get_connection_status();
 
   /////////////////////////////////////////////////////////
-  // SKWSClient task methods
+  // SK websocket connection methods
 
   void on_disconnected();
   // handshake_status is the HTTP status of a failed WebSocket upgrade (0 if not
@@ -447,7 +447,7 @@ class SKWSClient : public FileSystemSaveable,
   void process_received_updates();
 
   /////////////////////////////////////////////////////////
-  // SKWSClient task methods
+  // SK websocket connection methods
 
 #ifndef SENSESP_SSL_SUPPORT
   // Validate the auth token over plain HTTP before opening the WebSocket

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -116,6 +116,13 @@ class SKWSClient : public FileSystemSaveable,
   void connect();
   void loop();
   bool is_connected();
+  /// @brief Drop the current connection (detached, non-blocking teardown) and
+  /// let the reconnect path rebuild it.
+  ///
+  /// @warning client_ is not atomically swapped, so this must run on the SK
+  /// connection context only (the SKWSClient task today; the event loop after
+  /// the fold) — never concurrently with connect()/connect_ws() on another
+  /// task, or two teardowns could double-free the handle. See #1033.
   void restart();
   bool is_connect_due() const { return millis() >= next_attempt_ms_; }
   void send_delta();
@@ -291,6 +298,11 @@ class SKWSClient : public FileSystemSaveable,
   /// disconnect surfaces as kSKWSCertificateError rather than a plain disconnect.
   void flag_cert_error() { cert_error_.store(true); }
 
+  /// @brief Generation tag of the currently-valid client. The event handler
+  /// compares the generation it was registered with against this to drop
+  /// callbacks from a client that has been handed off for destruction.
+  uint32_t client_generation() const { return client_generation_.load(); }
+
  protected:
   // these are the actually used values
   String server_address_ = "";
@@ -357,6 +369,14 @@ class SKWSClient : public FileSystemSaveable,
       SKWSConnectionState::kSKWSDisconnected;
 
   esp_websocket_client_handle_t client_ = nullptr;
+  // Bumped on every teardown so the (singleton) event handler can drop late
+  // callbacks from a client that has been handed off for destruction. The
+  // handler is registered with the generation current at build time; an event
+  // whose generation != client_generation_ comes from a torn-down client.
+  std::atomic<uint32_t> client_generation_{0};
+  // True while a detached task is stopping+destroying a previous client.
+  // Bring-up is deferred until it clears, so at most one client ever exists.
+  std::atomic<bool> teardown_in_progress_{false};
   std::shared_ptr<SKDeltaQueue> sk_delta_queue_;
   /// @brief Emits the number of deltas sent since last report
   TaskQueueProducer<int> delta_tx_tick_producer_{0, event_loop(), 990};
@@ -420,6 +440,13 @@ class SKWSClient : public FileSystemSaveable,
   void poll_access_request(const String host, const uint16_t port,
                            const String href);
   void connect_ws(const String& host, const uint16_t port);
+  /// @brief Hand client_ to a detached one-shot task that stops+destroys it, so
+  /// the blocking teardown never runs on the caller's context. Nulls client_ and
+  /// bumps client_generation_ / sets teardown_in_progress_ immediately; no-op if
+  /// client_ is null. The OOM-spawn fallback reaps synchronously.
+  void detach_teardown();
+  /// @brief Body of the detached teardown task (stop+destroy+self-delete).
+  static void teardown_task(void* arg);
   void subscribe_listeners();
   bool get_mdns_service(String& server_address, uint16_t& server_port);
   bool detect_ssl();

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -463,7 +463,9 @@ class SKWSClient : public FileSystemSaveable,
   /// @brief Hand client_ to a detached one-shot task that stops+destroys it, so
   /// the blocking teardown never runs on the caller's context. Nulls client_ and
   /// bumps client_generation_ / sets teardown_in_progress_ immediately; no-op if
-  /// client_ is null. The OOM-spawn fallback reaps synchronously.
+  /// client_ is null. If the reaper task can't be spawned (OOM), the handle is
+  /// stashed in pending_teardown_ and the spawn is retried on the next event-loop
+  /// tick -- never reaped synchronously, which would block the loop.
   void detach_teardown();
   /// @brief Spawn the detached reaper for `old`; on spawn failure (OOM) stash it
   /// in pending_teardown_ for a later retry instead of blocking the loop with a

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -119,10 +119,11 @@ class SKWSClient : public FileSystemSaveable,
   /// @brief Drop the current connection (detached, non-blocking teardown) and
   /// let the reconnect path rebuild it.
   ///
-  /// @warning client_ is not atomically swapped, so this must run on the SK
-  /// connection context only (the SKWSClient task today; the event loop after
-  /// the fold) — never concurrently with connect()/connect_ws() on another
-  /// task, or two teardowns could double-free the handle. See #1033.
+  /// @warning Must run on the SK connection context only (the SKWSClient task
+  /// today; the event loop after the fold). It does not check auth_job_running_,
+  /// so calling it concurrently with a running connect worker could interleave
+  /// its client_.exchange(nullptr) with the worker's client_.store(h) and orphan
+  /// a live client (leak + dropped events). Has no callers today. See #1033.
   void restart();
   bool is_connect_due() const { return millis() >= next_attempt_ms_; }
   void send_delta();
@@ -368,7 +369,15 @@ class SKWSClient : public FileSystemSaveable,
   SKWSConnectionState task_connection_state_ =
       SKWSConnectionState::kSKWSDisconnected;
 
-  esp_websocket_client_handle_t client_ = nullptr;
+  // Atomic for pointer-atomicity: the connect worker builds/stores it; the
+  // SK/event-loop context loads it to send and reaps it via exchange(nullptr)
+  // (single check-and-null, so no double-free). Writers are serialized
+  // single-owner-at-a-time by auth_job_running_ / teardown_in_progress_.
+  // NOTE: the atomic does NOT confer lifetime safety — a cross-task sender that
+  // already loaded the handle can still race the detached teardown's destroy()
+  // (narrow window, pre-existing since the teardown was detached; tracked for
+  // the fold commit, where all sends move onto one context). See #1033.
+  std::atomic<esp_websocket_client_handle_t> client_{nullptr};
   // Bumped on every teardown so the (singleton) event handler can drop late
   // callbacks from a client that has been handed off for destruction. The
   // handler is registered with the generation current at build time; an event
@@ -377,6 +386,10 @@ class SKWSClient : public FileSystemSaveable,
   // True while a detached task is stopping+destroying a previous client.
   // Bring-up is deferred until it clears, so at most one client ever exists.
   std::atomic<bool> teardown_in_progress_{false};
+  // True while a one-shot worker is running a (blocking) connect attempt
+  // (mDNS / SSL-detect / access-request / poll legs). The dispatcher skips
+  // while it is set, so at most one attempt runs at a time.
+  std::atomic<bool> auth_job_running_{false};
   std::shared_ptr<SKDeltaQueue> sk_delta_queue_;
   /// @brief Emits the number of deltas sent since last report
   TaskQueueProducer<int> delta_tx_tick_producer_{0, event_loop(), 990};
@@ -447,6 +460,11 @@ class SKWSClient : public FileSystemSaveable,
   void detach_teardown();
   /// @brief Body of the detached teardown task (stop+destroy+self-delete).
   static void teardown_task(void* arg);
+  /// @brief The (blocking) connect attempt — mDNS resolve, SSL detect, and the
+  /// access-request / poll / connect_ws leg. Run on a one-shot worker task so
+  /// none of it blocks the SK/event-loop context. connect() is the dispatcher.
+  void run_connect_attempt();
+  static void connect_worker(void* arg);
   void subscribe_listeners();
   bool get_mdns_service(String& server_address, uint16_t& server_port);
   bool detect_ssl();


### PR DESCRIPTION
## Motivation

Part of #1033. The Signal K WebSocket client ran on its own FreeRTOS task (`SKWSClient`, an 8 KB poll loop). That task existed only because the connect / auth / send / reconnect lifecycle made blocking calls. Folding it onto the ReactESP event loop removes a persistent task (reclaims ~8 KB), removes an independent context that races on the SK connection, and keeps the loop responsive — but only once every blocking call on that path is made non-blocking. This PR does that, then folds.

## Approach (commit chain)

1. **make delta send non-blocking** — `send_delta` uses a 0-timeout send and drops the rest of the batch on failure instead of the blocking `restart()`.
2. **make WebSocket teardown non-blocking** — `restart()` / `connect_ws` hand the old client to a detached one-shot reaper task (`stop`+`destroy` off the caller); `connect()` reaps a stale client at the top, deferring bring-up so at most one client exists. A generation tag makes the singleton event handler drop late events from a reaped client.
3. **run SK auth/connect on a worker; thread-safe client handle** — `connect()` becomes a non-blocking dispatcher that spawns a one-shot worker for the blocking auth legs (access-request / poll / SSL-detect), guarded by `auth_job_running_`. `client_` becomes `std::atomic` (reaped via `exchange`, closing a latent double-free). Also fixes a pre-existing wedge where `poll_access_request` could stick in `Authorizing` on a malformed/unexpected server response.
4. **fold the SK client onto the event loop, delete its task** — replace the task with `onRepeat(100)`; the OOM teardown path is also made non-blocking (stash + retry next tick) so it can't stall the loop; closes the send-vs-teardown lifetime window now that sends and the teardown trigger share the event-loop context.
5. **drop stale "SKWSClient task" section labels** — docs.

## Verification

On a bench HALSER (ESP32-C3) against a real signalk-server, with a producer generating live delta traffic:

- Non-blocking send: deltas keep landing, no steady-state regression.
- Detached teardown: forcing `restart()` on a *healthy* connection repeatedly → clean reconnect, flat heap across cycles, no stall (the detached reaper reclaims even a live client).
- Worker-dispatched auth: existing-token reconnect runs through the worker; the cold-token attempt runs with the loop responsive through the blocking HTTP and recovers cleanly.
- Fold: heartbeat holds `dt ≈ 1000 ms` through connect attempts and forced `restart()` cycles now running **on the event loop** (the loop-stall test); heap stable and ~8 KB higher with the task gone; no crash.

Each non-trivial commit also passed an independent adversarial review (concurrency / lifecycle / reliability) — all GO; findings were folded into the commits.

**Pending before merge** (gated on a stable LAN — the bench WiFi → SK-server link was too flaky to complete end-to-end): the cold-token flow (access-request approval → poll → connect) and a connected-state soak (deltas flowing while folded; reconnect/backoff across a server bounce and WiFi drop; ≥10 min). These code paths are verified by review plus on-device attempt/recovery, but not yet end-to-end on hardware.

## Notes

- `esp_websocket_client` `auto_reconnect` is left ON (smaller change; the detached `stop()` reclaims even a healthy client — verified against the library's stop/STOPPED-bit semantics).
- `restart()` has no callers; it is documented as event-loop-context-only (it does not check `auth_job_running_`).
