### PR TITLE
feat(wifi): add multi-network WiFi client failover API

### DIFF
--- a/docs/pages/features/index.md
+++ b/docs/pages/features/index.md
@@ -21,6 +21,7 @@ nav_order: 40
 | Method | Description |
 |--------|-------------|
 | `set_wifi_client(String ssid, String password)` | Set WiFi network credentials |
+| `set_wifi_clients(std::vector<ClientSSIDConfig> configs)` | Set multiple WiFi client networks tried in order with failover (up to 3) |
 | `set_wifi_access_point(String ssid, String password)` | Configure the WiFi soft-AP SSID and password |
 | `disable_wifi()` | Disable WiFi entirely (for Ethernet-only setups) |
 | `set_ethernet(config)` | Configure Ethernet provisioner (ESP32-P4 boards) |
@@ -206,6 +207,20 @@ auto app = builder.set_hostname("my-device")
                   ->get_app();
 ```
 
+To define more than one network in code (tried in order with failover, up
+to three), use `set_wifi_clients()` with a list of `ClientSSIDConfig`
+entries instead:
+
+```c++
+SensESPAppBuilder builder;
+auto app = builder.set_hostname("my-device")
+                  ->set_wifi_clients({
+                      {"PrimarySSID", "password1"},
+                      {"BackupSSID", "password2"},
+                  })
+                  ->get_app();
+```
+
 ### Ethernet (ESP32-P4)
 
 Native RMII Ethernet is supported on ESP32-P4 boards with an external
@@ -257,6 +272,8 @@ SensESP v3 includes a built-in WiFi provisioner — no external WiFiManager libr
 The AP mode serves a built-in captive portal with the same web UI used for runtime configuration. Up to 3 WiFi client configurations can be saved; if the current network connection fails, the device cycles through the saved networks automatically.
 
 WiFi configuration is persisted to the device file system and restored on restart. If you hard-code credentials with `set_wifi_client()` in your sketch, those serve as defaults — but they can be overridden by saved configuration through the web UI. This means you can ship a device with initial credentials and let the end user change them later without reflashing.
+
+The same precedence applies to the multi-network `set_wifi_clients()` list shown above: it is the in-code equivalent of the network list the web UI manages, but a configuration saved through the web UI always wins over the hard-coded presets.
 
 ## System info sensors
 

--- a/src/sensesp/net/wifi_provisioner.cpp
+++ b/src/sensesp/net/wifi_provisioner.cpp
@@ -48,6 +48,45 @@ WiFiProvisioner::WiFiProvisioner(const String& config_path,
     client_enabled_ = true;
   }
 
+  init_wifi();
+}
+
+WiFiProvisioner::WiFiProvisioner(
+    const String& config_path,
+    const std::vector<ClientSSIDConfig>& client_configs, const String& ap_ssid,
+    const String& ap_password)
+    : FileSystemSaveable{config_path}, Resettable(0) {
+  bool config_loaded = load();
+
+  if (!config_loaded) {
+    if (ap_ssid != "" && ap_password != "") {
+      this->ap_settings_.enabled_ = true;
+      this->ap_settings_.ssid_ = ap_ssid;
+      this->ap_settings_.password_ = ap_password;
+    } else {
+      this->ap_settings_.enabled_ = false;
+    }
+  }
+
+  if (!config_loaded) {
+    // Seed the preset client list, skipping incomplete entries and honoring
+    // the kMaxNumClientConfigs cap.
+    for (const ClientSSIDConfig& config : client_configs) {
+      if (client_settings_.size() >= kMaxNumClientConfigs) {
+        break;
+      }
+      if (config.ssid_ == "" || config.password_ == "") {
+        continue;
+      }
+      client_settings_.push_back(config);
+    }
+    client_enabled_ = !client_settings_.empty();
+  }
+
+  init_wifi();
+}
+
+void WiFiProvisioner::init_wifi() {
   // Fill in the rest of the client settings array with empty configs
   int num_fill = kMaxNumClientConfigs - client_settings_.size();
   for (int i = 0; i < num_fill; i++) {

--- a/src/sensesp/net/wifi_provisioner.h
+++ b/src/sensesp/net/wifi_provisioner.h
@@ -176,6 +176,29 @@ class WiFiProvisioner : public FileSystemSaveable,
                   const String& client_password = "",
                   const String& ap_ssid = "",
                   const String& ap_password = "");
+
+  /**
+   * @brief Construct with a preset list of client (STA) networks.
+   *
+   * Seeds up to kMaxNumClientConfigs client configurations that are tried
+   * in order, failing over between them, when the device is not already
+   * associated. Use this instead of the single-SSID constructor to define
+   * more than one network in code (the same list the web UI edits).
+   *
+   * Like the single-SSID constructor, the presets are applied only when no
+   * configuration has been saved to flash yet; a saved (e.g. web-UI-edited)
+   * list always wins and is never overwritten. Client entries with an empty
+   * SSID or password are ignored. Any entries beyond kMaxNumClientConfigs
+   * are dropped.
+   *
+   * @param config_path     flash config path (identifies the saved object)
+   * @param client_configs  ordered list of client networks to try
+   * @param ap_ssid         soft-AP SSID, or "" to leave the AP disabled
+   * @param ap_password     soft-AP password
+   */
+  WiFiProvisioner(const String& config_path,
+                  const std::vector<ClientSSIDConfig>& client_configs,
+                  const String& ap_ssid = "", const String& ap_password = "");
   ~WiFiProvisioner() override;
 
   // -- Resettable --
@@ -214,6 +237,14 @@ class WiFiProvisioner : public FileSystemSaveable,
   int16_t get_wifi_scan_results(std::vector<WiFiNetworkInfo>& ssid_list);
 
  protected:
+  /**
+   * @brief Bring the WiFi interface up from the current ap_settings_ /
+   * client_settings_ state. Shared by both constructors: it pads the client
+   * list to kMaxNumClientConfigs, selects the STA/AP/AP+STA mode, and starts
+   * the access point, client autoconnect, and captive-portal DNS as needed.
+   */
+  void init_wifi();
+
   void start_access_point();
   void start_client_autoconnect();
 

--- a/src/sensesp_app.h
+++ b/src/sensesp_app.h
@@ -162,6 +162,11 @@ class SensESPApp : public SensESPBaseApp {
     this->wifi_client_password_ = wifi_password;
     return this;
   }
+  const SensESPApp* set_wifi_clients(
+      const std::vector<ClientSSIDConfig>& wifi_client_configs) {
+    this->wifi_client_configs_ = wifi_client_configs;
+    return this;
+  }
   const SensESPApp* set_ap_ssid(const String& ssid) {
     this->ap_ssid_ = ssid;
     return this;
@@ -236,9 +241,18 @@ class SensESPApp : public SensESPBaseApp {
       }
     }
     if (!network_provisioner_) {
-      auto wifi = std::make_shared<WiFiProvisioner>(
-          "/System/WiFi Settings", ssid_, wifi_client_password_, ap_ssid_,
-          ap_password_);
+      std::shared_ptr<WiFiProvisioner> wifi;
+      if (!wifi_client_configs_.empty()) {
+        // Multi-network client list provided in code (set_wifi_clients()).
+        wifi = std::make_shared<WiFiProvisioner>("/System/WiFi Settings",
+                                                 wifi_client_configs_, ap_ssid_,
+                                                 ap_password_);
+      } else {
+        // Legacy single-SSID path (set_wifi_client() or defaults).
+        wifi = std::make_shared<WiFiProvisioner>("/System/WiFi Settings", ssid_,
+                                                 wifi_client_password_,
+                                                 ap_ssid_, ap_password_);
+      }
       network_provisioner_ = wifi;
       wifi_provisioner_ = wifi;
     }
@@ -447,6 +461,10 @@ class SensESPApp : public SensESPBaseApp {
 
   String ssid_ = "";
   String wifi_client_password_ = "";
+  // Optional multi-network client list. When non-empty, setup() constructs
+  // the default WiFiProvisioner from this list (failing over between the
+  // entries) instead of the single ssid_/wifi_client_password_ pair.
+  std::vector<ClientSSIDConfig> wifi_client_configs_;
   String sk_server_address_ = "";
   uint16_t sk_server_port_ = 0;
   String ap_ssid_ = "";

--- a/src/sensesp_app_builder.h
+++ b/src/sensesp_app_builder.h
@@ -62,6 +62,29 @@ class SensESPAppBuilder : public SensESPBaseAppBuilder {
   }
 
   /**
+   * @brief Set multiple Wi-Fi client (STA) networks for failover.
+   *
+   * The device tries the networks in order, failing over to the next when
+   * one is unreachable (up to WiFiProvisioner::kMaxNumClientConfigs entries;
+   * extras are dropped, and entries with an empty SSID or password are
+   * ignored). This is the in-code equivalent of the multi-network list the
+   * web UI manages.
+   *
+   * Like set_wifi_client(), these values only seed a device with no saved
+   * WiFi configuration; a configuration saved via the web UI always wins.
+   * Use this instead of set_wifi_client() when you need more than one
+   * network defined in code.
+   *
+   * @param wifi_client_configs ordered list of client networks
+   * @return SensESPAppBuilder*
+   */
+  SensESPAppBuilder* set_wifi_clients(
+      const std::vector<ClientSSIDConfig>& wifi_client_configs) {
+    app_->set_wifi_clients(wifi_client_configs);
+    return this;
+  }
+
+  /**
    * @brief Set the wifi access point object SSID and password.
    *
    * To disable the SSID, set both to empty strings.


### PR DESCRIPTION
## Summary

Adds a first-class multi-network WiFi client API so more than one STA network can be defined **in code**, tried in order with failover — the in-code equivalent of the multi-network list the WiFi web UI already manages.

`WiFiProvisioner` already stored up to `kMaxNumClientConfigs` (3) client networks and failed over between them, but that list could only be populated from a saved (web-UI) config. The builder exposed just a single `set_wifi_client(ssid, password)`. Defining more than one network in code required subclassing `WiFiProvisioner` and installing it via `set_network_provisioner_factory()` — which also skips the `wifi_provisioner_` wiring and so silently drops the WiFi web UI / scan REST handlers.

## What's new

- **`WiFiProvisioner`** gains a constructor taking a `std::vector<ClientSSIDConfig>`, seeding the preset list (skipping entries with an empty SSID/password and honoring the `kMaxNumClientConfigs` cap). The common bring-up is factored into a shared `init_wifi()` helper so both constructors behave identically. Presets still apply only when nothing is saved to flash.
- **`SensESPApp::set_wifi_clients(...)`** stores the list; `setup()` uses the new constructor for the default provisioner when it is non-empty, so `wifi_provisioner_` is set as usual and the WiFi web UI keeps working.
- **`SensESPAppBuilder::set_wifi_clients(...)`** convenience method.

## Usage

```c++
SensESPAppBuilder builder;
auto app = builder.set_hostname("my-device")
                  ->set_wifi_clients({
                      {"PrimarySSID", "password1"},
                      {"BackupSSID", "password2"},
                  })
                  ->get_app();
```

Like `set_wifi_client()`, these presets only seed a device with no saved configuration; a configuration saved through the web UI always wins.

## Backward compatibility

Fully backward compatible. `set_wifi_client()` / the single-SSID constructor and all existing behavior are unchanged.

## Documentation

- Doxygen `@brief`/`@param` on the new constructor and `set_wifi_clients()` builder method.
- `docs/pages/features/index.md`: method-reference table row, a usage snippet in the WiFi section, and a note on the saved-config-wins precedence.

## Testing

- Verified the change applies and builds cleanly.
- New code formatted with clang-format (Google style, per `.clang-format`); reformatting was limited to the lines this change introduces.

## Notes

- `CHANGELOG.md` was intentionally left untouched — it has not been maintained per-PR since 2020 (v0.4.3-era) while the project is at v3.x. Happy to add an entry if maintainers prefer.
