### PR TITLE
perf(system): reduce LogBuffer RAM footprint

### DIFF
--- a/src/sensesp/system/log_buffer.h
+++ b/src/sensesp/system/log_buffer.h
@@ -27,7 +27,7 @@ struct LogRecord {
 inline constexpr size_t kLogCaptureLineMax = 256;
 /// Depth of the lock-free handoff queue between the vprintf hook and the
 /// capture task. Bursts beyond this drop lines rather than block the logger.
-inline constexpr size_t kLogCaptureQueueDepth = 16;
+inline constexpr size_t kLogCaptureQueueDepth = 8;
 /// Stack (bytes) and priority of the capture task. The task does the
 /// heap-allocating work the hook offloads, so its stack must be roomy;
 /// priority 1 matches the other SensESP service tasks.
@@ -97,7 +97,7 @@ class LogBuffer {
   // max_line_length defaults to kLogCaptureLineMax to match the capture buffer
   // in vprintf_trampoline(); a larger value cannot recover more than that
   // buffer already captured.
-  explicit LogBuffer(size_t max_lines = 200, uint32_t max_age_ms = 2000,
+  explicit LogBuffer(size_t max_lines = 100, uint32_t max_age_ms = 2000,
                      size_t max_line_length = kLogCaptureLineMax,
                      size_t min_headroom_bytes = kLogCaptureMinHeadroomBytes);
 


### PR DESCRIPTION
## Why

Part of #1036 (framework RAM audit). The log capture path holds more RAM than it needs on a memory-constrained device — free heap on an ESP32-C3 connected over TLS sits around 100 KB, and the connect/TLS handshake is the tightest moment.

## What

- **`kLogCaptureQueueDepth` 16 → 8.** The vprintf-hook → capture-task handoff queue is allocated unconditionally in `install()` (~264 B/slot), held for the whole uptime even if `/api/log` is never opened. ~2.1 KB persistent. The handoff is already non-blocking drop-on-full, so a shallower queue only raises the burst-drop rate.
- **`LogBuffer` default `max_lines` 200 → 100.** `records_` can hold up to `max_lines` heap `std::string`s during a verbose connect/TLS burst; the 2 s age cap keeps steady-state low, so this trims the *peak* during the heap-pressure window. The web log is a ~2 s live tail, not scrollback.

## Verification

- Compiles (`pio ci -e pioarduino_esp32`, `examples/ssl_connection.cpp`).
- On-device (HALSER, ESP32-C3): boot + web log tail still functional.

Refs #1036
