### PR TITLE
Log Signal K deltas at verbose level

### DIFF
--- a/src/sensesp/signalk/signalk_delta_queue.cpp
+++ b/src/sensesp/signalk/signalk_delta_queue.cpp
@@ -111,7 +111,7 @@ void SKDeltaQueue::get_deltas(std::vector<String>& output) {
     String delta;
     serializeJson(json_doc, delta);
     output.push_back(std::move(delta));
-    ESP_LOGD(__FILENAME__, "delta: %s", output.back().c_str());
+    ESP_LOGV(__FILENAME__, "delta: %s", output.back().c_str());
     return;
   }
 
@@ -162,7 +162,7 @@ void SKDeltaQueue::get_deltas(std::vector<String>& output) {
 
     String delta;
     serializeJson(json_doc, delta);
-    ESP_LOGD(__FILENAME__, "delta: %s", delta.c_str());
+    ESP_LOGV(__FILENAME__, "delta: %s", delta.c_str());
     output.push_back(std::move(delta));
   }
 
@@ -182,7 +182,7 @@ void SKDeltaQueue::get_deltas(std::vector<String>& output) {
 
     String delta;
     serializeJson(json_doc, delta);
-    ESP_LOGD(__FILENAME__, "delta: %s", delta.c_str());
+    ESP_LOGV(__FILENAME__, "delta: %s", delta.c_str());
     output.push_back(std::move(delta));
   }
 }


### PR DESCRIPTION
## Why

Outbound Signal K deltas are logged at DEBUG and written synchronously to UART0. Under the default DEBUG runtime level they print on every delta, and on a high-rate device the blocking UART write stalls the event loop when the TX FIFO fills. That loop stall starves the SK WebSocket client itself, turning heavy logging into dropped deltas and disconnects.

## What

Move the three delta log calls in `signalk_delta_queue.cpp` from `ESP_LOGD` to `ESP_LOGV`. Deltas are then suppressed at the default DEBUG level but still available when the runtime level is raised to VERBOSE for debugging — they remain the primary "is my data going out?" diagnostic, just off by default.

## Evidence

Validated on a live AIS device (ESP32-C3) carrying real bus traffic. Together with quieting the application's own per-message logs, the device went from loop-starved — HTTP API answering 0/8, SK WebSocket chronically "not connected", every delta dropped — to healthy: HTTP 8/8, WebSocket connected, deltas and N2K both flowing steadily, no reboot.

This is the cheap mitigation. The synchronous, blocking UART log transport is the underlying cause; anyone who raises the runtime level to DEBUG/VERBOSE re-triggers the stall. #1045 tracks the real fix (a non-blocking log transport).

Refs #1045.
