### PR TITLE
feat(system): task-stack high-water reporting + right-size httpd/LogCapture stacks

### DIFF
--- a/src/sensesp/net/http_server.h
+++ b/src/sensesp/net/http_server.h
@@ -14,8 +14,14 @@
 #include "sensesp/system/serializable.h"
 #include "sensesp_base_app.h"
 
+// HTTP server worker task stack. Measured worst case on an ESP32-C3 was ~3.4 KB
+// used by a config PUT (max-nesting JSON deserialize + SPIFFS save, with a long
+// request URI on the same frame). The digest-auth path (a 1024-byte
+// Authorization buffer + MD5/String temporaries) runs and returns before the
+// handler, so it never stacks on top of it. 6144 leaves ~2.7 KB of headroom
+// over the deepest measured path.
 #ifndef HTTP_SERVER_STACK_SIZE
-#define HTTP_SERVER_STACK_SIZE 8192
+#define HTTP_SERVER_STACK_SIZE 6144
 #endif
 
 namespace sensesp {

--- a/src/sensesp/net/web/base_command_handler.cpp
+++ b/src/sensesp/net/web/base_command_handler.cpp
@@ -1,8 +1,13 @@
 #include "base_command_handler.h"
 
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
 #include <cerrno>
 #include <cstdint>
 #include <cstdlib>
+#include <memory>
+#include <new>
 
 #include "sensesp/net/web/autogen/frontend_files.h"
 #include "sensesp/system/log_buffer.h"
@@ -97,6 +102,32 @@ void add_http_info_handler(std::shared_ptr<HTTPServer>& server) {
              info_item != status_page_items->end(); ++info_item) {
           info_items.add(info_item->second->as_json());
         }
+
+        // Per-task minimum-ever free stack, grouped under "Task stack free
+        // (bytes)", for spotting over- or under-provisioned task stacks.
+        // Computed live per request; needs the FreeRTOS trace facility, which
+        // the Arduino/ESP-IDF default config enables.
+#if defined(CONFIG_FREERTOS_USE_TRACE_FACILITY) && \
+    CONFIG_FREERTOS_USE_TRACE_FACILITY
+        // Over-allocate a few slots so a task created between the count and the
+        // snapshot can't undersize the array: uxTaskGetSystemState returns 0 on
+        // an undersized buffer, which would drop the whole section that request.
+        UBaseType_t task_slots = uxTaskGetNumberOfTasks() + 4;
+        std::unique_ptr<TaskStatus_t[]> tasks(
+            new (std::nothrow) TaskStatus_t[task_slots]);
+        if (tasks) {
+          UBaseType_t n = uxTaskGetSystemState(tasks.get(), task_slots, nullptr);
+          for (UBaseType_t i = 0; i < n; i++) {
+            JsonDocument item;
+            item["name"] = tasks[i].pcTaskName;
+            item["value"] = static_cast<uint32_t>(
+                tasks[i].usStackHighWaterMark * sizeof(StackType_t));
+            item["group"] = "Task stack free (bytes)";
+            item["order"] = kUIOutputDefaultOrder;
+            info_items.add(item);
+          }
+        }
+#endif
 
         String response;
         serializeJson(json_doc, response);

--- a/src/sensesp/system/log_buffer.h
+++ b/src/sensesp/system/log_buffer.h
@@ -29,9 +29,11 @@ inline constexpr size_t kLogCaptureLineMax = 256;
 /// capture task. Bursts beyond this drop lines rather than block the logger.
 inline constexpr size_t kLogCaptureQueueDepth = 8;
 /// Stack (bytes) and priority of the capture task. The task does the
-/// heap-allocating work the hook offloads, so its stack must be roomy;
-/// priority 1 matches the other SensESP service tasks.
-inline constexpr uint32_t kLogCaptureTaskStackSize = 4096;
+/// heap-allocating work the hook offloads (ANSI strip + std::string build + a
+/// largest-free-block probe). Measured worst case ~0.7 KB used on an ESP32-C3;
+/// 3072 keeps a conservative margin because this task allocates under memory
+/// pressure. Priority 1 matches the other SensESP service tasks.
+inline constexpr uint32_t kLogCaptureTaskStackSize = 3072;
 inline constexpr UBaseType_t kLogCaptureTaskPriority = 1;
 /// Minimum largest-free-block (bytes) required before the capture path will
 /// allocate. Below this, push_line() drops the line instead of building the


### PR DESCRIPTION
## Why

Closes the measurement-gated items on #1036. The httpd (8192) and LogCapture (4096) task stacks were sized by guesswork; the #1037/#1038 review flagged them as trim candidates but required on-device high-water measurement first. This adds that measurement capability, then uses it.

## What

1. **Task-stack HWM reporting (feat).** `/api/info` gains a `Task stack free (bytes)` group listing each FreeRTOS task's minimum-ever free stack (`uxTaskGetSystemState`), computed live per request, guarded by `CONFIG_FREERTOS_USE_TRACE_FACILITY` (on by default). The status array is `new(std::nothrow)`, over-allocated by a few slots (so a task spawned mid-call can't blank the section), and skipped on alloc failure so `/api/info` still responds. Reset-free stack-headroom visibility — and the basis for the two trims below.
2. **httpd stack 8192 → 6144 (perf).** Deepest path is a config PUT (max-nesting JSON deserialize + SPIFFS save, long URI on the same frame); digest auth runs and returns before the handler, so it never stacks on top.
3. **LogCapture stack 4096 → 3072 (perf).** Capture work is ANSI-strip + `std::string` + a largest-free-block probe.

Net ~3 KB persistent DRAM reclaimed.

## Verification

- Compiles: `pio ci -e pioarduino_esp32` for `examples/ssl_connection.cpp` and `examples/minimal_app.cpp`.
- On-device (ESP32-C3), high-water under sustained load of the **deepest path for each task**:

  | task | before | used / after | headroom |
  |---|---|---|---|
  | httpd | 8192 | 3460 / 6144 (deep config PUT + long URI) | 2684 B free |
  | LogCapture | 4096 | 668 / 3072 | 2404 B free |

  No stack overflow; device stayed up and SK-connected throughout. `/api/info` returns the 14-task group correctly.

Refs #1036
