### PR TITLE
Add CodeRabbit review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,85 @@
+language: en-US
+
+reviews:
+  profile: assertive
+  auto_review:
+    enabled: true
+    drafts: false
+  high_level_summary_instructions: |
+    Write all summaries in present tense.
+    Describe what the code does, not what it did.
+    Example: "This PR adds feature X" instead of "This PR added feature X"
+
+  path_instructions:
+    - path: '**/*'
+      instructions: |
+        ## Contribution guidelines compliance
+        Check that the PR follows the SensESP contribution guidelines:
+        https://github.com/SignalK/SensESP/blob/main/docs/pages/contributing_code/index.md
+        Flag any deviation in PR structure, commit message format, or documentation
+        requirements. In particular: commits should be small and atomic, pure
+        reformatting belongs in its own commit, and the branch should not carry
+        merge commits from upstream.
+
+        ## Echo comments
+        Flag any comment that merely restates what the code already says.
+        Examples of echo comments to flag:
+        - `// Set the pin` above a method named `set_pin()`
+        - `// Loop through the sensors` above a `for` loop
+        These add noise without adding meaning. Request removal or replacement
+        with a comment explaining *why*, not *what*.
+        Doxygen blocks are exempt — see below.
+
+        ## Doxygen documentation of public API
+        Public classes and methods in `src/**/*.h` are the source of the generated
+        API documentation. Flag a new public class that has no `/** @brief ... */`
+        block, and a documented constructor whose parameters are not covered by
+        `@param`. Never flag a Doxygen block as an echo comment, even when it
+        repeats the class or parameter name — these blocks are required.
+
+        ## Leftover crumbs from intermediate commits
+        Check for references to things that existed in earlier commits of this PR
+        but are no longer present — removed variables, old function names, deleted
+        files, superseded approaches. These are confusing to future readers.
+        Flag any comments, docs, or code that refer to something not present in
+        the current state of the branch.
+
+        ## Documentation drift risk
+        Flag any .md file that contains detailed implementation steps, specific
+        API call sequences, code snippets, or configuration values that are likely
+        to fall out of sync as the code evolves. Documentation should describe
+        architecture and how things work conceptually — not step-by-step
+        instructions that duplicate or shadow the code itself.
+
+        ## Unchecked items in test plans
+        If a PR description or any .md file contains a checklist with unchecked
+        items, flag it. Either the work is incomplete, or the checklist should be
+        removed before merge. Do not let unchecked boxes pass silently.
+
+        ## Implementation status in documentation
+        Flag any .md file that describes implementation progress, status, or
+        build steps (e.g. "Step 3: implement X", "TODO: add Y", "currently
+        implemented as Z"). This belongs in PR descriptions or commit messages,
+        not in documentation. Documentation should describe how things work,
+        not how they were built or what stage they are in.
+        Architecture decisions and design rationale are fine. Build narratives
+        are not.
+
+        ## What NOT to flag
+        Do not flag the following patterns — they are intentional:
+        - Identifier naming that follows `.clang-tidy`: trailing underscore on
+          private and protected members, `k` prefix on constants and enum
+          constants, `lower_case` variables, `CamelCase` types. Do not suggest
+          renames towards other conventions.
+        - Formatting that `.clang-format` owns: 2-space indent, Google style,
+          include ordering and grouping. Formatting nits are handled by the
+          formatter, not by review.
+        - Missing host tests for code that includes `sensesp.h`. That code needs
+          Arduino, ReactESP and FreeRTOS, so it only builds on target and its
+          tests live in `test/system/`. `test/native/` is for self-contained
+          headers only — do not ask for native tests for framework code.
+
+        ## Scope
+        Focus on files changed since main. Think carefully about how changes
+        interact with existing code and documentation — not just the diff in
+        isolation.

--- a/docs/pages/contributing_code/index.md
+++ b/docs/pages/contributing_code/index.md
@@ -24,6 +24,8 @@ If you like SensESP and want to make it even better, please do! It's written in 
 
 - Normally, you should not need to modify `platformio.ini` for your PR. However, if you're adding code that requires a new library dependency, add the dependency both to `library.json` and `platformio.ini`. If you have questions, the best place to discuss SensESP is on [Signal K Discord Server](https://github.com/SignalK/SensESP/discussions), in the `#sensesp` channel.
 
+- Every pull request is reviewed automatically by [CodeRabbit](https://coderabbit.ai/). Address the comments it raises, or explain why they don't apply, before a maintainer picks up the review.
+
 ## Write Comments That Create Interactive Documentation
 
 SensESP is set up to generate Doxygen documentation files from the comments in the .h files, if you follow the appropriate formatting for your comments. So if you create a new .h file, or if you're working on an existing one, please use the following comment format for every Class definition.


### PR DESCRIPTION
Enables automated CodeRabbit reviews on pull requests, using the same setup that signalk-server runs.

The configuration is adapted from signalk-server's `.coderabbit.yaml`: assertive profile, auto-review on non-draft PRs, present-tense summaries, and the review instructions covering echo comments, leftover references from intermediate commits, documentation drift, and unchecked checklists.

Three parts are SensESP-specific rather than copied:

- The guidelines link points at `docs/pages/contributing_code/index.md`, and the review checks the atomic-commit, separate-reformatting, and no-merge-commit rules stated there.
- A Doxygen section asks for `@brief` on new public classes and `@param` coverage on documented constructors, and exempts Doxygen blocks from the echo-comment rule.
- The "what not to flag" list carries the naming rules from `.clang-tidy`, the formatting `.clang-format` owns, and the fact that code including `sensesp.h` cannot have `test/native` tests.

The contributing guide gains one line telling contributors that CodeRabbit reviews every PR and that its comments should be addressed before a maintainer picks the PR up.

Installing the CodeRabbit GitHub App on the repository is a separate step in the GitHub UI; this config takes effect once that is done.