### PR TITLE
feat(signalk): SKPrefixListener for path-family subscriptions

### DIFF
--- a/src/sensesp/signalk/signalk_listener.h
+++ b/src/sensesp/signalk/signalk_listener.h
@@ -51,6 +51,18 @@ class SKListener : virtual public Observable, public FileSystemSaveable {
 
   int get_listen_delay() { return listen_delay; }
 
+  /**
+   * Whether a received delta on `path` should be routed to this listener.
+   *
+   * Defaults to an exact match against `sk_path`. Listeners that observe a
+   * *family* of paths (e.g. a prefix subscription like `notifications.*`,
+   * where the server publishes on paths the client cannot enumerate in
+   * advance) override this to widen the match. `SKWSClient::process_received_updates`
+   * calls it per delta instead of comparing paths directly, so the routing
+   * policy lives with the listener.
+   */
+  virtual bool matches(const String& path) const { return sk_path == path; }
+
   virtual void parse_value(const JsonObject& json) {}
 
   /**

--- a/src/sensesp/signalk/signalk_prefix_listener.h
+++ b/src/sensesp/signalk/signalk_prefix_listener.h
@@ -1,0 +1,81 @@
+#ifndef SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_PREFIX_LISTENER_H_
+#define SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_PREFIX_LISTENER_H_
+
+#include <ArduinoJson.h>
+
+#include "sensesp/system/valueproducer.h"
+#include "signalk_listener.h"
+
+namespace sensesp {
+
+/**
+ * @brief A value+path pair emitted for a delta on a prefix-matched path.
+ *
+ * Unlike `SKValueListener` (one exact path, value only), a prefix listener
+ * serves a family of paths, so the consumer needs to know *which* path a
+ * delta arrived on. `path` is the full received path; `value` is a read-only
+ * view of that delta's `value` member — valid only for the duration of the
+ * observer call (it aliases the receive-queue document), so copy anything you
+ * need to retain.
+ */
+struct SKPathValue {
+  String path;
+  JsonVariantConst value;
+};
+
+/**
+ * @brief A ValueProducer that listens to every Signal K value delta whose
+ * path begins with a given prefix, emitting the `{path, value}` pair.
+ *
+ * `SKValueListener`/`SKMetadataListener` match a single exact path. Some
+ * consumers must observe a *family* of paths whose members appear and
+ * disappear at runtime and cannot be enumerated in advance — the canonical
+ * case is `notifications.*`, where a Signal K server raises alarms on
+ * arbitrary paths. This listener subscribes with the wildcard `<prefix>*`
+ * and routes any delta whose path starts with `<prefix>` (via the overridden
+ * `matches()`), so `SKWSClient::process_received_updates` fans matching
+ * deltas to it through the normal listener dispatch.
+ *
+ * Example — observe all notifications:
+ * @code
+ * auto nl = std::make_shared<SKPrefixListener>("notifications.");
+ * nl->connect_to(new LambdaConsumer<SKPathValue>([](const SKPathValue& pv) {
+ *   // pv.path e.g. "notifications.mob"; pv.value the notification object
+ * }));
+ * @endcode
+ *
+ * @see SKValueListener
+ * @see SKWSClient
+ */
+class SKPrefixListener : public SKListener, public ValueProducer<SKPathValue> {
+ public:
+  /**
+   * @param prefix The path prefix to match, e.g. "notifications.". The
+   *   subscription is sent as "<prefix>*".
+   * @param listen_delay The minimum interval between updates in ms.
+   * @param config_path Optional configuration path.
+   */
+  SKPrefixListener(const String& prefix, int listen_delay = 1000,
+                   const String& config_path = "")
+      : SKListener(prefix + "*", listen_delay, config_path), prefix_{prefix} {
+    if (prefix == "") {
+      ESP_LOGE(__FILENAME__,
+               "SKPrefixListener: User has provided no prefix to listen to.");
+    }
+  }
+
+  bool matches(const String& path) const override {
+    return path.startsWith(prefix_);
+  }
+
+  void parse_value(const JsonObject& json) override {
+    this->emit(SKPathValue{json["path"].as<String>(), json["value"]});
+  }
+
+ private:
+  String prefix_;
+};
+
+}  // namespace sensesp
+
+#endif  // SENSESP_SRC_SENSESP_SIGNALK_SIGNALK_PREFIX_LISTENER_H_

--- a/src/sensesp/signalk/signalk_prefix_listener.h
+++ b/src/sensesp/signalk/signalk_prefix_listener.h
@@ -3,6 +3,9 @@
 
 #include <ArduinoJson.h>
 
+#include <memory>
+#include <utility>
+
 #include "sensesp/system/valueproducer.h"
 #include "signalk_listener.h"
 
@@ -14,13 +17,37 @@ namespace sensesp {
  * Unlike `SKValueListener` (one exact path, value only), a prefix listener
  * serves a family of paths, so the consumer needs to know *which* path a
  * delta arrived on. `path` is the full received path; `value` is a read-only
- * view of that delta's `value` member — valid only for the duration of the
- * observer call (it aliases the receive-queue document), so copy anything you
- * need to retain.
+ * view of that delta's `value` member.
+ *
+ * `value` is backed by `value_doc`, an owned, refcounted copy of the delta
+ * value lifted off the transient receive-queue document. Copying this struct
+ * is a refcount bump, not a deep copy, and `value` stays valid for as long as
+ * any copy survives — so it is safe to retain past the observer call (e.g. for
+ * UI work marshalled onto the event loop), unlike a raw alias of the receive
+ * document.
  */
 struct SKPathValue {
   String path;
+
+  /// Owns the value object so `value` outlives the transient receive-queue
+  /// document. Null on a default-constructed (no-data-yet) instance.
+  std::shared_ptr<const JsonDocument> value_doc;
+
+  /// Read-only view of the delta's `value` member, backed by `value_doc`.
   JsonVariantConst value;
+
+  SKPathValue() = default;
+
+  /**
+   * @param path The full received Signal K path.
+   * @param doc An owned document holding a copy of the delta `value`; `value`
+   *   is exposed as a read-only view of its root.
+   */
+  SKPathValue(String path, std::shared_ptr<const JsonDocument> doc)
+      : path{std::move(path)},
+        value_doc{std::move(doc)},
+        value{value_doc ? value_doc->as<JsonVariantConst>()
+                        : JsonVariantConst{}} {}
 };
 
 /**
@@ -69,7 +96,12 @@ class SKPrefixListener : public SKListener, public ValueProducer<SKPathValue> {
   }
 
   void parse_value(const JsonObject& json) override {
-    this->emit(SKPathValue{json["path"].as<String>(), json["value"]});
+    // Copy the delta value into an owned document so the emitted view outlives
+    // the receive-queue entry (freed as soon as process_received_updates pops
+    // it). Notifications are low-frequency, so the per-delta copy is cheap.
+    auto value_doc = std::make_shared<JsonDocument>();
+    value_doc->set(json["value"]);
+    this->emit(SKPathValue{json["path"].as<String>(), std::move(value_doc)});
   }
 
  private:

--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -689,7 +689,7 @@ void SKWSClient::process_received_updates() {
           std::make_shared<const JsonDocument>(std::move(ru.doc));
       for (size_t i = 0; i < listeners.size(); i++) {
         SKListener* listener = listeners[i];
-        if (listener->wants_meta() && listener->get_sk_path().equals(path)) {
+        if (listener->wants_meta() && listener->matches(path)) {
           listener->parse_meta(meta_doc);
         }
       }
@@ -700,7 +700,7 @@ void SKWSClient::process_received_updates() {
 
       for (size_t i = 0; i < listeners.size(); i++) {
         SKListener* listener = listeners[i];
-        if (!listener->wants_meta() && listener->get_sk_path().equals(path)) {
+        if (!listener->wants_meta() && listener->matches(path)) {
           listener->parse_value(value);
         }
       }


### PR DESCRIPTION
## Problem

`SKValueListener` and `SKMetadataListener` each match a single **exact** path. There's no way to observe a *family* of paths whose members appear and disappear at runtime and can't be enumerated in advance.

The canonical case is **`notifications.*`**: a Signal K server raises alarms on arbitrary paths (`notifications.mob`, `notifications.nmea.alarm.navigational.*`, engine alarms, etc.) that a client cannot know ahead of time. A UI that surfaces alarms has to watch the whole subtree, but today that requires registering a listener per exact path — impossible when the paths are dynamic.

## Approach

A minimal, listener-shaped addition that composes with the existing dispatch, rather than a new callback surface on `SKWSClient`:

1. **`SKListener::matches(path)`** — a virtual that defaults to the existing exact compare (`sk_path == path`). `process_received_updates` now calls `listener->matches(path)` instead of comparing paths inline, so a listener owns its own routing policy. Behaviour for existing exact-path listeners is unchanged.

2. **`SKPrefixListener`** — subscribes with the wildcard `<prefix>*` and overrides `matches()` to prefix-match. Because a prefix listener serves many paths, it emits `SKPathValue{path, value}` so the consumer knows which path a delta arrived on.

```cpp
auto nl = std::make_shared<SKPrefixListener>("notifications.");
nl->connect_to(new LambdaConsumer<SKPathValue>([](const SKPathValue& pv) {
  // pv.path e.g. "notifications.mob"; pv.value the notification object
}));
```

## Notes

- No change to `SKValueListener`/`SKMetadataListener`, and put listeners are untouched (`SKPutListener` doesn't derive from `SKListener`, so its loop keeps the direct compare).
- Fires through the normal `process_received_updates` path (on the event loop), same as every other listener.
- Relies on the server honouring a `path: "<prefix>*"` subscription, which the Signal K subscription protocol supports.

Verified on hardware (ESP32-P4): an `SKPrefixListener("notifications.")` reliably delivers `notifications.*` alarms to a UI overlay, and exact-path value/meta listeners continue to work unchanged alongside it.