### PR TITLE
fix(signalk): recover a stale token on a plaintext secured server

### DIFF
--- a/src/sensesp/signalk/signalk_ws_client.cpp
+++ b/src/sensesp/signalk/signalk_ws_client.cpp
@@ -417,25 +417,28 @@ void SKWSClient::on_disconnected() {
   this->set_connection_state(SKWSConnectionState::kSKWSDisconnected);
 }
 
+bool should_clear_token_on_status(int handshake_status) {
+  return handshake_status == kHttpUnauthorized;
+}
+
 /**
  * @brief Called when the websocket connection encounters an error.
  *
  * Called in the websocket task context.
  *
  */
-bool should_clear_token_on_status(bool ssl_enabled, int handshake_status) {
-  return ssl_enabled && handshake_status == kHttpUnauthorized;
-}
-
 void SKWSClient::on_error(int handshake_status) {
   this->set_connection_state(SKWSConnectionState::kSKWSDisconnected);
-  if (should_clear_token_on_status(ssl_enabled_, handshake_status)) {
+  if (auth_token_ != NULL_AUTH_TOKEN &&
+      should_clear_token_on_status(handshake_status)) {
     // The server rejected the token on the WebSocket upgrade (e.g. the server
     // was reinstalled, or the device was moved to a different server). Clear it
-    // so the next reconnect requests fresh access, and shorten the backoff so
-    // re-authorization starts promptly instead of after the (possibly grown)
-    // reconnect interval. A non-401 error (transport, TLS, network) leaves the
-    // token intact and simply retries.
+    // so the next reconnect requests fresh access, and reset the backoff so
+    // attempts after the already-scheduled one come at the short interval. A
+    // 401 on a tokenless upgrade cannot mean a stale token: it falls through
+    // to the retry branch, keeping the backoff growing and avoiding a config
+    // flash write per attempt. A non-401 error (transport, TLS, network)
+    // leaves the token intact and simply retries.
     ESP_LOGW(__FILENAME__, "Token rejected (%d), requesting new access",
              handshake_status);
     auth_token_ = NULL_AUTH_TOKEN;

--- a/src/sensesp/signalk/signalk_ws_client.h
+++ b/src/sensesp/signalk/signalk_ws_client.h
@@ -57,11 +57,19 @@ static constexpr int kHttpUnauthorized = 401;
 /**
  * @brief Decide whether a failed WebSocket upgrade should clear the auth token.
  *
- * Only an authenticated (TLS) channel yields a trustworthy handshake status;
- * over plaintext the status could be injected by an on-path attacker, so the
- * token is never discarded based on it.
+ * A 401 on the upgrade means the server rejected the presented token, and the
+ * device must re-request access to recover; the caller acts on it only when a
+ * token was actually sent. The decision is transport-independent: over
+ * plaintext the status is unauthenticated, so anything that can answer for the
+ * server (an on-path attacker, or any same-network device when mDNS discovery
+ * is enabled) can inject a 401 to force a token wipe and a manual re-approval.
+ * But gating on TLS leaves a plaintext deployment with no recovery route at
+ * all, locked out indefinitely on a stale token. Recovering on its own is the
+ * better failure mode. TLS deployments with a pinned TOFU anchor are
+ * unaffected, since their 401 is authenticated; with TOFU disabled or before
+ * an anchor is pinned, the status is as spoofable as plaintext.
  */
-bool should_clear_token_on_status(bool ssl_enabled, int handshake_status);
+bool should_clear_token_on_status(int handshake_status);
 
 enum class SKWSConnectionState {
   kSKWSDisconnected,

--- a/test/system/test_sk_token_clear/main.cpp
+++ b/test/system/test_sk_token_clear/main.cpp
@@ -3,31 +3,27 @@
 
 using namespace sensesp;
 
-// A token may only be discarded when the rejecting server is reached over an
-// authenticated (TLS) channel and the upgrade status is 401.
-void test_clears_on_ssl_401() {
-  TEST_ASSERT_TRUE(should_clear_token_on_status(true, 401));
+// A 401 on the upgrade means the server rejected the token: discard it so the
+// next reconnect re-requests access. The decision does not depend on the
+// transport -- a plaintext deployment would otherwise have no recovery route
+// and would loop forever on a stale token.
+void test_clears_on_401() {
+  TEST_ASSERT_TRUE(should_clear_token_on_status(401));
 }
 
-// Any non-401 status over TLS is a transport/TLS/network error: keep the token.
-void test_keeps_token_on_ssl_non_401() {
-  TEST_ASSERT_FALSE(should_clear_token_on_status(true, 0));
-  TEST_ASSERT_FALSE(should_clear_token_on_status(true, 200));
-  TEST_ASSERT_FALSE(should_clear_token_on_status(true, 426));
-  TEST_ASSERT_FALSE(should_clear_token_on_status(true, 500));
-}
-
-// Over plaintext the status is unauthenticated and could be injected by an
-// on-path attacker, so a 401 must never wipe the token.
-void test_keeps_token_on_plaintext_401() {
-  TEST_ASSERT_FALSE(should_clear_token_on_status(false, 401));
+// Any status other than 401 keeps the token. 0 is the "not applicable" value
+// reported by websocket clients that do not expose the handshake status.
+void test_keeps_token_on_non_401() {
+  TEST_ASSERT_FALSE(should_clear_token_on_status(0));
+  TEST_ASSERT_FALSE(should_clear_token_on_status(200));
+  TEST_ASSERT_FALSE(should_clear_token_on_status(426));
+  TEST_ASSERT_FALSE(should_clear_token_on_status(500));
 }
 
 void setup() {
   UNITY_BEGIN();
-  RUN_TEST(test_clears_on_ssl_401);
-  RUN_TEST(test_keeps_token_on_ssl_non_401);
-  RUN_TEST(test_keeps_token_on_plaintext_401);
+  RUN_TEST(test_clears_on_401);
+  RUN_TEST(test_keeps_token_on_non_401);
   UNITY_END();
 }
 


### PR DESCRIPTION
## Problem

An **SSL-capable build** (`SENSESP_SSL_SUPPORT`) connecting to a **security-enabled** Signal K server over **plaintext `ws://`** has no bad-token recovery path and loops forever on the WebSocket-upgrade 401.

Two pieces from #1048's follow-up (4224d955f, "preserve non-SSL token recovery, gate 401 clear on TLS") interact to leave a gap:

- `test_token()` — the plain-HTTP probe that clears a rejected token and re-requests access — is compiled **only** under `#ifndef SENSESP_SSL_SUPPORT`.
- `should_clear_token_on_status()` refused to clear on a **plaintext** WS-upgrade 401, so `on_error()` never cleared the token either.

So an SSL-*capable* build pointed at a **plaintext** secured server with a stale/rotated token never re-authorises: repeated 401s, no access request, and the device sits "disconnected" indefinitely.

Observed on an ESP32-P4 panel against a secured Signal K 2.30 server on plain `:80`:
```
esp_ws_handshake_status_code=401
W signalk_ws_client.cpp: Websocket client error.   <- the wrong branch; token kept
I websocket_client: Reconnect after 10000 ms       <- forever
```

## Fix

Drop the TLS condition from `should_clear_token_on_status()`:

```cpp
bool should_clear_token_on_status(int handshake_status) {
  return handshake_status == kHttpUnauthorized;
}
```

The `#ifdef SENSESP_SSL_SUPPORT` that selects the handshake status keys on the **build**, not the connection, so an SSL-capable build already receives the real upgrade status over plaintext. The device knows it got a 401 — it just refused to act on it. No second channel and no extra HTTP round trip per reconnect are needed to re-learn that.

This also picks up `reset_reconnect_interval()` for free, since `on_error()` already calls it on the token-clear path, so recovery starts promptly instead of at the grown backoff.

The decision is now transport-independent, so the `ssl_enabled` parameter is removed rather than ignored.

`arduino_esp32` is unchanged: the EOL platform's bundled `esp_websocket_client` has no handshake status field, so `on_error()` gets a 0 and `test_token()` remains its only recovery route. Both flavours now agree on what a 401 means — the property that broke here in the first place.

### The tradeoff, stated plainly

This accepts what the gate was added to prevent: on a plaintext network, anything that can answer for the server can force a token wipe and a manual re-approval. That is the pre-4224d955f behaviour that ran for years, TLS deployments are unaffected because their 401 is authenticated, and a device that recovers on its own beats one that can be locked out indefinitely. Requiring two consecutive 401s before wiping would blunt the DoS later; not in this PR.

## Verified on hardware

ESP32-P4, SSL-capable build, secured Signal K 2.30 on plain `:80`, `ssl_enabled: false`.

Confirming the premise directly against the server, before any firmware change:

| Token | Plaintext `ws://` upgrade |
|---|---|
| valid | `101 Switching Protocols` |
| stale | `401` |

Then the full cycle with this patch flashed, injecting a stale token (valid JWT structure, corrupted signature) and restarting:

```
E websocket_client: esp_transport_connect() failed with -1, ... esp_ws_handshake_status_code=401, errno=119
W signalk_ws_client.cpp: Token rejected (401), requesting new access
```

- stored token cleared (config `token` empty)
- access request filed — server reports `{"state":"PENDING","ip":"::ffff:192.168.0.118"}`
- approving it in Security → Access Requests flips the request to `COMPLETED`/`APPROVED`
- the device collects the issued token (byte-identical to the one the server minted), clears `polling_href`, and the WebSocket reconnects — delta RX climbing again

Test suites compile clean on `espidf_esp32` (16/16) and `arduino_esp32` (15/15); the three native suites run green (25 assertions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR makes Signal K token recovery transport-independent for SSL-capable builds.

- Clears a presented token when the WebSocket upgrade returns HTTP 401.
- Removes the unused `ssl_enabled` parameter from `should_clear_token_on_status()`.
- Avoids an additional HTTP probe.
- Resets the reconnect interval during recovery.
- Keeps the `arduino_esp32` path unchanged.
- Updates tests for 401 and non-401 statuses.
- Documents the plaintext token-wipe tradeoff.

Hardware verification confirms recovery over plaintext port 80. Platform and native tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->