### PR TITLE
Add example, displayScale, and zones metadata fields

### DIFF
--- a/docs/pages/concepts/index.md
+++ b/docs/pages/concepts/index.md
@@ -407,3 +407,7 @@ Here are three different ways to specify the Units for any data you're sending t
 ```
 
 If the only metadata you want to provide is the Units, that's most easily done the first of the three ways above. If you want to provide more metadata than just the Units, the last way above is probably best. It's certainly easier to understand than the middle approach above.
+
+### Display scale, zones, and other metadata fields
+
+Beyond the descriptive fields above, `SKMetadata` supports the remaining fields of the Signal K [meta model](https://signalk.org/specification/1.5.0/doc/data_model_metadata.html): `supportsPut`, `example`, `displayScale`, and `zones`. A `displayScale` gives gauges a fixed range and requires both bounds. `zones` map value ranges to alarm states; a missing zone bound means the zone is unbounded on that side. SensESP emits zones in the order they were added; consumers differ in how they resolve overlapping zones, so prefer non-overlapping zones. See the [`rpm_counter.cpp` example](https://github.com/SignalK/SensESP/blob/main/examples/rpm_counter.cpp) for a display scale and alarm zones in context.

--- a/examples/rpm_counter.cpp
+++ b/examples/rpm_counter.cpp
@@ -76,7 +76,19 @@ void setup() {
       ->set_description("Frequency of the engine RPM signal")
       ->set_sort_order(1000);
 
-  auto frequency_sk_output = new SKOutput<float>(sk_path, config_path_skpath);
+  // Metadata lets consumers render a gauge with a sensible range and raise
+  // an overspeed alarm. displayScale needs both bounds; keep zones
+  // non-overlapping so every consumer resolves them the same way.
+  auto* metadata = new SKMetadata("Hz", "Engine RPM");
+  metadata->display_scale_lower_ = 0.0f;
+  metadata->display_scale_upper_ = 120.0f;
+  metadata->zones_.push_back(
+      SKMetadataZone(SKAlarmState::kNominal, "Normal range", 10.0f, 100.0f));
+  metadata->zones_.push_back(
+      SKMetadataZone(SKAlarmState::kAlarm, "Overspeed", 110.0f));
+
+  auto frequency_sk_output =
+      new SKOutput<float>(sk_path, config_path_skpath, metadata);
 
   ConfigItem(frequency_sk_output)
       ->set_title("Frequency SK Output Path")

--- a/src/sensesp/signalk/signalk_metadata.cpp
+++ b/src/sensesp/signalk/signalk_metadata.cpp
@@ -49,15 +49,11 @@ void SKMetadata::add_entry(const String& sk_path, JsonArray& meta) {
     val["example"] = this->example_;
   }
 
-  if (!std::isnan(this->display_scale_lower_) ||
+  if (!std::isnan(this->display_scale_lower_) &&
       !std::isnan(this->display_scale_upper_)) {
     JsonObject scale = val["displayScale"].to<JsonObject>();
-    if (!std::isnan(this->display_scale_lower_)) {
-      scale["lower"] = this->display_scale_lower_;
-    }
-    if (!std::isnan(this->display_scale_upper_)) {
-      scale["upper"] = this->display_scale_upper_;
-    }
+    scale["lower"] = this->display_scale_lower_;
+    scale["upper"] = this->display_scale_upper_;
   }
 
   if (!this->zones_.empty()) {

--- a/src/sensesp/signalk/signalk_metadata.cpp
+++ b/src/sensesp/signalk/signalk_metadata.cpp
@@ -12,9 +12,7 @@ SKMetadata::SKMetadata(const String& units, const String& display_name,
       description_{description},
       short_name_{short_name},
       timeout_{timeout},
-      supports_put_{supports_put},
-      display_scale_lower_{NAN},
-      display_scale_upper_{NAN} {}
+      supports_put_{supports_put} {}
 
 void SKMetadata::add_entry(const String& sk_path, JsonArray& meta) {
   JsonObject json = meta.add<JsonObject>();
@@ -61,7 +59,9 @@ void SKMetadata::add_entry(const String& sk_path, JsonArray& meta) {
     for (const SKMetadataZone& zone : this->zones_) {
       JsonObject zone_obj = zones_arr.add<JsonObject>();
       zone_obj["state"] = alarm_state_to_string(zone.state);
-      zone_obj["message"] = zone.message;
+      if (!zone.message.isEmpty()) {
+        zone_obj["message"] = zone.message;
+      }
       if (!std::isnan(zone.lower)) zone_obj["lower"] = zone.lower;
       if (!std::isnan(zone.upper)) zone_obj["upper"] = zone.upper;
     }
@@ -70,14 +70,20 @@ void SKMetadata::add_entry(const String& sk_path, JsonArray& meta) {
 
 const char* SKMetadata::alarm_state_to_string(SKAlarmState state) {
   switch (state) {
-    case SKAlarmState::kNominal:   return "nominal";
-    case SKAlarmState::kNormal:    return "normal";
-    case SKAlarmState::kAlert:     return "alert";
-    case SKAlarmState::kWarn:      return "warn";
-    case SKAlarmState::kAlarm:     return "alarm";
-    case SKAlarmState::kEmergency: return "emergency";
-    default:                       return "normal";
+    case SKAlarmState::kNominal:
+      return "nominal";
+    case SKAlarmState::kNormal:
+      return "normal";
+    case SKAlarmState::kAlert:
+      return "alert";
+    case SKAlarmState::kWarn:
+      return "warn";
+    case SKAlarmState::kAlarm:
+      return "alarm";
+    case SKAlarmState::kEmergency:
+      return "emergency";
   }
+  return "normal";
 }
 
 }  // namespace sensesp

--- a/src/sensesp/signalk/signalk_metadata.cpp
+++ b/src/sensesp/signalk/signalk_metadata.cpp
@@ -1,5 +1,7 @@
 #include "signalk_metadata.h"
 
+#include <cmath>
+
 namespace sensesp {
 
 SKMetadata::SKMetadata(const String& units, const String& display_name,
@@ -10,7 +12,9 @@ SKMetadata::SKMetadata(const String& units, const String& display_name,
       description_{description},
       short_name_{short_name},
       timeout_{timeout},
-      supports_put_{supports_put} {}
+      supports_put_{supports_put},
+      display_scale_lower_{NAN},
+      display_scale_upper_{NAN} {}
 
 void SKMetadata::add_entry(const String& sk_path, JsonArray& meta) {
   JsonObject json = meta.add<JsonObject>();
@@ -39,6 +43,44 @@ void SKMetadata::add_entry(const String& sk_path, JsonArray& meta) {
 
   if (this->supports_put_) {
     val["supportsPut"] = this->supports_put_;
+  }
+
+  if (!this->example_.isEmpty()) {
+    val["example"] = this->example_;
+  }
+
+  if (!std::isnan(this->display_scale_lower_) ||
+      !std::isnan(this->display_scale_upper_)) {
+    JsonObject scale = val["displayScale"].to<JsonObject>();
+    if (!std::isnan(this->display_scale_lower_)) {
+      scale["lower"] = this->display_scale_lower_;
+    }
+    if (!std::isnan(this->display_scale_upper_)) {
+      scale["upper"] = this->display_scale_upper_;
+    }
+  }
+
+  if (!this->zones_.empty()) {
+    JsonArray zones_arr = val["zones"].to<JsonArray>();
+    for (const SKMetadataZone& zone : this->zones_) {
+      JsonObject zone_obj = zones_arr.add<JsonObject>();
+      zone_obj["state"] = alarm_state_to_string(zone.state);
+      zone_obj["message"] = zone.message;
+      if (!std::isnan(zone.lower)) zone_obj["lower"] = zone.lower;
+      if (!std::isnan(zone.upper)) zone_obj["upper"] = zone.upper;
+    }
+  }
+}
+
+const char* SKMetadata::alarm_state_to_string(SKAlarmState state) {
+  switch (state) {
+    case SKAlarmState::kNominal:   return "nominal";
+    case SKAlarmState::kNormal:    return "normal";
+    case SKAlarmState::kAlert:     return "alert";
+    case SKAlarmState::kWarn:      return "warn";
+    case SKAlarmState::kAlarm:     return "alarm";
+    case SKAlarmState::kEmergency: return "emergency";
+    default:                       return "normal";
   }
 }
 

--- a/src/sensesp/signalk/signalk_metadata.h
+++ b/src/sensesp/signalk/signalk_metadata.h
@@ -9,7 +9,8 @@ namespace sensesp {
 
 /**
  * @brief Alarm state values for Signal K Zone metadata.
- * @see https://demo.signalk.org/documentation/_signalk/server-api/ALARM_STATE.html
+ * @see
+ * https://demo.signalk.org/documentation/_signalk/server-api/ALARM_STATE.html
  */
 enum class SKAlarmState {
   kNominal,
@@ -22,16 +23,27 @@ enum class SKAlarmState {
 
 /**
  * @brief Represents a single Signal K alarm zone within metadata.
+ *
+ * A missing bound means the zone is unbounded on that side. Zones are
+ * emitted in the order they were added; consumers differ in how they
+ * resolve overlapping zones, so prefer non-overlapping zones.
+ *
  * @see https://demo.signalk.org/documentation/_signalk/server-api/Zone.html
  */
 struct SKMetadataZone {
-  float lower;    ///< Lower bound of the zone; NAN if not set
-  float upper;    ///< Upper bound of the zone; NAN if not set
+  float lower;  ///< Lower bound of the zone; NAN if not set
+  float upper;  ///< Upper bound of the zone; NAN if not set
   String message;
   SKAlarmState state;
 
-  SKMetadataZone(SKAlarmState state, const String& message,
-                 float lower = NAN, float upper = NAN)
+  /**
+   * @param state Alarm state the zone maps to.
+   * @param message Text shown for values in the zone.
+   * @param lower Lower bound; pass NAN for a zone only bounded from above.
+   * @param upper Upper bound; omit for a zone only bounded from below.
+   */
+  SKMetadataZone(SKAlarmState state, const String& message, float lower,
+                 float upper = NAN)
       : lower{lower}, upper{upper}, message{message}, state{state} {}
 };
 
@@ -59,14 +71,18 @@ class SKMetadata {
   String short_name_;
   float timeout_;
   bool supports_put_;
-  String example_;
-  float display_scale_lower_;   ///< NAN = not set; displayScale requires both bounds
-  float display_scale_upper_;   ///< NAN = not set; displayScale requires both bounds
+  String example_;  ///< Example value for the path, shown by consumers
+  /// NAN = not set; displayScale is emitted only when both bounds are set
+  float display_scale_lower_ = NAN;
+  /// NAN = not set; displayScale is emitted only when both bounds are set
+  float display_scale_upper_ = NAN;
+  /// Alarm zones, emitted in the order they were added
   std::vector<SKMetadataZone> zones_;
 
   /**
-   * @param units The unit of measurement the value represents. This is primarily used
-   * for numeric values. If NO unit needs to be specified, pass an empty string. See
+   * @param units The unit of measurement the value represents. This is
+   * primarily used for numeric values. If NO unit needs to be specified, pass
+   * an empty string. See
    * https://github.com/SignalK/specification/blob/master/schemas/definitions.json#L87
    * @param display_name This is used on or near any display or gauge which
    * shows the data.
@@ -87,11 +103,7 @@ class SKMetadata {
              float timeout = -1.0, bool supports_put = false);
 
   /// Default constructor creates a blank Metadata structure
-  SKMetadata()
-      : timeout_{-1},
-        supports_put_{false},
-        display_scale_lower_{NAN},
-        display_scale_upper_{NAN} {}
+  SKMetadata() : timeout_{-1}, supports_put_{false} {}
 
   /**
    * Adds an entry to the specified meta array that represents this metadata
@@ -102,7 +114,7 @@ class SKMetadata {
    */
   virtual void add_entry(const String& sk_path, JsonArray& meta);
 
- private:
+ protected:
   static const char* alarm_state_to_string(SKAlarmState state);
 };
 

--- a/src/sensesp/signalk/signalk_metadata.h
+++ b/src/sensesp/signalk/signalk_metadata.h
@@ -2,8 +2,38 @@
 #define SENSESP_SIGNALK_SIGNALK_METADATA_H_
 
 #include <ArduinoJson.h>
+#include <cmath>
+#include <vector>
 
 namespace sensesp {
+
+/**
+ * @brief Alarm state values for Signal K Zone metadata.
+ * @see https://demo.signalk.org/documentation/_signalk/server-api/ALARM_STATE.html
+ */
+enum class SKAlarmState {
+  kNominal,
+  kNormal,
+  kAlert,
+  kWarn,
+  kAlarm,
+  kEmergency
+};
+
+/**
+ * @brief Represents a single Signal K alarm zone within metadata.
+ * @see https://demo.signalk.org/documentation/_signalk/server-api/Zone.html
+ */
+struct SKMetadataZone {
+  float lower;    ///< Lower bound of the zone; NAN if not set
+  float upper;    ///< Upper bound of the zone; NAN if not set
+  String message;
+  SKAlarmState state;
+
+  SKMetadataZone(SKAlarmState state, const String& message,
+                 float lower = NAN, float upper = NAN)
+      : lower{lower}, upper{upper}, message{message}, state{state} {}
+};
 
 /**
  * @brief Holds Signal K meta data that is associated with
@@ -29,6 +59,10 @@ class SKMetadata {
   String short_name_;
   float timeout_;
   bool supports_put_;
+  String example_;
+  float display_scale_lower_;   ///< NAN = not set
+  float display_scale_upper_;   ///< NAN = not set
+  std::vector<SKMetadataZone> zones_;
 
   /**
    * @param units The unit of measurement the value represents. This is primarily used
@@ -53,7 +87,11 @@ class SKMetadata {
              float timeout = -1.0, bool supports_put = false);
 
   /// Default constructor creates a blank Metadata structure
-  SKMetadata() : timeout_{-1}, supports_put_{false} {}
+  SKMetadata()
+      : timeout_{-1},
+        supports_put_{false},
+        display_scale_lower_{NAN},
+        display_scale_upper_{NAN} {}
 
   /**
    * Adds an entry to the specified meta array that represents this metadata
@@ -63,6 +101,9 @@ class SKMetadata {
    * @param[out] meta The array the metadata entry is supposed to be added to
    */
   virtual void add_entry(const String& sk_path, JsonArray& meta);
+
+ private:
+  static const char* alarm_state_to_string(SKAlarmState state);
 };
 
 }  // namespace sensesp

--- a/src/sensesp/signalk/signalk_metadata.h
+++ b/src/sensesp/signalk/signalk_metadata.h
@@ -60,8 +60,8 @@ class SKMetadata {
   float timeout_;
   bool supports_put_;
   String example_;
-  float display_scale_lower_;   ///< NAN = not set
-  float display_scale_upper_;   ///< NAN = not set
+  float display_scale_lower_;   ///< NAN = not set; displayScale requires both bounds
+  float display_scale_upper_;   ///< NAN = not set; displayScale requires both bounds
   std::vector<SKMetadataZone> zones_;
 
   /**

--- a/test/native/test_sk_metadata/WString.h
+++ b/test/native/test_sk_metadata/WString.h
@@ -1,0 +1,28 @@
+/**
+ * @file WString.h
+ * @brief Minimal Arduino String stand-in for host-run tests.
+ *
+ * The native env has no Arduino core. This provides just enough of the
+ * String API for signalk_metadata.cpp, plus an ArduinoJson custom
+ * converter so `json["key"] = String(...)` serializes as a JSON string.
+ */
+
+#ifndef SENSESP_TEST_NATIVE_TEST_SK_METADATA_WSTRING_H_
+#define SENSESP_TEST_NATIVE_TEST_SK_METADATA_WSTRING_H_
+
+#include <ArduinoJson.h>
+#include <string>
+
+class String : public std::string {
+ public:
+  String() = default;
+  String(const char* s) : std::string(s ? s : "") {}
+  String(const std::string& s) : std::string(s) {}
+  bool isEmpty() const { return empty(); }
+};
+
+inline void convertToJson(const String& src, ArduinoJson::JsonVariant dst) {
+  dst.set(src.c_str());
+}
+
+#endif

--- a/test/native/test_sk_metadata/sk_metadata_test.cpp
+++ b/test/native/test_sk_metadata/sk_metadata_test.cpp
@@ -1,0 +1,172 @@
+/**
+ * @file sk_metadata_test.cpp
+ * @brief Host unit tests for SKMetadata::add_entry serialization.
+ *
+ * Runs on the `native` env (no Arduino core):
+ *   pio test -e native -f native/test_sk_metadata
+ *
+ * The first tests pin the exact JSON emitted when none of the newer fields
+ * are set, so additions to SKMetadata cannot silently change what existing
+ * firmware sends. The rest cover the example, supportsPut, displayScale,
+ * and zones serialization added for the Signal K MetaValue model.
+ */
+
+#include <ArduinoJson.h>
+#include <unity.h>
+
+#include "WString.h"
+#include "sensesp/signalk/signalk_metadata.cpp"
+
+using namespace sensesp;
+
+static std::string entry_json(SKMetadata& meta_obj, const char* path) {
+  JsonDocument doc;
+  JsonArray meta = doc.to<JsonArray>();
+  meta_obj.add_entry(String(path), meta);
+  std::string output;
+  serializeJson(doc, output);
+  return output;
+}
+
+void test_default_metadata(void) {
+  SKMetadata meta;
+  TEST_ASSERT_EQUAL_STRING("[{\"path\":\"test.path\",\"value\":{}}]",
+                           entry_json(meta, "test.path").c_str());
+}
+
+void test_units_only(void) {
+  SKMetadata meta("V");
+  TEST_ASSERT_EQUAL_STRING(
+      "[{\"path\":\"test.path\",\"value\":{\"units\":\"V\"}}]",
+      entry_json(meta, "test.path").c_str());
+}
+
+void test_legacy_fields(void) {
+  SKMetadata meta("V", "Battery Voltage", "House battery", "Batt V", 30.0,
+                  true);
+  TEST_ASSERT_EQUAL_STRING(
+      "[{\"path\":\"test.path\",\"value\":{"
+      "\"displayName\":\"Battery Voltage\",\"units\":\"V\","
+      "\"description\":\"House battery\",\"shortName\":\"Batt V\","
+      "\"timeout\":30,\"supportsPut\":true}}]",
+      entry_json(meta, "test.path").c_str());
+}
+
+void test_supports_put_false_omitted(void) {
+  SKMetadata meta("V");
+  meta.supports_put_ = false;
+  TEST_ASSERT_EQUAL_STRING(
+      "[{\"path\":\"test.path\",\"value\":{\"units\":\"V\"}}]",
+      entry_json(meta, "test.path").c_str());
+}
+
+void test_example_field(void) {
+  SKMetadata meta;
+  meta.example_ = "12.6";
+  TEST_ASSERT_EQUAL_STRING(
+      "[{\"path\":\"test.path\",\"value\":{\"example\":\"12.6\"}}]",
+      entry_json(meta, "test.path").c_str());
+}
+
+void test_display_scale_both_bounds(void) {
+  SKMetadata meta;
+  meta.display_scale_lower_ = 0.0f;
+  meta.display_scale_upper_ = 8000.0f;
+  TEST_ASSERT_EQUAL_STRING(
+      "[{\"path\":\"test.path\",\"value\":{"
+      "\"displayScale\":{\"lower\":0,\"upper\":8000}}}]",
+      entry_json(meta, "test.path").c_str());
+}
+
+// A one-sided displayScale is invalid per the Signal K schema: omit it.
+void test_display_scale_single_bound_omitted(void) {
+  SKMetadata lower_only;
+  lower_only.display_scale_lower_ = 0.0f;
+  TEST_ASSERT_EQUAL_STRING("[{\"path\":\"test.path\",\"value\":{}}]",
+                           entry_json(lower_only, "test.path").c_str());
+
+  SKMetadata upper_only;
+  upper_only.display_scale_upper_ = 8000.0f;
+  TEST_ASSERT_EQUAL_STRING("[{\"path\":\"test.path\",\"value\":{}}]",
+                           entry_json(upper_only, "test.path").c_str());
+}
+
+void test_zones(void) {
+  SKMetadata meta;
+  meta.zones_.push_back(
+      SKMetadataZone(SKAlarmState::kNominal, "Normal range", 600.0f, 6500.0f));
+  meta.zones_.push_back(
+      SKMetadataZone(SKAlarmState::kAlarm, "Overspeed", 7000.0f));
+  TEST_ASSERT_EQUAL_STRING(
+      "[{\"path\":\"test.path\",\"value\":{\"zones\":["
+      "{\"state\":\"nominal\",\"message\":\"Normal range\","
+      "\"lower\":600,\"upper\":6500},"
+      "{\"state\":\"alarm\",\"message\":\"Overspeed\",\"lower\":7000}"
+      "]}}]",
+      entry_json(meta, "test.path").c_str());
+}
+
+void test_zone_upper_only(void) {
+  SKMetadata meta;
+  meta.zones_.push_back(
+      SKMetadataZone(SKAlarmState::kAlarm, "Low fuel", NAN, 0.1f));
+  TEST_ASSERT_EQUAL_STRING(
+      "[{\"path\":\"test.path\",\"value\":{\"zones\":["
+      "{\"state\":\"alarm\",\"message\":\"Low fuel\",\"upper\":0.1}"
+      "]}}]",
+      entry_json(meta, "test.path").c_str());
+}
+
+// An empty zone message is omitted so the server default applies.
+void test_zone_empty_message_omitted(void) {
+  SKMetadata meta;
+  meta.zones_.push_back(SKMetadataZone(SKAlarmState::kWarn, "", 100.0f));
+  TEST_ASSERT_EQUAL_STRING(
+      "[{\"path\":\"test.path\",\"value\":{\"zones\":["
+      "{\"state\":\"warn\",\"lower\":100}"
+      "]}}]",
+      entry_json(meta, "test.path").c_str());
+}
+
+void test_alarm_state_strings(void) {
+  const struct {
+    SKAlarmState state;
+    const char* expected;
+  } cases[] = {
+      {SKAlarmState::kNominal, "nominal"},
+      {SKAlarmState::kNormal, "normal"},
+      {SKAlarmState::kAlert, "alert"},
+      {SKAlarmState::kWarn, "warn"},
+      {SKAlarmState::kAlarm, "alarm"},
+      {SKAlarmState::kEmergency, "emergency"},
+  };
+  for (const auto& c : cases) {
+    SKMetadata meta;
+    meta.zones_.push_back(SKMetadataZone(c.state, "msg", 1.0f));
+    std::string expected =
+        std::string("[{\"path\":\"test.path\",\"value\":{\"zones\":[") +
+        "{\"state\":\"" + c.expected + "\",\"message\":\"msg\",\"lower\":1}" +
+        "]}}]";
+    TEST_ASSERT_EQUAL_STRING(expected.c_str(),
+                             entry_json(meta, "test.path").c_str());
+  }
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_default_metadata);
+  RUN_TEST(test_units_only);
+  RUN_TEST(test_legacy_fields);
+  RUN_TEST(test_supports_put_false_omitted);
+  RUN_TEST(test_example_field);
+  RUN_TEST(test_display_scale_both_bounds);
+  RUN_TEST(test_display_scale_single_bound_omitted);
+  RUN_TEST(test_zones);
+  RUN_TEST(test_zone_upper_only);
+  RUN_TEST(test_zone_empty_message_omitted);
+  RUN_TEST(test_alarm_state_strings);
+  return UNITY_END();
+}


### PR DESCRIPTION
Closes #848.

This supersedes PR https://github.com/SignalK/SensESP/pull/850 by @mxtommy, whose commit this branch carries with authorship preserved. That PR was written against a 3.2.3-alpha checkout and both files now conflict with main; its head branch is the fork's `main`, so it could not be updated in place.

## What this adds

`SKMetadata` gains the remaining MetaValue fields from the Signal K specification: `example`, `displayScale`, and `zones`, serialized by `add_entry()` only when set. `SKAlarmState` maps to the spec's lowercase zone state strings. (`supportsPut`, the fourth field requested in #848, already shipped on main in v3.3.0 and is untouched here.)

## Conflict resolution against main

* The `supportsPut` part of the original PR was dropped: main already has `bool supports_put_` with a constructor parameter, and the original `int` tri-state re-implementation would have replaced the released API.
* The new zone struct is named `SKMetadataZone` because `sensesp::SKZone` is now taken by the inbound-metadata struct in `signalk_metadata_listener.h`. Its members follow the repo's struct convention (`lower`, `upper`, `message`, `state` — no trailing underscores).

Everything else is as originally authored.

Usage:

```cpp
SKMetadata* meta = new SKMetadata("rpm", "Engine RPM");
meta->display_scale_lower_ = 0.0f;
meta->display_scale_upper_ = 8000.0f;
meta->zones_.push_back(SKMetadataZone(SKAlarmState::kNominal, "Normal range", 600.0f, 6500.0f));
meta->zones_.push_back(SKMetadataZone(SKAlarmState::kAlarm, "Overspeed", 7000.0f));
```

## Verification

`pio ci` compile of `examples/minimal_app.cpp` with the full library (`pioarduino_esp32`) passes locally, including the changed `signalk_metadata.cpp` translation unit.

The open findings from the review on PR 850 (the `||` displayScale guard, bound-less zone masking, missing serialization tests, and the smaller cleanups) apply to this branch unchanged and are not addressed here — this PR is deliberately just the rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds the remaining Signal K metadata fields to `SKMetadata`:

- `example`
- `displayScale`
- `zones`

`add_entry()` serializes each field only when it is set. `displayScale` requires both bounds. Zone states map to lowercase Signal K strings. The zone type is named `SKMetadataZone` to avoid conflict with `sensesp::SKZone`.

`supportsPut` remains unchanged because it already exists in v3.3.0.

## Testing

- Native serialization tests cover backward compatibility, metadata fields, display-scale bounds, zone bounds, empty messages, and all alarm-state strings.
- All four native test suites pass, with 36 test cases.
- CI-style compilation of `examples/rpm_counter.cpp` passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->