### PR TITLE
perf(signalk): allocate TOFU PEM buffer on demand

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -16,6 +16,7 @@
 #endif
 
 #include <memory>
+#include <new>
 
 #include "Arduino.h"
 #include "elapsedMillis.h"
@@ -90,22 +91,34 @@ static String cert_common_name(const mbedtls_x509_crt* crt) {
   return out;
 }
 
-// PEM-encode a certificate's DER for storage. Uses a static buffer (the verify
-// callback runs serialized on the TLS task and the task stack is small).
+// PEM-encode a certificate's DER for storage. The encode buffer is allocated on
+// demand and freed on return rather than held for the device's lifetime: TOFU CA
+// capture happens only during the TLS handshake, so a permanent .bss buffer
+// would waste ~4 KB for the whole uptime. It is heap- rather than stack-
+// allocated because the verify callback runs on a small TLS task stack.
 static String cert_to_pem(const mbedtls_x509_crt* crt) {
-  // Sized for a large CA cert (RSA-4096 + SANs/extensions). On overflow,
-  // mbedtls_pem_write_buffer returns an error and this returns "" -- callers
-  // must treat an empty PEM as "no usable CA" and fail safe, never store it.
-  static unsigned char pem_buf[4096];
+  // Sized for a large CA cert (RSA-4096 + SANs/extensions). The size is fixed,
+  // not derived from crt->raw.len: PEM is base64 (~4/3 of the DER) plus the
+  // header/footer and line breaks, so the encoded form is always larger than the
+  // DER. On overflow mbedtls_pem_write_buffer returns an error and this returns
+  // "" -- callers must treat an empty PEM as "no usable CA" and fail safe, never
+  // store it.
+  constexpr size_t kPemBufSize = 4096;
+  std::unique_ptr<unsigned char[]> pem_buf(
+      new (std::nothrow) unsigned char[kPemBufSize]);
+  if (!pem_buf) {
+    ESP_LOGE("SKWSClient", "TOFU: PEM buffer allocation failed");
+    return String("");
+  }
   size_t olen = 0;
   int r = mbedtls_pem_write_buffer(
       "-----BEGIN CERTIFICATE-----\n", "-----END CERTIFICATE-----\n",
-      crt->raw.p, crt->raw.len, pem_buf, sizeof(pem_buf), &olen);
+      crt->raw.p, crt->raw.len, pem_buf.get(), kPemBufSize, &olen);
   if (r != 0) {
     ESP_LOGE("SKWSClient", "TOFU: PEM encode failed (-0x%x)", -r);
     return String("");
   }
-  return String(reinterpret_cast<const char*>(pem_buf));
+  return String(reinterpret_cast<const char*>(pem_buf.get()));
 }
 
 // Normalized (lowercase, sorted, deduplicated, comma-joined) set of the


### PR DESCRIPTION
## Why

Part of #1036 (framework RAM audit). `cert_to_pem()` held a function-static 4096-byte buffer in `.bss` for the device's whole uptime, although TOFU CA capture only runs during the TLS handshake.

## What

Allocate the PEM encode buffer on the heap, scoped to the call, and free it on return. It stays off the small TLS task stack (the original reason for the `static` buffer). The size is kept fixed at 4096 rather than derived from `crt->raw.len` — PEM is base64 (~4/3 of the DER) plus header/footer, so the encoded form is always larger than its DER input, and sizing from `raw.len` would silently truncate the CA. Allocation failure fails safe to "no usable CA", matching the existing encode-error contract.

~4 KB returned to the heap pool on SSL builds.

## Verification

- Compiles (`pio ci -e pioarduino_esp32`, `examples/ssl_connection.cpp`).
- On-device (HALSER, ESP32-C3 → halosdev.local:4430 TLS): TOFU CA capture + pinning intact, no crash, identical PEM output path.

Refs #1036
