### PR TITLE
fix(signalk): make WS buffer size configurable; drop oversize deltas

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -6,6 +6,8 @@
 #include <ESPmDNS.h>
 #include <esp_http_client.h>
 
+#include "sensesp/signalk/signalk_ws_delta_size.h"
+
 #ifdef SENSESP_SSL_SUPPORT
 #include <mbedtls/pem.h>
 #include <mbedtls/sha256.h>
@@ -36,6 +38,9 @@ constexpr TickType_t kWsSendTimeoutTicks = pdMS_TO_TICKS(5000);
 // the event loop). 0 = enqueue if the ws-client lock and transport are free
 // right now, otherwise fail fast. Deltas are supersedable. See SignalK/SensESP#1033.
 constexpr TickType_t kWsDeltaSendTimeoutTicks = 0;
+// A device that keeps producing a delta larger than the buffer would drop one
+// every send cycle; rate-limit the warning so it does not flood the log.
+constexpr uint32_t kOversizeDropLogIntervalMs = 10000;
 
 SKWSClient* ws_client;
 
@@ -1404,7 +1409,7 @@ void SKWSClient::connect_ws(const String& host, const uint16_t port) {
   esp_websocket_client_config_t config = {};
   config.uri = url.c_str();
   config.task_stack = kWsTransportTaskStackSize;
-  config.buffer_size = 1024;
+  config.buffer_size = SENSESP_SK_WS_BUFFER_SIZE;
   if (auth_header.length() > 0) {
     config.headers = auth_header.c_str();
   }
@@ -1521,6 +1526,30 @@ void SKWSClient::send_delta() {
       sk_delta_queue_->get_deltas(deltas);
       bool first = true;
       for (const auto& delta : deltas) {
+        if (sk_delta_exceeds_ws_buffer(delta.length(),
+                                       SENSESP_SK_WS_BUFFER_SIZE)) {
+          // Drop the delta to keep the connection alive (signalk_ws_delta_size.h
+          // explains why an oversize delta would otherwise abort it). Unlike the
+          // transient send failure below, an oversize delta is deterministic, so
+          // do NOT re-arm metadata here: get_deltas() already bundles metadata
+          // into the first delta and marks it sent, and re-arming would have
+          // get_deltas() rebuild the same oversize first delta every cycle --
+          // dropped and re-armed forever, never delivered. Leaving it sent lets
+          // the next, metadata-free first delta fit and flow; metadata waits for
+          // a reconnect or a larger SENSESP_SK_WS_BUFFER_SIZE.
+          uint32_t now = millis();
+          if (last_oversize_log_ms_ == 0 ||
+              now - last_oversize_log_ms_ >= kOversizeDropLogIntervalMs) {
+            ESP_LOGW(__FILENAME__,
+                     "Delta too large (%u B > %u buffer); dropped to keep the "
+                     "connection alive -- raise SENSESP_SK_WS_BUFFER_SIZE",
+                     (unsigned)delta.length(),
+                     (unsigned)SENSESP_SK_WS_BUFFER_SIZE);
+            last_oversize_log_ms_ = now;
+          }
+          first = false;
+          continue;
+        }
         int send_result = esp_websocket_client_send_text(
             client_.load(), delta.c_str(), delta.length(), kWsDeltaSendTimeoutTicks);
         if (send_result < 0) {

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -35,6 +35,17 @@
 #define SENSESP_MAX_RECEIVED_META_UPDATES 20
 #endif
 
+// Signal K WebSocket buffer size in bytes, allocated by esp_websocket_client for
+// both the tx and rx buffer. send_delta drops any delta longer than this rather
+// than let esp_websocket_client split it across non-blocking writes and abort
+// the connection (see signalk_ws_delta_size.h). Override per board via
+// build_flags to hold the largest delta a device sends (e.g. a GNSS receiver's
+// full-sky satellitesInView); kept small by default for memory-constrained
+// boards.
+#ifndef SENSESP_SK_WS_BUFFER_SIZE
+#define SENSESP_SK_WS_BUFFER_SIZE 1024
+#endif
+
 namespace sensesp {
 
 static const char* NULL_AUTH_TOKEN = "";
@@ -402,6 +413,11 @@ class SKWSClient : public FileSystemSaveable,
   TaskQueueProducer<int> delta_tx_tick_producer_{0, event_loop(), 990};
   Integrator<int, int> delta_tx_count_producer_{1, 0, ""};
   Integrator<int, int> delta_rx_count_producer_{1, 0, ""};
+
+  /// @brief millis() timestamp of the last oversize-delta-drop warning, used to
+  /// rate-limit it when a device keeps producing a delta larger than the buffer.
+  /// 0 = never logged, so the next drop logs immediately.
+  uint32_t last_oversize_log_ms_ = 0;
 
   /// @brief A single received delta entry awaiting dispatch on the main task.
   ///

--- a/src/sensesp/signalk/signalk_ws_delta_size.h
+++ b/src/sensesp/signalk/signalk_ws_delta_size.h
@@ -1,0 +1,30 @@
+#ifndef SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_WS_DELTA_SIZE_H_
+#define SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_WS_DELTA_SIZE_H_
+
+#include <cstddef>
+
+namespace sensesp {
+
+/**
+ * @brief True if a delta is too large to hand to esp_websocket_client as a
+ * single tx chunk, so send_delta drops it to keep the connection alive.
+ *
+ * Pure and dependency-free (no Arduino, no esp_websocket_client) so it can be
+ * unit-tested on the host.
+ *
+ * The bound is strictly greater-than, and that is deliberate. esp_websocket_client
+ * copies up to buffer_size *payload* bytes per transport write; the WebSocket
+ * frame header is framed separately, not in tx_buffer. A delta of exactly
+ * buffer_size is sent as one chunk with FIN set and never enters the multi-write
+ * path. Only a delta longer than buffer_size is split into two or more
+ * non-blocking writes, the second of which can short-write and make
+ * esp_websocket_client abort the connection. Do not subtract a frame-header
+ * margin here: the header does not consume buffer_size.
+ */
+inline bool sk_delta_exceeds_ws_buffer(size_t delta_length, size_t buffer_size) {
+  return delta_length > buffer_size;
+}
+
+}  // namespace sensesp
+
+#endif  // SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_WS_DELTA_SIZE_H_

--- a/test/native/test_ws_delta_size/ws_delta_size_test.cpp
+++ b/test/native/test_ws_delta_size/ws_delta_size_test.cpp
@@ -1,0 +1,59 @@
+/**
+ * @file ws_delta_size_test.cpp
+ * @brief Host unit tests for the oversize-delta drop decision
+ *        (signalk_ws_delta_size.h).
+ *
+ * Runs on the `native` env (no Arduino / esp_websocket_client):
+ *   pio test -e native -f native/test_ws_delta_size
+ *
+ * The boundary is locked deliberately: esp_websocket_client copies up to
+ * buffer_size payload bytes per transport write, so a delta of exactly
+ * buffer_size is sent as a single chunk and must NOT be dropped; only a delta
+ * longer than buffer_size would split into multiple non-blocking writes and
+ * abort the connection. A frame-header margin must not be subtracted.
+ */
+
+#include <unity.h>
+
+#include "sensesp/signalk/signalk_ws_delta_size.h"
+
+using namespace sensesp;
+
+// A delta shorter than the buffer fits in one chunk: send it.
+void test_under_buffer_is_sent(void) {
+  TEST_ASSERT_FALSE(sk_delta_exceeds_ws_buffer(1023, 1024));
+}
+
+// A delta of exactly buffer_size is one chunk (FIN set), not a multi-write: send.
+void test_exactly_buffer_is_sent(void) {
+  TEST_ASSERT_FALSE(sk_delta_exceeds_ws_buffer(1024, 1024));
+}
+
+// One byte over the buffer splits into two writes that can abort: drop.
+void test_one_over_buffer_is_dropped(void) {
+  TEST_ASSERT_TRUE(sk_delta_exceeds_ws_buffer(1025, 1024));
+}
+
+// An empty delta is always sendable.
+void test_empty_is_sent(void) {
+  TEST_ASSERT_FALSE(sk_delta_exceeds_ws_buffer(0, 1024));
+}
+
+// The boundary tracks an overridden buffer size, not the 1024 default.
+void test_custom_buffer_boundary(void) {
+  TEST_ASSERT_FALSE(sk_delta_exceeds_ws_buffer(8192, 8192));
+  TEST_ASSERT_TRUE(sk_delta_exceeds_ws_buffer(8193, 8192));
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_under_buffer_is_sent);
+  RUN_TEST(test_exactly_buffer_is_sent);
+  RUN_TEST(test_one_over_buffer_is_dropped);
+  RUN_TEST(test_empty_is_sent);
+  RUN_TEST(test_custom_buffer_boundary);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Problem

On a busy device, the Signal K WebSocket connection drops and reconnects every ~10s, freezing **all** deltas for the backoff. The connection is healthy — the client is tearing it down itself.

`esp_websocket_client` is configured with a hardcoded `buffer_size = 1024`. A delta larger than that is sent as several non-blocking transport writes (deltas use a 0-tick send so they never block the event loop). When a later chunk isn't instantly writable, the short write makes `esp_websocket_client` abort the connection (`transport_poll_write(0)`, `errno=2`, `transport_error=ESP_OK` — no TLS or network error).

Any device whose deltas exceed 1 KB trips this on nearly every connect:
- the `sendMeta=all` metadata delta sent on connect (one entry per path), and
- large value deltas such as a GNSS receiver's full-sky `navigation.gnss.satellitesInView` (~4 KB).

It's load-dependent: a light device (a temperature sensor) never trips it; a GNSS compass whose connect-time delta reaches ~7 KB reconnect-loops continuously.

## Fix

- **Configurable buffer size.** The buffer is now `SENSESP_SK_WS_BUFFER_SIZE`, a build-flag-overridable `#define` (default **1024**). `esp_websocket_client` allocates it for *both* tx and rx, so it stays small by default for memory-constrained boards (ESP32-C3); a device that legitimately sends large deltas raises it: `-D SENSESP_SK_WS_BUFFER_SIZE=8192`.
- **Drop oversize deltas instead of disconnecting.** `send_delta` skips any delta larger than the buffer with an `ESP_LOGE`, rather than attempting the multi-chunk send that aborts the connection. Losing one supersedable delta beats losing the connection and every delta after it.

## Verification

On an ESP32 GNSS compass whose connect-time delta is ~7 KB:
- Default 1024: 6 reconnects / 81 s, deltas frozen in 10–50 s windows.
- `-D SENSESP_SK_WS_BUFFER_SIZE=8192`: **0 reconnects over 75 s, connection stays up, deltas flow continuously (<1 s gaps), 0 oversize drops.**

## Follow-ups (not in this PR)

Splitting multi-path deltas (e.g. capping paths per delta so the metadata delta is chunked) would bound delta size and let the buffer stay small even on devices with many paths.